### PR TITLE
Fix unsupported Scan, storing driver.Value type []uint8 into type *[]time.Time

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -14,7 +14,7 @@ import (
 
 type MigrationRecord struct {
 	VersionId int64
-	TStamp    time.Time
+	TStamp    string
 	IsApplied bool // was this a result of up() or down()
 }
 

--- a/status.go
+++ b/status.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"time"
 )
 
 func Status(db *sql.DB, dir string) error {
@@ -41,7 +40,7 @@ func printMigrationStatus(db *sql.DB, version int64, script string) {
 	var appliedAt string
 
 	if row.IsApplied {
-		appliedAt = row.TStamp.Format(time.ANSIC)
+		appliedAt = row.TStamp
 	} else {
 		appliedAt = "Pending"
 	}


### PR DESCRIPTION
This pull request fixes a bug when calling `Status`

```bash
$ goose -dir db/migrations mysql "user:passwd@/db" status
    Applied At                  Migration
    =======================================
2017/03/14 10:24:00 sql: Scan error on column index 0: unsupported Scan, storing driver.Value type []uint8 into type *time.Time
```
