### PR TITLE
Do not use `log.Fatal` or its variants in library code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 cmd/goose/goose*
 *.swp
 *.test
+*.exe
+*.db
+
+.idea/
+vendor/

--- a/goose_test.go
+++ b/goose_test.go
@@ -1,18 +1,25 @@
 package goose
 
 import (
+	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func TestDefaultBinary(t *testing.T) {
+	bin := "goose"
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+
 	commands := []string{
-		"go build -i -o goose ./cmd/goose",
-		"./goose -dir=examples/sql-migrations sqlite3 sql.db up",
-		"./goose -dir=examples/sql-migrations sqlite3 sql.db version",
-		"./goose -dir=examples/sql-migrations sqlite3 sql.db down",
-		"./goose -dir=examples/sql-migrations sqlite3 sql.db status",
+		fmt.Sprintf("go build -i -o %s ./cmd/goose", bin),
+		fmt.Sprintf("./%s -dir=examples/sql-migrations sqlite3 sql.db up", bin),
+		fmt.Sprintf("./%s -dir=examples/sql-migrations sqlite3 sql.db version", bin),
+		fmt.Sprintf("./%s -dir=examples/sql-migrations sqlite3 sql.db down", bin),
+		fmt.Sprintf("./%s -dir=examples/sql-migrations sqlite3 sql.db status", bin),
 	}
 
 	for _, cmd := range commands {
@@ -25,12 +32,16 @@ func TestDefaultBinary(t *testing.T) {
 }
 
 func TestCustomBinary(t *testing.T) {
+	bin := "custom-goose"
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
 	commands := []string{
-		"go build -i -o custom-goose ./examples/go-migrations",
-		"./custom-goose -dir=examples/go-migrations sqlite3 go.db up",
-		"./custom-goose -dir=examples/go-migrations sqlite3 go.db version",
-		"./custom-goose -dir=examples/go-migrations sqlite3 go.db down",
-		"./custom-goose -dir=examples/go-migrations sqlite3 go.db status",
+		fmt.Sprintf("go build -i -o %s ./examples/go-migrations", bin),
+		fmt.Sprintf("./%s -dir=examples/go-migrations sqlite3 go.db up", bin),
+		fmt.Sprintf("./%s -dir=examples/go-migrations sqlite3 go.db version", bin),
+		fmt.Sprintf("./%s -dir=examples/go-migrations sqlite3 go.db down", bin),
+		fmt.Sprintf("./%s -dir=examples/go-migrations sqlite3 go.db status", bin),
 	}
 
 	for _, cmd := range commands {

--- a/migrate.go
+++ b/migrate.go
@@ -30,7 +30,7 @@ func (ms Migrations) Len() int      { return len(ms) }
 func (ms Migrations) Swap(i, j int) { ms[i], ms[j] = ms[j], ms[i] }
 func (ms Migrations) Less(i, j int) bool {
 	if ms[i].Version == ms[j].Version {
-		log.Fatalf("goose: duplicate version %v detected:\n%v\n%v", ms[i].Version, ms[i].Source, ms[j].Source)
+		log.Panicf("goose: duplicate version %v detected:\n%v\n%v", ms[i].Version, ms[i].Source, ms[j].Source)
 	}
 	return ms[i].Version < ms[j].Version
 }
@@ -214,7 +214,7 @@ func EnsureDBVersion(db *sql.DB) (int64, error) {
 	for rows.Next() {
 		var row MigrationRecord
 		if err = rows.Scan(&row.VersionID, &row.IsApplied); err != nil {
-			log.Fatal("error scanning rows:", err)
+			log.Panicf("error scanning rows: %v", err)
 		}
 
 		// have we already marked this version to be skipped?

--- a/migration.go
+++ b/migration.go
@@ -60,11 +60,15 @@ func (m *Migration) run(db *sql.DB, direction bool) error {
 
 	case ".go":
 		if !m.Registered {
-			log.Fatalf("failed to apply Go migration %q: Go functions must be registered and built into a custom binary (see https://github.com/pressly/goose/tree/master/examples/go-migrations)", m.Source)
+			msg := fmt.Sprintf("failed to apply Go migration %q: Go functions must be registered and built into a custom binary (see https://github.com/pressly/goose/tree/master/examples/go-migrations)", m.Source)
+			log.Print(msg)
+			err := errors.New(msg)
+			return err
 		}
 		tx, err := db.Begin()
 		if err != nil {
-			log.Fatal("db.Begin: ", err)
+			log.Printf("db.Begin: %v", err)
+			return err
 		}
 
 		fn := m.UpFn
@@ -74,7 +78,7 @@ func (m *Migration) run(db *sql.DB, direction bool) error {
 		if fn != nil {
 			if err := fn(tx); err != nil {
 				tx.Rollback()
-				log.Fatalf("FAIL %s (%v), quitting migration.", filepath.Base(m.Source), err)
+				log.Printf("FAIL %s (%v), quitting migration.", filepath.Base(m.Source), err)
 				return err
 			}
 		}

--- a/migration_sql_test.go
+++ b/migration_sql_test.go
@@ -80,7 +80,7 @@ func TestSplitStatements(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		stmts, _ := getSQLStatements(strings.NewReader(test.sql), test.direction)
+		stmts, _, _ := getSQLStatements(strings.NewReader(test.sql), test.direction)
 		if len(stmts) != test.count {
 			t.Errorf("incorrect number of stmts. got %v, want %v", len(stmts), test.count)
 		}
@@ -113,7 +113,7 @@ func TestUseTransactions(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		_, useTx := getSQLStatements(f, true)
+		_, useTx, _ := getSQLStatements(f, true)
 		if useTx != test.useTransactions {
 			t.Errorf("Failed transaction check. got %v, want %v", useTx, test.useTransactions)
 		}

--- a/reset.go
+++ b/reset.go
@@ -45,7 +45,8 @@ func dbMigrationsStatus(db *sql.DB) (map[int64]bool, error) {
 	for rows.Next() {
 		var row MigrationRecord
 		if err = rows.Scan(&row.VersionID, &row.IsApplied); err != nil {
-			log.Fatal("error scanning rows:", err)
+			log.Printf("error scanning rows: %v", err)
+			return map[int64]bool{}, err
 		}
 
 		if _, ok := result[row.VersionID]; ok {

--- a/status.go
+++ b/status.go
@@ -36,7 +36,9 @@ func printMigrationStatus(db *sql.DB, version int64, script string) {
 	e := db.QueryRow(q).Scan(&row.TStamp, &row.IsApplied)
 
 	if e != nil && e != sql.ErrNoRows {
-		log.Fatal(e)
+		log.Print(e)
+		fmt.Print(e)
+		return
 	}
 
 	var appliedAt string


### PR DESCRIPTION
Fixes https://github.com/pressly/goose/issues/76

As `log.Fatal()` triggers `os.Exit(1)`, calling code has no option to control the behaviour in the event of encountering such error handling.

I've left `log.Fatal()` calls in the command-line code where it is a reasonable approach. Within the library code I've generally taken one of two approaches:
- replace with a `log.Print()` statement, then return immediately with an error
- replace with a `log.Panic()` statement, in code that has no scope to return an error. (In principle this could at least be captured by the caller with some sort of `recover` handling).