### PR TITLE
Add vendoring support using dep vendor package manager.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-- 1.6
+- 1.7
 - tip
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ go:
 - tip
 
 install:
-- go get github.com/go-sql-driver/mysql
-- go get github.com/lib/pq
-- go get github.com/mattn/go-sqlite3
-- go get github.com/ziutek/mymysql/godrv
+- go get github.com/golang/dep/cmd/dep
+- dep ensure
 
 script:
 - go test

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,0 +1,11 @@
+[[constraint]]
+  name = "github.com/go-sql-driver/mysql"
+  version = "^1.3.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/lib/pq"
+
+[[constraint]]
+  name = "github.com/mattn/go-sqlite3"
+  version = "^1.2.0"


### PR DESCRIPTION
- Add vendor dependencies for better macos homebrew support
- Referencing #42
- Referencing Homebrew/homebrew-core#14724

Signed-off-by: Mario Kozjak <kozjakm1@gmail.com>