### PR TITLE
Update documentation for GetDBVersion to match functionality

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -266,8 +266,7 @@ func createVersionTable(db *sql.DB) error {
 	return txn.Commit()
 }
 
-// GetDBVersion is a wrapper for EnsureDBVersion for callers that don't already
-// have their own DB instance
+// GetDBVersion is an alias for EnsureDBVersion, but returns -1 in error.
 func GetDBVersion(db *sql.DB) (int64, error) {
 	version, err := EnsureDBVersion(db)
 	if err != nil {


### PR DESCRIPTION
GetDBVersion appears to not have had the documented functionality since 2cccd9df36bf8db0270e1767ae01f07828fa82e5. I've updated the documentation accordingly.