### PR TITLE
Add Redshift driver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Examples:
     goose postgres "user=postgres dbname=postgres sslmode=disable" up
     goose mysql "user:password@/dbname" down
     goose sqlite3 ./foo.db status
+    goose redshift "postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" create init sql
 
 Options:
   -dir string

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -46,7 +46,7 @@ func main() {
 	driver, dbstring, command := args[0], args[1], args[2]
 
 	switch driver {
-	case "postgres", "mysql", "sqlite3":
+	case "postgres", "mysql", "sqlite3", "redshift":
 		if err := goose.SetDialect(driver); err != nil {
 			log.Fatal(err)
 		}
@@ -58,6 +58,10 @@ func main() {
 	case "":
 		log.Fatalf("-dbstring=%q not supported\n", dbstring)
 	default:
+	}
+
+	if driver == "redshift" {
+		driver = "postgres"
 	}
 
 	db, err := sql.Open(driver, dbstring)
@@ -88,7 +92,7 @@ Examples:
     goose postgres "user=postgres dbname=postgres sslmode=disable" up
     goose mysql "user:password@/dbname" down
     goose sqlite3 ./foo.db status
-    goose postgres "user=postgres dbname=postgres sslmode=disable" create init sql
+    goose redshift "postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" create init sql
 
 Options:
 `

--- a/example/migrations-go/cmd/main.go
+++ b/example/migrations-go/cmd/main.go
@@ -40,7 +40,7 @@ func main() {
 	driver, dbstring, command := args[0], args[1], args[2]
 
 	switch driver {
-	case "postgres", "mysql", "sqlite3":
+	case "postgres", "mysql", "sqlite3", "redshift":
 		if err := goose.SetDialect(driver); err != nil {
 			log.Fatal(err)
 		}
@@ -52,6 +52,10 @@ func main() {
 	case "":
 		log.Fatalf("-dbstring=%q not supported\n", dbstring)
 	default:
+	}
+
+	if driver == "redshift" {
+		driver = "postgres"
 	}
 
 	db, err := sql.Open(driver, dbstring)
@@ -77,6 +81,7 @@ Examples:
     goose postgres "user=postgres dbname=postgres sslmode=disable" up
     goose mysql "user:password@/dbname" down
     goose sqlite3 ./foo.db status
+    goose redshift "postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" create init sql
 
 Options:
 `


### PR DESCRIPTION
Redshift can be accessed and `up`/`down` SQL executed with the `pq`
library by default, however, the `createVersionTableSql` of the `PostgresDialect`
is not compatible with Redshift due to the `serial` datatype and `now()` default.

This PR creates a new Redshift dialect. The dialect still uses the `pq` library and
only updates the SQL in `createVersionTableSql` to be compatible with Redshift.

Closes #32.