### PR TITLE
Update CreateMigration time to UTC

### DIFF
--- a/create.go
+++ b/create.go
@@ -8,7 +8,7 @@ import (
 
 // Create writes a new blank migration file.
 func Create(db *sql.DB, dir, name, migrationType string) error {
-	path, err := CreateMigration(name, migrationType, dir, time.Now())
+	path, err := CreateMigration(name, migrationType, dir, time.Now().UTC())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The timestamp used on files when using `create` should be in UTC.
Developers may be distributed across timezones and so the time
should be standardized and not rely on local time.