### PR TITLE
Add lock of the internal goose table

### DIFF
--- a/migration_sql.go
+++ b/migration_sql.go
@@ -154,6 +154,12 @@ func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) err
 			log.Fatal(err)
 		}
 
+		err = GetDialect().lockTableQuery(tx)
+
+		if err != nil {
+			log.Fatalf("Could not acquire table lock. Is there another migration in progress? Error: %v", err)
+		}
+
 		for _, query := range statements {
 			if _, err = tx.Exec(query); err != nil {
 				tx.Rollback()


### PR DESCRIPTION
Problem:

Two automated builds/people start the migration process at the same
time. Currently the results are relatively unpredictable expecially on
data migration tasks.

Solution:

Before starting the migration we lock the goose version table resulting
in an error if a second lock attempt is made.
This would force the second migration to back off and retry later. It is
important that the process of acquiring the lock results in an error and
does not just wait for the lock to be released (as it seems to be the
case for Mysql, RedShift) as that would still result in undesired
behaviour.

Unfortunately only PG seems to support locking of the nature that is
required and is thus the only system implemented. The lock call in other
dialects result in a NOOP, but provides a framework and commentary.