### PR TITLE
Suggestion: Order by timestamp in goose_db_version

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -181,7 +181,7 @@ func (m TiDBDialect) insertVersionSQL() string {
 }
 
 func (m TiDBDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY id DESC", TableName()))
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied from %s ORDER BY tstamp DESC", TableName()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Some distributed databases (like TiDB) does not guarantee ID to be allocated sequentially with AUTO_INCREMENT. This makes the migration become out of sync, and goose try to run a migration that has already been run.

Because of this it might be good to sort by timestamp, to avoid this type of conflict? I don't think it would be a breaking change.