### PR TITLE
Add support to override migration template

### DIFF
--- a/create.go
+++ b/create.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Create writes a new blank migration file.
-func Create(db *sql.DB, dir, name, migrationType string) error {
+func CreateWithTemplate(db *sql.DB, dir string, migrationTemplate *template.Template, name, migrationType string) error {
 	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
@@ -26,9 +26,14 @@ func Create(db *sql.DB, dir, name, migrationType string) error {
 	filename := fmt.Sprintf("%v_%v.%v", version, name, migrationType)
 
 	fpath := filepath.Join(dir, filename)
+
 	tmpl := sqlMigrationTemplate
 	if migrationType == "go" {
 		tmpl = goSQLMigrationTemplate
+	}
+
+	if migrationTemplate != nil {
+		tmpl = migrationTemplate
 	}
 
 	path, err := writeTemplateToFile(fpath, tmpl, version)
@@ -38,6 +43,11 @@ func Create(db *sql.DB, dir, name, migrationType string) error {
 
 	log.Printf("Created new file: %s\n", path)
 	return nil
+}
+
+// Create writes a new blank migration file.
+func Create(db *sql.DB, dir, name, migrationType string) error {
+	return CreateWithTemplate(db, dir, nil, name, migrationType)
 }
 
 func writeTemplateToFile(path string, t *template.Template, version string) (string, error) {


### PR DESCRIPTION
We are using goose with gorm to write GO migrations and needed to override default go migration template to add gorm dependencies into auto-generated migration files. This pull request adds support to "Create" migrations with custom templates without breaking the existing interface.