### PR TITLE
Remove StatementBegin/StatementEnd directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Examples:
     goose mysql "user:password@/dbname" status
     goose redshift "postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" status
 ```
+
+Note: **MySQL** using [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql) driver: Both [parseTime=true](https://github.com/go-sql-driver/mysql#parsetime) and [multiStatements=true](https://github.com/go-sql-driver/mysql#multistatements) connection string parameters must be enabled.
+
 ## create
 
 Create a new SQL migration.
@@ -135,8 +138,6 @@ Print the status of all migrations:
     $   Sun Jan  6 11:25:03 2013 -- 001_basics.sql
     $   Sun Jan  6 11:25:03 2013 -- 002_next.sql
     $   Pending                  -- 003_and_again.go
-
-Note: for MySQL [parseTime flag](https://github.com/go-sql-driver/mysql#parsetime) must be enabled.
 
 ## version
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ Examples:
     goose sqlite3 ./foo.db up
 
     goose postgres "user=postgres dbname=postgres sslmode=disable" status
-    goose mysql "user:password@/dbname" status
     goose redshift "postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" status
+    goose mysql "user:password@/dbname?parseTime=true&multiStatements=true" status
 ```
 
-Note: **MySQL** using [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql) driver: Both [parseTime=true](https://github.com/go-sql-driver/mysql#parsetime) and [multiStatements=true](https://github.com/go-sql-driver/mysql#multistatements) connection string parameters must be enabled.
+Note: **MySQL** using [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql) driver must have both [parseTime=true](https://github.com/go-sql-driver/mysql#parsetime) and [multiStatements=true](https://github.com/go-sql-driver/mysql#multistatements) connection string parameters enabled.
 
 ## create
 

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -103,8 +103,8 @@ Examples:
     goose sqlite3 ./foo.db up
 
     goose postgres "user=postgres dbname=postgres sslmode=disable" status
-    goose mysql "user:password@/dbname" status
     goose redshift "postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" status
+    goose mysql "user:password@/dbname?parseTime=true&multiStatements=true" status
 
 Options:
 `

--- a/examples/go-migrations/main.go
+++ b/examples/go-migrations/main.go
@@ -103,8 +103,8 @@ Examples:
     goose sqlite3 ./foo.db up
 
     goose postgres "user=postgres dbname=postgres sslmode=disable" status
-    goose mysql "user:password@/dbname" status
     goose redshift "postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" status
+    goose mysql "user:password@/dbname?parseTime=true&multiStatements=true" status
 
 Options:
 `

--- a/examples/sql-migrations/00002_rename_root.sql
+++ b/examples/sql-migrations/00002_rename_root.sql
@@ -1,7 +1,9 @@
 -- +goose Up
--- +goose StatementBegin
 UPDATE users SET username='admin' WHERE username='root';
--- +goose StatementEnd
+
+UPDATE users SET username='admin' WHERE username='root';
+
+UPDATE users SET username='admin' WHERE username='root';
 
 -- +goose Down
 -- +goose StatementBegin

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -10,134 +10,7 @@ import (
 	"strings"
 )
 
-const sqlCmdPrefix = "-- +goose "
-
-// Checks the line to see if the line has a statement-ending semicolon
-// or if the line contains a double-dash comment.
-func endsWithSemicolon(line string) bool {
-
-	prev := ""
-	scanner := bufio.NewScanner(strings.NewReader(line))
-	scanner.Split(bufio.ScanWords)
-
-	for scanner.Scan() {
-		word := scanner.Text()
-		if strings.HasPrefix(word, "--") {
-			break
-		}
-		prev = word
-	}
-
-	return strings.HasSuffix(prev, ";")
-}
-
-// Split the given sql script into individual statements.
-//
-// The base case is to simply split on semicolons, as these
-// naturally terminate a statement.
-//
-// However, more complex cases like pl/pgsql can have semicolons
-// within a statement. For these cases, we provide the explicit annotations
-// 'StatementBegin' and 'StatementEnd' to allow the script to
-// tell us to ignore semicolons.
-func getSQLStatements(r io.Reader, direction bool) (stmts []string, tx bool) {
-	var buf bytes.Buffer
-	scanner := bufio.NewScanner(r)
-
-	// track the count of each section
-	// so we can diagnose scripts with no annotations
-	upSections := 0
-	downSections := 0
-
-	statementEnded := false
-	ignoreSemicolons := false
-	directionIsActive := false
-	tx = true
-
-	for scanner.Scan() {
-
-		line := scanner.Text()
-
-		// handle any goose-specific commands
-		if strings.HasPrefix(line, sqlCmdPrefix) {
-			cmd := strings.TrimSpace(line[len(sqlCmdPrefix):])
-			switch cmd {
-			case "Up":
-				directionIsActive = (direction == true)
-				upSections++
-				break
-
-			case "Down":
-				directionIsActive = (direction == false)
-				downSections++
-				break
-
-			case "StatementBegin":
-				if directionIsActive {
-					ignoreSemicolons = true
-				}
-				break
-
-			case "StatementEnd":
-				if directionIsActive {
-					statementEnded = (ignoreSemicolons == true)
-					ignoreSemicolons = false
-				}
-				break
-
-			case "NO TRANSACTION":
-				tx = false
-				break
-			}
-		}
-
-		if !directionIsActive {
-			continue
-		}
-
-		if _, err := buf.WriteString(line + "\n"); err != nil {
-			log.Fatalf("io err: %v", err)
-		}
-
-		// Wrap up the two supported cases: 1) basic with semicolon; 2) psql statement
-		// Lines that end with semicolon that are in a statement block
-		// do not conclude statement.
-		if (!ignoreSemicolons && endsWithSemicolon(line)) || statementEnded {
-			statementEnded = false
-			stmts = append(stmts, buf.String())
-			buf.Reset()
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		log.Fatalf("scanning migration: %v", err)
-	}
-
-	// diagnose likely migration script errors
-	if ignoreSemicolons {
-		log.Println("WARNING: saw '-- +goose StatementBegin' with no matching '-- +goose StatementEnd'")
-	}
-
-	if bufferRemaining := strings.TrimSpace(buf.String()); len(bufferRemaining) > 0 {
-		log.Printf("WARNING: Unexpected unfinished SQL query: %s. Missing a semicolon?\n", bufferRemaining)
-	}
-
-	if upSections == 0 && downSections == 0 {
-		log.Fatalf(`ERROR: no Up/Down annotations found, so no statements were executed.
-			See https://bitbucket.org/liamstask/goose/overview for details.`)
-	}
-
-	return
-}
-
-// Run a migration specified in raw SQL.
-//
-// Sections of the script can be annotated with a special comment,
-// starting with "-- +goose" to specify whether the section should
-// be applied during an Up or Down migration
-//
-// All statements following an Up or Down directive are grouped together
-// until another direction directive is found.
+// Run SQL statements defined in a given file for a given direction (Up or Down).
 func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) error {
 	f, err := os.Open(scriptFile)
 	if err != nil {
@@ -145,7 +18,7 @@ func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) err
 	}
 	defer f.Close()
 
-	statements, useTx := getSQLStatements(f, direction)
+	query, useTx := getSQLQuery(f, direction)
 
 	if useTx {
 		// TRANSACTION.
@@ -155,12 +28,11 @@ func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) err
 			log.Fatal(err)
 		}
 
-		for _, query := range statements {
-			if _, err = tx.Exec(query); err != nil {
-				tx.Rollback()
-				return err
-			}
+		if _, err = tx.Exec(query); err != nil {
+			tx.Rollback()
+			return err
 		}
+
 		if _, err := tx.Exec(GetDialect().insertVersionSQL(), v, direction); err != nil {
 			tx.Rollback()
 			return err
@@ -170,14 +42,66 @@ func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) err
 	}
 
 	// NO TRANSACTION.
-	for _, query := range statements {
-		if _, err := db.Exec(query); err != nil {
-			return err
-		}
+	if _, err := db.Exec(query); err != nil {
+		return err
 	}
 	if _, err := db.Exec(GetDialect().insertVersionSQL(), v, direction); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// Get SQL statements defined in a given file for a given direction (Up or Down).
+func getSQLQuery(r io.Reader, direction bool) (statements string, tx bool) {
+	var buf bytes.Buffer
+	scanner := bufio.NewScanner(r)
+
+	upSections := 0
+	downSections := 0
+	directionIsActive := false
+	tx = true
+
+	for scanner.Scan() {
+
+		line := scanner.Text()
+
+		// handle any goose-specific commands
+		switch strings.ToLower(line) {
+		case "-- +goose up":
+			directionIsActive = (direction == true)
+			upSections++
+			break
+
+		case "-- +goose down":
+			directionIsActive = (direction == false)
+			downSections++
+			break
+
+		case "-- +goose no transaction":
+			if directionIsActive {
+				log.Fatal("-- +goose NO TRANSACTION should be defined on top of the file")
+			}
+			tx = false
+			break
+		}
+
+		if !directionIsActive {
+			continue
+		}
+
+		if _, err := buf.WriteString(line + "\n"); err != nil {
+			log.Fatalf("io err: %v", err)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatalf("scanning migration: %v", err)
+	}
+
+	if upSections == 0 && downSections == 0 {
+		log.Fatalf(`ERROR: No Up/Down annotations found.`)
+	}
+
+	return
 }

--- a/migration_sql_test.go
+++ b/migration_sql_test.go
@@ -2,90 +2,8 @@ package goose
 
 import (
 	"os"
-	"strings"
 	"testing"
 )
-
-func TestSemicolons(t *testing.T) {
-
-	type testData struct {
-		line   string
-		result bool
-	}
-
-	tests := []testData{
-		{
-			line:   "END;",
-			result: true,
-		},
-		{
-			line:   "END; -- comment",
-			result: true,
-		},
-		{
-			line:   "END   ; -- comment",
-			result: true,
-		},
-		{
-			line:   "END -- comment",
-			result: false,
-		},
-		{
-			line:   "END -- comment ;",
-			result: false,
-		},
-		{
-			line:   "END \" ; \" -- comment",
-			result: false,
-		},
-	}
-
-	for _, test := range tests {
-		r := endsWithSemicolon(test.line)
-		if r != test.result {
-			t.Errorf("incorrect semicolon. got %v, want %v", r, test.result)
-		}
-	}
-}
-
-func TestSplitStatements(t *testing.T) {
-
-	type testData struct {
-		sql       string
-		direction bool
-		count     int
-	}
-
-	tests := []testData{
-		{
-			sql:       functxt,
-			direction: true,
-			count:     2,
-		},
-		{
-			sql:       functxt,
-			direction: false,
-			count:     2,
-		},
-		{
-			sql:       multitxt,
-			direction: true,
-			count:     2,
-		},
-		{
-			sql:       multitxt,
-			direction: false,
-			count:     2,
-		},
-	}
-
-	for _, test := range tests {
-		stmts, _ := getSQLStatements(strings.NewReader(test.sql), test.direction)
-		if len(stmts) != test.count {
-			t.Errorf("incorrect number of stmts. got %v, want %v", len(stmts), test.count)
-		}
-	}
-}
 
 func TestUseTransactions(t *testing.T) {
 	type testData struct {
@@ -113,70 +31,10 @@ func TestUseTransactions(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		_, useTx := getSQLStatements(f, true)
+		_, useTx := getSQLQuery(f, true)
 		if useTx != test.useTransactions {
 			t.Errorf("Failed transaction check. got %v, want %v", useTx, test.useTransactions)
 		}
 		f.Close()
 	}
 }
-
-var functxt = `-- +goose Up
-CREATE TABLE IF NOT EXISTS histories (
-  id                BIGSERIAL  PRIMARY KEY,
-  current_value     varchar(2000) NOT NULL,
-  created_at      timestamp with time zone  NOT NULL
-);
-
--- +goose StatementBegin
-CREATE OR REPLACE FUNCTION histories_partition_creation( DATE, DATE )
-returns void AS $$
-DECLARE
-  create_query text;
-BEGIN
-  FOR create_query IN SELECT
-      'CREATE TABLE IF NOT EXISTS histories_'
-      || TO_CHAR( d, 'YYYY_MM' )
-      || ' ( CHECK( created_at >= timestamp '''
-      || TO_CHAR( d, 'YYYY-MM-DD 00:00:00' )
-      || ''' AND created_at < timestamp '''
-      || TO_CHAR( d + INTERVAL '1 month', 'YYYY-MM-DD 00:00:00' )
-      || ''' ) ) inherits ( histories );'
-    FROM generate_series( $1, $2, '1 month' ) AS d
-  LOOP
-    EXECUTE create_query;
-  END LOOP;  -- LOOP END
-END;         -- FUNCTION END
-$$
-language plpgsql;
--- +goose StatementEnd
-
--- +goose Down
-drop function histories_partition_creation(DATE, DATE);
-drop TABLE histories;
-`
-
-// test multiple up/down transitions in a single script
-var multitxt = `-- +goose Up
-CREATE TABLE post (
-    id int NOT NULL,
-    title text,
-    body text,
-    PRIMARY KEY(id)
-);
-
--- +goose Down
-DROP TABLE post;
-
--- +goose Up
-CREATE TABLE fancier_post (
-    id int NOT NULL,
-    title text,
-    body text,
-    created_on timestamp without time zone,
-    PRIMARY KEY(id)
-);
-
--- +goose Down
-DROP TABLE fancier_post;
-`


### PR DESCRIPTION
All major DB drivers support multiple statements within db.Exec().

MySQL using github.com/go-sql-driver/mysql driver must have `multiStatements=true` connection string parameter enabled.

Fixes: #34