### PR TITLE
replace fmt.Print statements with log.Print

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"database/sql"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 
@@ -81,9 +80,9 @@ func main() {
 }
 
 func usage() {
-	fmt.Print(usagePrefix)
+	log.Print(usagePrefix)
 	flags.PrintDefaults()
-	fmt.Print(usageCommands)
+	log.Print(usageCommands)
 }
 
 var (

--- a/create.go
+++ b/create.go
@@ -3,6 +3,7 @@ package goose
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -35,7 +36,7 @@ func Create(db *sql.DB, dir, name, migrationType string) error {
 		return err
 	}
 
-	fmt.Printf("Created new file: %s\n", path)
+	log.Printf("Created new file: %s\n", path)
 	return nil
 }
 

--- a/down.go
+++ b/down.go
@@ -3,6 +3,7 @@ package goose
 import (
 	"database/sql"
 	"fmt"
+	"log"
 )
 
 // Down rolls back a single migration from the current version.
@@ -40,12 +41,12 @@ func DownTo(db *sql.DB, dir string, version int64) error {
 
 		current, err := migrations.Current(currentVersion)
 		if err != nil {
-			fmt.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
+			log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
 			return nil
 		}
 
 		if current.Version <= version {
-			fmt.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
+			log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
 			return nil
 		}
 

--- a/examples/go-migrations/main.go
+++ b/examples/go-migrations/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"database/sql"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 
@@ -81,9 +80,9 @@ func main() {
 }
 
 func usage() {
-	fmt.Print(usagePrefix)
+	log.Print(usagePrefix)
 	flags.PrintDefaults()
-	fmt.Print(usageCommands)
+	log.Print(usageCommands)
 }
 
 var (

--- a/migration.go
+++ b/migration.go
@@ -38,7 +38,7 @@ func (m *Migration) Up(db *sql.DB) error {
 	if err := m.run(db, true); err != nil {
 		return err
 	}
-	fmt.Println("OK   ", filepath.Base(m.Source))
+	log.Println("OK   ", filepath.Base(m.Source))
 	return nil
 }
 
@@ -47,7 +47,7 @@ func (m *Migration) Down(db *sql.DB) error {
 	if err := m.run(db, false); err != nil {
 		return err
 	}
-	fmt.Println("OK   ", filepath.Base(m.Source))
+	log.Println("OK   ", filepath.Base(m.Source))
 	return nil
 }
 

--- a/status.go
+++ b/status.go
@@ -21,8 +21,8 @@ func Status(db *sql.DB, dir string) error {
 		return err
 	}
 
-	fmt.Println("    Applied At                  Migration")
-	fmt.Println("    =======================================")
+	log.Println("    Applied At                  Migration")
+	log.Println("    =======================================")
 	for _, migration := range migrations {
 		printMigrationStatus(db, migration.Version, filepath.Base(migration.Source))
 	}
@@ -47,5 +47,5 @@ func printMigrationStatus(db *sql.DB, version int64, script string) {
 		appliedAt = "Pending"
 	}
 
-	fmt.Printf("    %-24s -- %v\n", appliedAt, script)
+	log.Printf("    %-24s -- %v\n", appliedAt, script)
 }

--- a/up.go
+++ b/up.go
@@ -2,7 +2,7 @@ package goose
 
 import (
 	"database/sql"
-	"fmt"
+	"log"
 )
 
 // UpTo migrates up to a specific version.
@@ -21,7 +21,7 @@ func UpTo(db *sql.DB, dir string, version int64) error {
 		next, err := migrations.Next(current)
 		if err != nil {
 			if err == ErrNoNextVersion {
-				fmt.Printf("goose: no migrations to run. current version: %d\n", current)
+				log.Printf("goose: no migrations to run. current version: %d\n", current)
 				return nil
 			}
 			return err
@@ -53,7 +53,7 @@ func UpByOne(db *sql.DB, dir string) error {
 	next, err := migrations.Next(currentVersion)
 	if err != nil {
 		if err == ErrNoNextVersion {
-			fmt.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
+			log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
 		}
 		return err
 	}

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package goose
 
 import (
 	"database/sql"
-	"fmt"
+	"log"
 )
 
 // Version prints the current version of the database.
@@ -12,6 +12,6 @@ func Version(db *sql.DB, dir string) error {
 		return err
 	}
 
-	fmt.Printf("goose: version %v\n", current)
+	log.Printf("goose: version %v\n", current)
 	return nil
 }


### PR DESCRIPTION
To address issue https://github.com/pressly/goose/issues/66 I've replaced all `fmt.Print` statements with `log.Print`.