### PR TITLE
Update CollectMigrations for subdirectories

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -97,7 +97,7 @@ func CollectMigrations(dirpath string, current, target int64) (Migrations, error
 	// extract the numeric component of each migration,
 	// filter out any uninteresting files,
 	// and ensure we only have one file per migration version.
-	sqlMigrations, err := filepath.Glob(dirpath + "/*.sql")
+	sqlMigrations, err := filepath.Glob(dirpath + "/**/*.sql")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I like to group my migrations by logical subdirectories.

```
[nicholasduffy@duffn:~/go/src/github.com/pressly/goose/migrations on sql-subdirectories]
% tree                                                                                                                                              ✭
.
├── group1
│   └── 20170506073854_table1_create_table.sql
└── group2
    └── 20170506073920_table2_create_table.sql

2 directories, 2 files
```

It's easy to run migrations by groups if necessary. However, I'd like the
ability to run all migrations in all subdirectories at the same time. This
PR adds discovery of all SQL files in subdirectories within the `-dir`
directory.