### PR TITLE
Fixed driver initialisation for MSSQL

### DIFF
--- a/db.go
+++ b/db.go
@@ -13,6 +13,8 @@ func OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
 	}
 
 	switch driver {
+	case "mssql":
+		driver = "sqlserver"
 	case "redshift":
 		driver = "postgres"
 	case "tidb":
@@ -20,7 +22,7 @@ func OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
 	}
 
 	switch driver {
-	case "postgres", "sqlite3", "mysql", "mssql":
+	case "postgres", "sqlite3", "mysql", "sqlserver":
 		return sql.Open(driver, dbstring)
 	default:
 		return nil, fmt.Errorf("unsupported driver %s", driver)


### PR DESCRIPTION
Sorry, @VojtechVitek , here is small fix for MSSQL driver initialisation

It means both identifiers `mssql` and `sqlserver` are correct for driver. But `mssql` initialises driver in mode with processing query text for non-native parameters. Otherwise `sqlserver` initialises driver with normal MSSQL syntax for parameters
Details are here: https://github.com/denisenkom/go-mssqldb#deprecated
And here: https://github.com/denisenkom/go-mssqldb/blob/master/mssql.go#L30