### PR TITLE
Fix SQL parser regression

### DIFF
--- a/sql_parser.go
+++ b/sql_parser.go
@@ -174,10 +174,12 @@ func parseSQLMigration(r io.Reader, direction bool) (stmts []string, useTx bool,
 			stmts = append(stmts, buf.String())
 			buf.Reset()
 			verboseInfo("StateMachine: store Up statement")
+			stateMachine.Set(gooseUp)
 		case gooseStatementEndDown:
 			stmts = append(stmts, buf.String())
 			buf.Reset()
 			verboseInfo("StateMachine: store Down statement")
+			stateMachine.Set(gooseDown)
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/sql_parser_test.go
+++ b/sql_parser_test.go
@@ -51,6 +51,7 @@ func TestSplitStatements(t *testing.T) {
 		{sql: mysqlChangeDelimiter, up: 4, down: 0},
 		{sql: copyFromStdin, up: 1, down: 0},
 		{sql: plpgsqlSyntax, up: 2, down: 2},
+		{sql: plpgsqlSyntaxMixedStatements, up: 2, down: 2},
 	}
 
 	for i, test := range tt {
@@ -318,4 +319,26 @@ DROP TRIGGER update_properties_updated_at
 -- +goose StatementBegin
 DROP FUNCTION update_updated_at_column()
 -- +goose StatementEnd
+`
+
+var plpgsqlSyntaxMixedStatements = `
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+-- +goose StatementEnd
+
+CREATE TRIGGER update_properties_updated_at
+BEFORE UPDATE
+ON properties 
+FOR EACH ROW EXECUTE PROCEDURE  update_updated_at_column();
+
+-- +goose Down
+DROP TRIGGER update_properties_updated_at;
+DROP FUNCTION update_updated_at_column();
 `


### PR DESCRIPTION
As pointed out by #158, the parser fails when a migration has statement blocks (e.g. `StatementBegin .. StatementEnd`) and "simple" or multi-line statements occurring in the same migration.

The problem appears to be since the state machine within `parseSQLMigration` never changes its state back to `gooseUp` or `gooseDown` after it is in `gooseStatementEndUp` or `gooseStatementEndDown`, respectively.

I have also added a new test case to cover the situation where there are statement blocks, simple statements, and multi-line statements in one migration.

As a side note, this fix also cut down the duration of the tests from ~40s to ~10s.