### PR TITLE
Added example of postgres migration with yml config file support.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,2 +1,3 @@
 # 1. [SQL migrations](sql-migrations)
 # 2. [Go migrations](go-migrations)
+# 3. [YML config](pq-ymlconfig)

--- a/examples/pq-ymlconfig/README.md
+++ b/examples/pq-ymlconfig/README.md
@@ -1,0 +1,15 @@
+# PostgresSQL + YML config migration
+
+## This example: Custom goose binary for PostgreSQL migrations with YML config.
+
+```bash
+$ go build -o goose *.go
+```
+
+```bash
+$ ./goose -h
+```
+
+## Best practice: Split migrations into a standalone package
+
+1. Move [main.go](main.go) into your `cmd/` directory

--- a/examples/pq-ymlconfig/dbconf.go
+++ b/examples/pq-ymlconfig/dbconf.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kylelemons/go-gypsy/yaml"
+	"github.com/lib/pq"
+)
+
+type DBConf struct {
+	DBString      string
+	Driver        string
+	MigrationsDir string
+	Env           string
+	PgSchema      string
+}
+
+// extract configuration details from the given file
+// inputs
+//	path: folder containing db info
+//  env: which DB environment to use
+//  pgschema: which postgres-schema to migrate (default = none)
+func NewDBConf(path, env string, pgschema string) (*DBConf, error) {
+	cfgFile := filepath.Join(path, "dbconf.yml")
+
+	f, err := yaml.ReadFile(cfgFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// database driver
+	drv, err := f.Get(fmt.Sprintf("%s.driver", env))
+	if err != nil {
+		return nil, err
+	}
+	drv = os.ExpandEnv(drv)
+
+	// database string
+	open, err := f.Get(fmt.Sprintf("%s.open", env))
+	if err != nil {
+		return nil, err
+	}
+	open = os.ExpandEnv(open)
+
+	// Automatically parse postgres urls
+	// Assumption: If we can parse the URL, we should
+	if parsedURL, err := pq.ParseURL(open); err == nil && parsedURL != "" {
+		open = parsedURL
+	}
+
+	return &DBConf{
+		DBString:      open,
+		Driver:        drv,
+		MigrationsDir: path,
+		Env:           env,
+		PgSchema:      pgschema,
+	}, nil
+}

--- a/examples/pq-ymlconfig/dbconf.yml
+++ b/examples/pq-ymlconfig/dbconf.yml
@@ -1,0 +1,9 @@
+development:
+    driver: postgres
+    open: user=example dbname=example_dev sslmode=disable
+staging:
+    driver: postgres
+    open: user=example dbname=example_staging sslmode=disable
+production:
+    driver: postgres
+    open: user=example host=postgres dbname=example sslmode=disable

--- a/examples/pq-ymlconfig/main.go
+++ b/examples/pq-ymlconfig/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/pressly/goose"
+)
+
+var (
+	flags   = flag.NewFlagSet("migrate", flag.ExitOnError)
+	env     = flags.String("env", "development", "which DB environment to use")
+	dir     = flags.String("dir", "", "directory with migration files")
+	verbose = flags.Bool("v", false, "enable verbose mode")
+	help    = flags.Bool("h", false, "print help")
+	version = flags.Bool("version", false, "print version")
+)
+
+func main() {
+	flags.Usage = usage
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		log.Panic(err)
+	}
+
+	if *version {
+		fmt.Println(goose.VERSION)
+		return
+	}
+	if *verbose {
+		goose.SetVerbose(true)
+	}
+
+	args := flags.Args()
+	if len(args) == 0 || *help {
+		flags.Usage()
+		return
+	}
+
+	conf, err := NewDBConf(*dir, *env, "")
+	if err != nil {
+		log.Fatalf("unable to process dbconf.yml: %v\n", err)
+	}
+
+	switch args[0] {
+	case "create":
+		if err := goose.Run("create", nil, conf.MigrationsDir, args[1:]...); err != nil {
+			log.Fatalf("migrate create: %s", err)
+		}
+		return
+	case "fix":
+		if err := goose.Run("fix", nil, conf.MigrationsDir); err != nil {
+			log.Fatalf("migrate fix: %s", err)
+		}
+		return
+	}
+
+	if len(args) < 1 {
+		flags.Usage()
+		return
+	}
+
+	db, err := goose.OpenDBWithDriver(conf.Driver, conf.DBString)
+	if err != nil {
+		log.Fatalf("dbstring=%q: %v\n", conf.DBString, err)
+	}
+
+	arguments := []string{}
+	if len(args) > 1 {
+		arguments = append(arguments, args[3:]...)
+	}
+
+	if err := goose.Run(args[0], db, conf.MigrationsDir, arguments...); err != nil {
+		log.Fatalf("goose %s: %s", args[0], err)
+	}
+}
+
+func usage() {
+	fmt.Println(usagePrefix)
+	flags.PrintDefaults()
+	fmt.Println(usageCommands)
+}
+
+var (
+	usagePrefix = `Usage: migrate [OPTIONS] COMMAND
+Examples:
+    migrate status
+    migrate create init sql
+    migrate create add_some_column sql
+    migrate create fetch_user_data go
+    migrate up
+Options:
+`
+
+	usageCommands = `
+Commands:
+    up                   Migrate the DB to the most recent version available
+    up-to VERSION        Migrate the DB to a specific VERSION
+    down                 Roll back the version by 1
+    down-to VERSION      Roll back to a specific VERSION
+    redo                 Re-run the latest migration
+    reset                Roll back all migrations
+    status               Dump the migration status for the current DB
+    version              Print the current version of the database
+    create NAME [sql|go] Creates new migration file with the current timestamp
+    fix                  Apply sequential ordering to migrations
+`
+)


### PR DESCRIPTION
I'm in a peculiar situation where I need to switch between multiple databases within the same environment (don't ask), so i had to create a wrapper around goose to enable this with yml configs. this is what i came up with and seems to work fairly well. thought to contribute back as an example. 

quick note: 
dbconf.go can be extended to support any db. this example is only for postgres, however it could be easily extended to anything else.
