### PR TITLE
ErrNoNextVersion returned on last migration

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -109,6 +109,12 @@ func collectMigrations(dirpath string, current, target int64) (Migrations, error
 		}
 	}
 
+	migrations = sortAndConnectMigrations(migrations)
+
+	return migrations, nil
+}
+
+func sortAndConnectMigrations(migrations Migrations) Migrations {
 	sort.Sort(migrations)
 
 	// now that we're sorted in the appropriate direction,
@@ -122,7 +128,7 @@ func collectMigrations(dirpath string, current, target int64) (Migrations, error
 		migrations[i].Previous = prev
 	}
 
-	return migrations, nil
+	return migrations
 }
 
 func versionFilter(v, current, target int64) bool {

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -8,7 +8,7 @@ func newMigration(v int64, src string) *Migration {
 	return &Migration{Version: v, Previous: -1, Next: -1, Source: src}
 }
 
-func TestMigrationMapSortUp(t *testing.T) {
+func TestMigrationSort(t *testing.T) {
 
 	ms := Migrations{}
 
@@ -18,26 +18,9 @@ func TestMigrationMapSortUp(t *testing.T) {
 	ms = append(ms, newMigration(20129000, "test"))
 	ms = append(ms, newMigration(20127000, "test"))
 
-	ms.Sort(true) // sort Upwards
+	ms = sortAndConnectMigrations(ms)
 
 	sorted := []int64{20120000, 20127000, 20128000, 20129000}
-
-	validateMigrationSort(t, ms, sorted)
-}
-
-func TestMigrationMapSortDown(t *testing.T) {
-
-	ms := Migrations{}
-
-	// insert in any order
-	ms = append(ms, newMigration(20120000, "test"))
-	ms = append(ms, newMigration(20128000, "test"))
-	ms = append(ms, newMigration(20129000, "test"))
-	ms = append(ms, newMigration(20127000, "test"))
-
-	ms.Sort(false) // sort Downwards
-
-	sorted := []int64{20129000, 20128000, 20127000, 20120000}
 
 	validateMigrationSort(t, ms, sorted)
 }

--- a/up.go
+++ b/up.go
@@ -21,6 +21,7 @@ func Up(db *sql.DB, dir string) error {
 		if err != nil {
 			if err == ErrNoNextVersion {
 				fmt.Printf("goose: no migrations to run. current version: %d\n", current)
+				return nil
 			}
 			return err
 		}


### PR DESCRIPTION
The behavior of Goose appears to have changed recently. Before a successful Up migration would not return an Error, this change stops this error from happening.