### PR TITLE
Add error if migration directory does not exist

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -105,6 +106,10 @@ func AddNamedMigration(filename string, up func(*sql.Tx) error, down func(*sql.T
 // CollectMigrations returns all the valid looking migration scripts in the
 // migrations folder and go func registry, and key them by version.
 func CollectMigrations(dirpath string, current, target int64) (Migrations, error) {
+	if _, err := os.Stat(dirpath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("%s directory does not exists", dirpath)
+	}
+
 	var migrations Migrations
 
 	// SQL migration files.


### PR DESCRIPTION
Make error more clear when the given migration directory doesn't exist

Example: I got `goose run: open files/00001_new.go: no such file or directory` when run `goose -dir files create new`. It doesn't make sense.