### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module "github.com/pressly/goose"
+module github.com/pressly/goose/v2
 
 require (
-	"github.com/go-sql-driver/mysql" v1.0.3
-	"github.com/lib/pq" v0.0.0-20180327071824-d34b9ff171c2
-	"github.com/mattn/go-sqlite3" v1.6.0
-	"github.com/ziutek/mymysql" v1.5.4
+	github.com/go-sql-driver/mysql v1.3.0
+	github.com/lib/pq v0.0.0-20180523031117-0677bdde3e15
+	github.com/mattn/go-sqlite3 v1.6.0
+	github.com/ziutek/mymysql v1.5.4
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module "github.com/pressly/goose"
+
+require (
+	"github.com/go-sql-driver/mysql" v1.0.3
+	"github.com/lib/pq" v0.0.0-20180327071824-d34b9ff171c2
+	"github.com/mattn/go-sqlite3" v1.6.0
+	"github.com/ziutek/mymysql" v1.5.4
+)


### PR DESCRIPTION
As stated in golang/go#24384:

> vgo only allows v2+ when there is a go.mod file so please tell the package maintainer/owner to make the package vgo compatible.

Thus it's impossible to add anything other than version 1.0 of this package as dependency in project built with vgo.