### PR TITLE
Move each driver import into its own file and use build flags to control inclusion.

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -7,12 +7,6 @@ import (
 	"os"
 
 	"github.com/pressly/goose"
-
-	// Init DB drivers.
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
-	_ "github.com/mattn/go-sqlite3"
-	_ "github.com/ziutek/mymysql/godrv"
 )
 
 var (
@@ -52,7 +46,7 @@ func main() {
 	switch driver {
 	case "redshift":
 		driver = "postgres"
-	case  "tidb":
+	case "tidb":
 		driver = "mysql"
 	}
 

--- a/cmd/goose/mymysql_driver.go
+++ b/cmd/goose/mymysql_driver.go
@@ -1,0 +1,5 @@
+// +build all mymysql
+
+package main
+
+import _ "github.com/ziutek/mymysql/godrv"

--- a/cmd/goose/mysql_driver.go
+++ b/cmd/goose/mysql_driver.go
@@ -1,0 +1,5 @@
+// +build all mysql
+
+package main
+
+import _ "github.com/go-sql-driver/mysql"

--- a/cmd/goose/pg_driver.go
+++ b/cmd/goose/pg_driver.go
@@ -1,0 +1,5 @@
+// +build all postgresql
+
+package main
+
+import _ "github.com/lib/pq"

--- a/cmd/goose/sqlite_driver.go
+++ b/cmd/goose/sqlite_driver.go
@@ -1,0 +1,5 @@
+// +build all sqlite3
+
+package main
+
+import _ "github.com/mattn/go-sqlite3"


### PR DESCRIPTION
To remove the need for pulling down drivers that are unused, each driver
has been put into its own file and its inclusion is controlled with a
build flag. This allows someone to build a driver specific
implementation of goose by passing the driver. For example, `tags postgresql`.