### PR TITLE
cgo functionality in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 dist:
 	@mkdir -p ./bin
 	@rm -f ./bin/*
-	GOOS=darwin GOARCH=amd64 go build -o ./bin/goose-darwin64 ./cmd/goose
-	GOOS=linux GOARCH=amd64 go build -o ./bin/goose-linux64 ./cmd/goose
-	GOOS=linux GOARCH=386 go build -o ./bin/goose-linux386 ./cmd/goose
+	$(CGO_FLAG) GOOS=darwin GOARCH=amd64 go build -o ./bin/goose-darwin64 ./cmd/goose
+	$(CGO_FLAG) GOOS=linux GOARCH=amd64 go build -o ./bin/goose-linux64 ./cmd/goose
+	$(CGO_FLAG) GOOS=linux GOARCH=386 go build -o ./bin/goose-linux386 ./cmd/goose
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Goose is a database migration tool. Manage your database schema by creating incr
 - We encourage using sequential versioning of migration files
     (rather than timestamps-based versioning) to prevent version
     mismatch and migration colissions
+#Build
+
+If you want to build binaries for linux 64,linux 386,darwin run the following command
+    $ make dist
+If you want to build binaries for linux 64,linux 386,darwin without CGO run the following command
+    $ make dist CGO_FLAG="CGO_ENABLED=0"
 
 # Install
 


### PR DESCRIPTION
Functionality to build goose image by disabling the CGO (CGO_ENABLED).
Use case: Bundling goose in an alpine image for docker.
Problem: The Makefile needs to be changed to disable cgo, as alpine does not have support for these c binaries and hence the build fails on alpine image.
