### PR TITLE
Added ability to change db version table name

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -54,15 +54,15 @@ func (pg PostgresDialect) createVersionTableSQL() string {
                 is_applied boolean NOT NULL,
                 tstamp timestamp NULL default now(),
                 PRIMARY KEY(id)
-            );`, GetDBVersionTableName())
+            );`, TableName())
 }
 
 func (pg PostgresDialect) insertVersionSQL() string {
-	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES ($1, $2);", GetDBVersionTableName())
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES ($1, $2);", TableName())
 }
 
 func (pg PostgresDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", GetDBVersionTableName()))
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", TableName()))
 	if err != nil {
 		return nil, err
 	}
@@ -84,15 +84,15 @@ func (m MySQLDialect) createVersionTableSQL() string {
                 is_applied boolean NOT NULL,
                 tstamp timestamp NULL default now(),
                 PRIMARY KEY(id)
-            );`, GetDBVersionTableName())
+            );`, TableName())
 }
 
 func (m MySQLDialect) insertVersionSQL() string {
-	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", GetDBVersionTableName())
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", TableName())
 }
 
 func (m MySQLDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", GetDBVersionTableName()))
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", TableName()))
 	if err != nil {
 		return nil, err
 	}
@@ -113,15 +113,15 @@ func (m Sqlite3Dialect) createVersionTableSQL() string {
                 version_id INTEGER NOT NULL,
                 is_applied INTEGER NOT NULL,
                 tstamp TIMESTAMP DEFAULT (datetime('now'))
-            );`, GetDBVersionTableName())
+            );`, TableName())
 }
 
 func (m Sqlite3Dialect) insertVersionSQL() string {
-	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", GetDBVersionTableName())
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", TableName())
 }
 
 func (m Sqlite3Dialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", GetDBVersionTableName()))
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", TableName()))
 	if err != nil {
 		return nil, err
 	}
@@ -143,15 +143,15 @@ func (rs RedshiftDialect) createVersionTableSQL() string {
                 is_applied boolean NOT NULL,
                 tstamp timestamp NULL default sysdate,
                 PRIMARY KEY(id)
-            );`, GetDBVersionTableName())
+            );`, TableName())
 }
 
 func (rs RedshiftDialect) insertVersionSQL() string {
-	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES ($1, $2);", GetDBVersionTableName())
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES ($1, $2);", TableName())
 }
 
 func (rs RedshiftDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", GetDBVersionTableName()))
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", TableName()))
 	if err != nil {
 		return nil, err
 	}
@@ -173,15 +173,15 @@ func (m TiDBDialect) createVersionTableSQL() string {
                 is_applied boolean NOT NULL,
                 tstamp timestamp NULL default now(),
                 PRIMARY KEY(id)
-            );`, GetDBVersionTableName())
+            );`, TableName())
 }
 
 func (m TiDBDialect) insertVersionSQL() string {
-	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", GetDBVersionTableName())
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", TableName())
 }
 
 func (m TiDBDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", GetDBVersionTableName()))
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", TableName()))
 	if err != nil {
 		return nil, err
 	}

--- a/dialect.go
+++ b/dialect.go
@@ -8,7 +8,7 @@ import (
 // SQLDialect abstracts the details of specific SQL dialects
 // for goose's few SQL specific statements
 type SQLDialect interface {
-	createVersionTableSQL() string // sql string to create the goose_db_version table
+	createVersionTableSQL() string // sql string to create the db version table
 	insertVersionSQL() string      // sql string to insert the initial version table row
 	dbVersionQuery(db *sql.DB) (*sql.Rows, error)
 }
@@ -48,21 +48,21 @@ func SetDialect(d string) error {
 type PostgresDialect struct{}
 
 func (pg PostgresDialect) createVersionTableSQL() string {
-	return `CREATE TABLE goose_db_version (
+	return fmt.Sprintf(`CREATE TABLE %s (
             	id serial NOT NULL,
                 version_id bigint NOT NULL,
                 is_applied boolean NOT NULL,
                 tstamp timestamp NULL default now(),
                 PRIMARY KEY(id)
-            );`
+            );`, GetDBVersionTableName())
 }
 
 func (pg PostgresDialect) insertVersionSQL() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES ($1, $2);"
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES ($1, $2);", GetDBVersionTableName())
 }
 
 func (pg PostgresDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", GetDBVersionTableName()))
 	if err != nil {
 		return nil, err
 	}
@@ -78,21 +78,21 @@ func (pg PostgresDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 type MySQLDialect struct{}
 
 func (m MySQLDialect) createVersionTableSQL() string {
-	return `CREATE TABLE goose_db_version (
+	return fmt.Sprintf(`CREATE TABLE %s (
                 id serial NOT NULL,
                 version_id bigint NOT NULL,
                 is_applied boolean NOT NULL,
                 tstamp timestamp NULL default now(),
                 PRIMARY KEY(id)
-            );`
+            );`, GetDBVersionTableName())
 }
 
 func (m MySQLDialect) insertVersionSQL() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, ?);"
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", GetDBVersionTableName())
 }
 
 func (m MySQLDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", GetDBVersionTableName()))
 	if err != nil {
 		return nil, err
 	}
@@ -108,20 +108,20 @@ func (m MySQLDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 type Sqlite3Dialect struct{}
 
 func (m Sqlite3Dialect) createVersionTableSQL() string {
-	return `CREATE TABLE goose_db_version (
+	return fmt.Sprintf(`CREATE TABLE %s (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 version_id INTEGER NOT NULL,
                 is_applied INTEGER NOT NULL,
                 tstamp TIMESTAMP DEFAULT (datetime('now'))
-            );`
+            );`, GetDBVersionTableName())
 }
 
 func (m Sqlite3Dialect) insertVersionSQL() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, ?);"
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", GetDBVersionTableName())
 }
 
 func (m Sqlite3Dialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", GetDBVersionTableName()))
 	if err != nil {
 		return nil, err
 	}
@@ -137,21 +137,21 @@ func (m Sqlite3Dialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 type RedshiftDialect struct{}
 
 func (rs RedshiftDialect) createVersionTableSQL() string {
-	return `CREATE TABLE goose_db_version (
+	return fmt.Sprintf(`CREATE TABLE %s (
             	id integer NOT NULL identity(1, 1),
                 version_id bigint NOT NULL,
                 is_applied boolean NOT NULL,
                 tstamp timestamp NULL default sysdate,
                 PRIMARY KEY(id)
-            );`
+            );`, GetDBVersionTableName())
 }
 
 func (rs RedshiftDialect) insertVersionSQL() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES ($1, $2);"
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES ($1, $2);", GetDBVersionTableName())
 }
 
 func (rs RedshiftDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", GetDBVersionTableName()))
 	if err != nil {
 		return nil, err
 	}
@@ -167,21 +167,21 @@ func (rs RedshiftDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 type TiDBDialect struct{}
 
 func (m TiDBDialect) createVersionTableSQL() string {
-	return `CREATE TABLE goose_db_version (
+	return fmt.Sprintf(`CREATE TABLE %s (
                 id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE,
                 version_id bigint NOT NULL,
                 is_applied boolean NOT NULL,
                 tstamp timestamp NULL default now(),
                 PRIMARY KEY(id)
-            );`
+            );`, GetDBVersionTableName())
 }
 
 func (m TiDBDialect) insertVersionSQL() string {
-	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, ?);"
+	return fmt.Sprintf("INSERT INTO %s (version_id, is_applied) VALUES (?, ?);", GetDBVersionTableName())
 }
 
 func (m TiDBDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", GetDBVersionTableName()))
 	if err != nil {
 		return nil, err
 	}

--- a/migrate.go
+++ b/migrate.go
@@ -242,7 +242,7 @@ func EnsureDBVersion(db *sql.DB) (int64, error) {
 	return 0, ErrNoNextVersion
 }
 
-// Create the goose_db_version table
+// Create the db version table
 // and insert the initial 0 value into it
 func createVersionTable(db *sql.DB) error {
 	txn, err := db.Begin()

--- a/status.go
+++ b/status.go
@@ -32,7 +32,7 @@ func Status(db *sql.DB, dir string) error {
 
 func printMigrationStatus(db *sql.DB, version int64, script string) {
 	var row MigrationRecord
-	q := fmt.Sprintf("SELECT tstamp, is_applied FROM %s WHERE version_id=%d ORDER BY tstamp DESC LIMIT 1", GetDBVersionTableName(), version)
+	q := fmt.Sprintf("SELECT tstamp, is_applied FROM %s WHERE version_id=%d ORDER BY tstamp DESC LIMIT 1", TableName(), version)
 	e := db.QueryRow(q).Scan(&row.TStamp, &row.IsApplied)
 
 	if e != nil && e != sql.ErrNoRows {

--- a/status.go
+++ b/status.go
@@ -32,7 +32,7 @@ func Status(db *sql.DB, dir string) error {
 
 func printMigrationStatus(db *sql.DB, version int64, script string) {
 	var row MigrationRecord
-	q := fmt.Sprintf("SELECT tstamp, is_applied FROM goose_db_version WHERE version_id=%d ORDER BY tstamp DESC LIMIT 1", version)
+	q := fmt.Sprintf("SELECT tstamp, is_applied FROM %s WHERE version_id=%d ORDER BY tstamp DESC LIMIT 1", GetDBVersionTableName(), version)
 	e := db.QueryRow(q).Scan(&row.TStamp, &row.IsApplied)
 
 	if e != nil && e != sql.ErrNoRows {

--- a/version.go
+++ b/version.go
@@ -15,3 +15,15 @@ func Version(db *sql.DB, dir string) error {
 	log.Printf("goose: version %v\n", current)
 	return nil
 }
+
+var dbVersionTableName = "goose_db_version"
+
+// GetDBVersionTableName returns goose db version table name
+func GetDBVersionTableName() string {
+	return dbVersionTableName
+}
+
+// SetDBVersionTableName set goose db version table name
+func SetDBVersionTableName(n string) {
+	dbVersionTableName = n
+}

--- a/version.go
+++ b/version.go
@@ -16,14 +16,14 @@ func Version(db *sql.DB, dir string) error {
 	return nil
 }
 
-var dbVersionTableName = "goose_db_version"
+var tableName = "goose_db_version"
 
-// GetDBVersionTableName returns goose db version table name
-func GetDBVersionTableName() string {
-	return dbVersionTableName
+// TableName returns goose db version table name
+func TableName() string {
+	return tableName
 }
 
-// SetDBVersionTableName set goose db version table name
-func SetDBVersionTableName(n string) {
-	dbVersionTableName = n
+// SetTableName set goose db version table name
+func SetTableName(n string) {
+	tableName = n
 }


### PR DESCRIPTION
Hi, guys! 

Change db version table name would be useful in some cases:
* follow the internal rules for tables naming 
* seeding db by goose for dev/test environments

Thanks!