### PR TITLE
Fix regression in SQL parser #158

### DIFF
--- a/sql_parser.go
+++ b/sql_parser.go
@@ -11,26 +11,24 @@ import (
 	"github.com/pkg/errors"
 )
 
-type parserState int
+type stateMachine int
 
 const (
-	start                   parserState = iota // 0
-	gooseUp                                    // 1
-	gooseStatementBeginUp                      // 2
-	gooseStatementEndUp                        // 3
-	gooseDown                                  // 4
-	gooseStatementBeginDown                    // 5
-	gooseStatementEndDown                      // 6
+	start                   stateMachine = iota // 0
+	gooseUp                                     // 1
+	gooseStatementBeginUp                       // 2
+	gooseStatementEndUp                         // 3
+	gooseDown                                   // 4
+	gooseStatementBeginDown                     // 5
+	gooseStatementEndDown                       // 6
 )
 
-type stateMachine parserState
-
-func (s *stateMachine) Get() parserState {
-	return parserState(*s)
+func (s *stateMachine) Get() stateMachine {
+	return stateMachine(*s)
 }
-func (s *stateMachine) Set(new parserState) {
-	verboseInfo("StateMachine: %v => %v", *s, new)
-	*s = stateMachine(new)
+func (s *stateMachine) Set(state stateMachine) {
+	verboseInfo("StateMachine: %v => %v", *s, state)
+	*s = state
 }
 
 const scanBufSize = 4 * 1024 * 1024
@@ -61,7 +59,7 @@ func parseSQLMigration(r io.Reader, direction bool) (stmts []string, useTx bool,
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(scanBuf, scanBufSize)
 
-	stateMachine := stateMachine(start)
+	stateMachine := start
 	useTx = true
 
 	for scanner.Scan() {

--- a/sql_parser_test.go
+++ b/sql_parser_test.go
@@ -51,6 +51,7 @@ func TestSplitStatements(t *testing.T) {
 		{sql: mysqlChangeDelimiter, up: 4, down: 0},
 		{sql: copyFromStdin, up: 1, down: 0},
 		{sql: plpgsqlSyntax, up: 2, down: 2},
+		{sql: statementAndSimpleMultilineQuery, up: 2, down: 1},
 	}
 
 	for i, test := range tt {
@@ -318,4 +319,25 @@ DROP TRIGGER update_properties_updated_at
 -- +goose StatementBegin
 DROP FUNCTION update_updated_at_column()
 -- +goose StatementEnd
+`
+
+var statementAndSimpleMultilineQuery = `
+-- +goose Up
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'things') THEN
+        create type things AS ENUM ('hello', 'world');
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+CREATE TABLE IF NOT EXISTS doge (
+  id int
+);
+-- +goose Down
+-- SQL in this section is executed when the migration is rolled back.
+DROP TABLE IF EXISTS doge;
 `


### PR DESCRIPTION
Fixes #158

If you write a complex query with `-- +goose StatementBegin` & `-- +goose StatementEnd` and follow up with a simple SQL statement, the parser will ignore it.