### PR TITLE
Add verbose option to print executed sql statements

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	if *verbose {
-		goose.SetVerbosity(goose.VerboseOn)
+		goose.SetVerbose(true)
 	}
 
 	switch args[0] {

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	flags = flag.NewFlagSet("goose", flag.ExitOnError)
-	dir   = flags.String("dir", ".", "directory with migration files")
+	flags   = flag.NewFlagSet("goose", flag.ExitOnError)
+	dir     = flags.String("dir", ".", "directory with migration files")
+	verbose = flags.Bool("v", false, "enable verbose mode")
 )
 
 func main() {
@@ -22,6 +23,10 @@ func main() {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		flags.Usage()
 		return
+	}
+
+	if *verbose {
+		goose.SetVerbosity(goose.VerboseOn)
 	}
 
 	switch args[0] {

--- a/goose.go
+++ b/goose.go
@@ -8,28 +8,18 @@ import (
 	"sync"
 )
 
-// VerboseMode is the goose verbosity
-type VerboseMode bool
-
-const (
-	// VerboseOn is the goose verbose mode
-	VerboseOn VerboseMode = true
-	// VerboseOff is the goose silent mode
-	VerboseOff VerboseMode = false
-)
-
 var (
 	duplicateCheckOnce sync.Once
 	minVersion         = int64(0)
 	maxVersion         = int64((1 << 63) - 1)
 	timestampFormat    = "20060102150405"
-	verbose            = VerboseOff
+	verbose            = false
 	reMatchSQLComments = regexp.MustCompile(`(--.*)`)
 )
 
-// SetVerbosity defines the goose verbosity
-func SetVerbosity(vl VerboseMode) {
-	verbose = vl
+// SetVerbose set the goose verbosity mode
+func SetVerbose(v bool) {
+	verbose = v
 }
 
 // Run runs a goose command.

--- a/goose.go
+++ b/goose.go
@@ -8,14 +8,14 @@ import (
 	"sync"
 )
 
-// VerboseLevel verbose level of the goose library
-type VerboseLevel int
+// VerboseMode is the goose verbosity
+type VerboseMode bool
 
 const (
-	// VerboseOff disable the log of the executed SQL statements
-	VerboseOff VerboseLevel = iota + 1
-	// VerboseOn log the executed SQL statements
-	VerboseOn
+	// VerboseOn is the goose verbose mode
+	VerboseOn VerboseMode = true
+	// VerboseOff is the goose silent mode
+	VerboseOff VerboseMode = false
 )
 
 var (
@@ -24,11 +24,11 @@ var (
 	maxVersion         = int64((1 << 63) - 1)
 	timestampFormat    = "20060102150405"
 	verbose            = VerboseOff
-	reMatchSQLComments = regexp.MustCompile(`(--.*)|(((\/\*)+?[\w\W]+?(\*\/)+))`)
+	reMatchSQLComments = regexp.MustCompile(`(--.*)`)
 )
 
-// SetVerbosity defines the goose verbose level
-func SetVerbosity(vl VerboseLevel) {
+// SetVerbosity defines the goose verbosity
+func SetVerbosity(vl VerboseMode) {
 	verbose = vl
 }
 

--- a/goose.go
+++ b/goose.go
@@ -3,8 +3,19 @@ package goose
 import (
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strconv"
 	"sync"
+)
+
+// VerboseLevel verbose level of the goose library
+type VerboseLevel int
+
+const (
+	// VerboseOff disable the log of the executed SQL statements
+	VerboseOff VerboseLevel = iota + 1
+	// VerboseOn log the executed SQL statements
+	VerboseOn
 )
 
 var (
@@ -12,7 +23,14 @@ var (
 	minVersion         = int64(0)
 	maxVersion         = int64((1 << 63) - 1)
 	timestampFormat    = "20060102150405"
+	verbose            = VerboseOff
+	reMatchSQLComments = regexp.MustCompile(`(--.*)|(((\/\*)+?[\w\W]+?(\*\/)+))`)
 )
+
+// SetVerbosity defines the goose verbose level
+func SetVerbosity(vl VerboseLevel) {
+	verbose = vl
+}
 
 // Run runs a goose command.
 func Run(command string, db *sql.DB, dir string, args ...string) error {

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -153,13 +153,17 @@ func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) err
 	if useTx {
 		// TRANSACTION.
 
+		printInfo("Begin transaction\n")
+
 		tx, err := db.Begin()
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		for _, query := range statements {
+			printInfo("Executing statement : %s\n", cleanStatement(query))
 			if _, err = tx.Exec(query); err != nil {
+				printInfo("Rollback transaction\n")
 				tx.Rollback()
 				return err
 			}
@@ -167,21 +171,25 @@ func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) err
 
 		if direction {
 			if _, err := tx.Exec(GetDialect().insertVersionSQL(), v, direction); err != nil {
+				printInfo("Rollback transaction\n")
 				tx.Rollback()
 				return err
 			}
 		} else {
 			if _, err := tx.Exec(GetDialect().deleteVersionSQL(), v); err != nil {
+				printInfo("Rollback transaction\n")
 				tx.Rollback()
 				return err
 			}
 		}
 
+		printInfo("Commit transaction\n")
 		return tx.Commit()
 	}
 
 	// NO TRANSACTION.
 	for _, query := range statements {
+		printInfo("Executing statement : %s\n", cleanStatement(query))
 		if _, err := db.Exec(query); err != nil {
 			return err
 		}
@@ -191,4 +199,14 @@ func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) err
 	}
 
 	return nil
+}
+
+func printInfo(s string, args ...interface{}) {
+	if verbose == VerboseOn {
+		log.Printf(s, args...)
+	}
+}
+
+func cleanStatement(s string) string {
+	return reMatchSQLComments.ReplaceAllString(s, ``)
 }

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -202,7 +202,7 @@ func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) err
 }
 
 func printInfo(s string, args ...interface{}) {
-	if verbose {
+	if verbose == VerboseOn {
 		log.Printf(s, args...)
 	}
 }

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -202,7 +202,7 @@ func runSQLMigration(db *sql.DB, scriptFile string, v int64, direction bool) err
 }
 
 func printInfo(s string, args ...interface{}) {
-	if verbose == VerboseOn {
+	if verbose {
 		log.Printf(s, args...)
 	}
 }


### PR DESCRIPTION
When executing sql migration, it's useful to be able to see the executed statements, especially when the execution fails.
So, I've added the verbose option (-v) to log each query before there execution.