### PR TITLE
fixing panic when a transaction can't be opened

### DIFF
--- a/migration_sql.go
+++ b/migration_sql.go
@@ -23,7 +23,7 @@ func runSQLMigration(db *sql.DB, statements []string, useTx bool, v int64, direc
 
 		tx, err := db.Begin()
 		if err != nil {
-			errors.Wrap(err, "failed to begin transaction")
+			return errors.Wrap(err, "failed to begin transaction")
 		}
 
 		for _, query := range statements {


### PR DESCRIPTION
Hello. When the transaction can't be opened, it turns nil pointer panic. (example: DB in read-only).

This pull request fixes it.


Signed-off-by: Pichugin Dmitry <pichugin.dmitry.v@gmail.com>