### PR TITLE
Fix globbing for files in subdirectories

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -97,7 +97,10 @@ func CollectMigrations(dirpath string, current, target int64) (Migrations, error
 	// extract the numeric component of each migration,
 	// filter out any uninteresting files,
 	// and ensure we only have one file per migration version.
-	sqlMigrations, err := filepath.Glob(dirpath + "/**/*.sql")
+	sqlMigrations, err := filepath.Glob(dirpath + "/*.sql")
+	sqlMigrationsSubDirectories, err := filepath.Glob(dirpath + "/**/*.sql")
+	sqlMigrations = append(sqlMigrations, sqlMigrationsSubDirectories...)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix for: https://github.com/pressly/goose/pull/39

The glob `/**/*.sql` was looking for files in subdirectories
only and not finding SQL files in the root directory.

Now making two globs and combining the slices.