### PR TITLE
Improve custom logger: Use stdlib's existing logger variable by default

### DIFF
--- a/log.go
+++ b/log.go
@@ -2,10 +2,9 @@ package goose
 
 import (
 	std "log"
-	"os"
 )
 
-var log Logger = std.New(os.Stderr, "", std.LstdFlags)
+var log Logger = &stdLogger{}
 
 // Logger is standart logger interface
 type Logger interface {
@@ -20,3 +19,12 @@ type Logger interface {
 func SetLogger(l Logger) {
 	log = l
 }
+
+// stdLogger is a default logger that outputs to a stdlib's log.std logger.
+type stdLogger struct{}
+
+func (*stdLogger) Fatal(v ...interface{})                 { std.Fatal(v...) }
+func (*stdLogger) Fatalf(format string, v ...interface{}) { std.Fatalf(format, v...) }
+func (*stdLogger) Print(v ...interface{})                 { std.Print(v...) }
+func (*stdLogger) Println(v ...interface{})               { std.Println(v...) }
+func (*stdLogger) Printf(format string, v ...interface{}) { std.Printf(format, v...) }


### PR DESCRIPTION
Follow-up on #105. Don't allocate new stdlib's logger and reuse
the default logger (unexported) variable. This will enable people
make custom changes to the std logger, ie. log.SetFlags(),
log.SetPrefix() or log.SetOutput() without having to duplicate
the same code and applying it to goose logger.

Note: I wish Go made the std logger an interface soon. They might plan it for Go 2, but who knows when it will land.. https://github.com/golang/go/issues/13182