### PR TITLE
Improve migration templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-- 1.8
+- 1.12
 
 install:
 - go get github.com/golang/dep/cmd/dep

--- a/create.go
+++ b/create.go
@@ -69,7 +69,7 @@ SELECT 'down SQL query';
 -- +goose StatementEnd
 `))
 
-var goSQLMigrationTemplate = template.Must(template.New("goose.go-migration").Parse(`package migration
+var goSQLMigrationTemplate = template.Must(template.New("goose.go-migration").Parse(`package migrations
 
 import (
 	"database/sql"

--- a/create.go
+++ b/create.go
@@ -7,55 +7,54 @@ import (
 	"path/filepath"
 	"text/template"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
+type tmplVars struct {
+	Version   string
+	CamelName string
+}
+
 // Create writes a new blank migration file.
-func CreateWithTemplate(db *sql.DB, dir string, migrationTemplate *template.Template, name, migrationType string) error {
+func CreateWithTemplate(db *sql.DB, dir string, tmpl *template.Template, name, migrationType string) error {
 	version := time.Now().Format(timestampFormat)
-	filename := fmt.Sprintf("%v_%v.%v", version, name, migrationType)
+	filename := fmt.Sprintf("%v_%v.%v", version, snakeCase(name), migrationType)
 
-	fpath := filepath.Join(dir, filename)
-
-	tmpl := sqlMigrationTemplate
-	if migrationType == "go" {
-		tmpl = goSQLMigrationTemplate
+	if tmpl == nil {
+		if migrationType == "go" {
+			tmpl = goSQLMigrationTemplate
+		} else {
+			tmpl = sqlMigrationTemplate
+		}
 	}
 
-	if migrationTemplate != nil {
-		tmpl = migrationTemplate
+	path := filepath.Join(dir, filename)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return errors.Wrap(err, "failed to create migration file")
 	}
 
-	path, err := writeTemplateToFile(fpath, tmpl, version)
+	f, err := os.Create(path)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to create migration file")
+	}
+	defer f.Close()
+
+	vars := tmplVars{
+		Version:   version,
+		CamelName: camelCase(name),
+	}
+	if err := tmpl.Execute(f, vars); err != nil {
+		return errors.Wrap(err, "failed to execute tmpl")
 	}
 
-	log.Printf("Created new file: %s\n", path)
+	log.Printf("Created new file: %s\n", f.Name())
 	return nil
 }
 
 // Create writes a new blank migration file.
 func Create(db *sql.DB, dir, name, migrationType string) error {
 	return CreateWithTemplate(db, dir, nil, name, migrationType)
-}
-
-func writeTemplateToFile(path string, t *template.Template, version string) (string, error) {
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		return "", fmt.Errorf("failed to create file: %v already exists", path)
-	}
-
-	f, err := os.Create(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	err = t.Execute(f, version)
-	if err != nil {
-		return "", err
-	}
-
-	return f.Name(), nil
 }
 
 var sqlMigrationTemplate = template.Must(template.New("goose.sql-migration").Parse(`-- +goose Up
@@ -77,15 +76,15 @@ import (
 )
 
 func init() {
-	goose.AddMigration(Up{{.}}, Down{{.}})
+	goose.AddMigration(up{{.CamelName}}, down{{.CamelName}})
 }
 
-func Up{{.}}(tx *sql.Tx) error {
+func up{{.CamelName}}(tx *sql.Tx) error {
 	// This code is executed when the migration is applied.
 	return nil
 }
 
-func Down{{.}}(tx *sql.Tx) error {
+func down{{.CamelName}}(tx *sql.Tx) error {
 	// This code is executed when the migration is rolled back.
 	return nil
 }

--- a/create.go
+++ b/create.go
@@ -59,10 +59,14 @@ func writeTemplateToFile(path string, t *template.Template, version string) (str
 }
 
 var sqlMigrationTemplate = template.Must(template.New("goose.sql-migration").Parse(`-- +goose Up
--- SQL in this section is executed when the migration is applied.
+-- +goose StatementBegin
+SELECT 'up SQL query';
+-- +goose StatementEnd
 
 -- +goose Down
--- SQL in this section is executed when the migration is rolled back.
+-- +goose StatementBegin
+SELECT 'down SQL query';
+-- +goose StatementEnd
 `))
 
 var goSQLMigrationTemplate = template.Must(template.New("goose.go-migration").Parse(`package migration

--- a/helpers.go
+++ b/helpers.go
@@ -58,14 +58,6 @@ func camelCase(str string) string {
 	return b.String()
 }
 
-func lowerCamelCase(str string) string {
-	str = camelCase(str)
-	if len(str) == 0 {
-		return str
-	}
-	return strings.ToLower(str[:1]) + str[1:]
-}
-
 func snakeCase(str string) string {
 	var b bytes.Buffer
 

--- a/helpers.go
+++ b/helpers.go
@@ -25,9 +25,8 @@ func (s camelSnakeStateMachine) next(r rune) camelSnakeStateMachine {
 	case firstAlphaNum:
 		if isAlphaNum(r) {
 			return alphaNum
-		} else {
-			return delimiter
 		}
+		return delimiter
 	case alphaNum:
 		if !isAlphaNum(r) {
 			return delimiter
@@ -35,9 +34,8 @@ func (s camelSnakeStateMachine) next(r rune) camelSnakeStateMachine {
 	case delimiter:
 		if isAlphaNum(r) {
 			return firstAlphaNum
-		} else {
-			return idle
 		}
+		return idle
 	}
 	return s
 }

--- a/helpers.go
+++ b/helpers.go
@@ -41,7 +41,7 @@ func (s camelSnakeStateMachine) next(r rune) camelSnakeStateMachine {
 	return s
 }
 
-func lowerCamelCase(str string) string {
+func camelCase(str string) string {
 	var b strings.Builder
 
 	stateMachine := begin
@@ -57,6 +57,14 @@ func lowerCamelCase(str string) string {
 		}
 	}
 	return b.String()
+}
+
+func lowerCamelCase(str string) string {
+	str = camelCase(str)
+	if len(str) == 0 {
+		return str
+	}
+	return strings.ToLower(str[:1]) + str[1:]
 }
 
 func isAlphaNum(r rune) bool {

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,64 @@
+package goose
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+type camelSnakeStateMachine int
+
+const (
+	begin         camelSnakeStateMachine = iota // 0
+	firstAlphaNum                               // 1
+	alphaNum                                    // 2
+	delimiter                                   // 3
+)
+
+func (s camelSnakeStateMachine) next(r rune) camelSnakeStateMachine {
+	switch s {
+	case begin:
+		if isAlphaNum(r) {
+			return firstAlphaNum
+		}
+	case firstAlphaNum:
+		if isAlphaNum(r) {
+			return alphaNum
+		} else {
+			return delimiter
+		}
+	case alphaNum:
+		if !isAlphaNum(r) {
+			return delimiter
+		}
+	case delimiter:
+		if isAlphaNum(r) {
+			return firstAlphaNum
+		} else {
+			return begin
+		}
+	}
+	return s
+}
+
+func lowerCamelCase(str string) string {
+	var b strings.Builder
+
+	stateMachine := begin
+	for i := 0; i < len(str); {
+		r, size := utf8.DecodeRuneInString(str[i:])
+		i += size
+		stateMachine = stateMachine.next(r)
+		switch stateMachine {
+		case firstAlphaNum:
+			b.WriteRune(unicode.ToUpper(r))
+		case alphaNum:
+			b.WriteRune(unicode.ToLower(r))
+		}
+	}
+	return b.String()
+}
+
+func isAlphaNum(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsNumber(r)
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -10,13 +10,13 @@ func TestCamelSnake(t *testing.T) {
 		camel string
 		snake string
 	}{
-		{in: "Add updated_at to users table", camel: "addUpdatedAtToUsersTable", snake: "add_updated_at_to_users_table"},
-		{in: "$()&^%(_--crazy__--input$)", camel: "crazyInput", snake: "crazy_input"},
+		{in: "Add updated_at to users table", camel: "AddUpdatedAtToUsersTable", snake: "add_updated_at_to_users_table"},
+		{in: "$()&^%(_--crazy__--input$)", camel: "CrazyInput", snake: "crazy_input"},
 	}
 
 	for _, test := range tt {
-		if got := lowerCamelCase(test.in); got != test.camel {
-			t.Errorf("unexpected lowerCamelCase for input(%q), got %q, want %q", test.in, got, test.camel)
+		if got := camelCase(test.in); got != test.camel {
+			t.Errorf("unexpected CamelCase for input(%q), got %q, want %q", test.in, got, test.camel)
 		}
 		if got := snakeCase(test.in); got != test.snake {
 			t.Errorf("unexpected snake_case for input(%q), got %q, want %q", test.in, got, test.snake)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -16,10 +16,10 @@ func TestCamelSnake(t *testing.T) {
 
 	for _, test := range tt {
 		if got := lowerCamelCase(test.in); got != test.camel {
-			t.Errorf("unexpected lower camel for input(%q), got %q, want %q", test.in, got, test.camel)
+			t.Errorf("unexpected lowerCamelCase for input(%q), got %q, want %q", test.in, got, test.camel)
 		}
-		// if got := snake(test.in); got != test.snake {
-		// 	t.Error("unexpected snake for input(%q), got %q, want %q", test.in, got, test.snake)
-		// }
+		if got := snakeCase(test.in); got != test.snake {
+			t.Errorf("unexpected snake_case for input(%q), got %q, want %q", test.in, got, test.snake)
+		}
 	}
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,25 @@
+package goose
+
+import (
+	"testing"
+)
+
+func TestCamelSnake(t *testing.T) {
+	tt := []struct {
+		in    string
+		camel string
+		snake string
+	}{
+		{in: "Add updated_at to users table", camel: "addUpdatedAtToUsersTable", snake: "add_updated_at_to_users_table"},
+		{in: "$()&^%(_--crazy__--input$)", camel: "crazyInput", snake: "crazy_input"},
+	}
+
+	for _, test := range tt {
+		if got := lowerCamelCase(test.in); got != test.camel {
+			t.Errorf("unexpected lower camel for input(%q), got %q, want %q", test.in, got, test.camel)
+		}
+		// if got := snake(test.in); got != test.snake {
+		// 	t.Error("unexpected snake for input(%q), got %q, want %q", test.in, got, test.snake)
+		// }
+	}
+}


### PR DESCRIPTION
Fixes #34

You can pass down a custom template via `goose.CreateWithTemplate(db, dir, customTemplate, name, migrationType)`