### PR TITLE
Add support for adding migrations with custom filenames

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -79,6 +79,10 @@ func (ms Migrations) String() string {
 
 func AddMigration(up func(*sql.Tx) error, down func(*sql.Tx) error) {
 	_, filename, _, _ := runtime.Caller(1)
+	AddNamedMigration(filename, up, down)
+}
+
+func AddNamedMigration(filename string, up func(*sql.Tx) error, down func(*sql.Tx) error) {
 	v, _ := NumericComponent(filename)
 	migration := &Migration{Version: v, Next: -1, Previous: -1, UpFn: up, DownFn: down, Source: filename}
 


### PR DESCRIPTION
This commit adds an alternative function for registering migrations in go. Some scenarios require migrations in go to be loaded during runtime and in that scenario, AddMigration won't provide a proper filename, which is taken as runtime.Caller(). This change does not break API - a new global function is added.