### PR TITLE
Rename collectMigrations to CollectMigrations

### DIFF
--- a/down.go
+++ b/down.go
@@ -11,7 +11,7 @@ func Down(db *sql.DB, dir string) error {
 		return err
 	}
 
-	migrations, err := collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}
@@ -25,7 +25,7 @@ func Down(db *sql.DB, dir string) error {
 }
 
 func DownTo(db *sql.DB, dir string, version int64) error {
-	migrations, err := collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}

--- a/migrate.go
+++ b/migrate.go
@@ -85,9 +85,9 @@ func AddMigration(up func(*sql.Tx) error, down func(*sql.Tx) error) {
 	goMigrations = append(goMigrations, migration)
 }
 
-// collect all the valid looking migration scripts in the
-// migrations folder and go func registry, and key them by version
-func collectMigrations(dirpath string, current, target int64) (Migrations, error) {
+// CollectMigrations returns all the valid looking migration scripts in the
+// migrations folder and go func registry, and key them by version.
+func CollectMigrations(dirpath string, current, target int64) (Migrations, error) {
 	var migrations Migrations
 
 	// extract the numeric component of each migration,

--- a/redo.go
+++ b/redo.go
@@ -10,7 +10,7 @@ func Redo(db *sql.DB, dir string) error {
 		return err
 	}
 
-	migrations, err := collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}

--- a/status.go
+++ b/status.go
@@ -10,7 +10,7 @@ import (
 
 func Status(db *sql.DB, dir string) error {
 	// collect all migrations
-	migrations, err := collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}

--- a/up.go
+++ b/up.go
@@ -6,7 +6,7 @@ import (
 )
 
 func UpTo(db *sql.DB, dir string, version int64) error {
-	migrations, err := collectMigrations(dir, minVersion, version)
+	migrations, err := CollectMigrations(dir, minVersion, version)
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func Up(db *sql.DB, dir string) error {
 }
 
 func UpByOne(db *sql.DB, dir string) error {
-	migrations, err := collectMigrations(dir, minVersion, maxVersion)
+	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR exports CollectMigrations, Migrations are already exported but currently there is no way to get them from outside goose package.