### PR TITLE
Adding ability to pass custom tablename from cmd arguments

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -10,11 +10,12 @@ import (
 )
 
 var (
-	flags   = flag.NewFlagSet("goose", flag.ExitOnError)
-	dir     = flags.String("dir", ".", "directory with migration files")
-	verbose = flags.Bool("v", false, "enable verbose mode")
-	help    = flags.Bool("h", false, "print help")
-	version = flags.Bool("version", false, "print version")
+	flags     = flag.NewFlagSet("goose", flag.ExitOnError)
+	dir       = flags.String("dir", ".", "directory with migration files")
+	verbose   = flags.Bool("v", false, "enable verbose mode")
+	help      = flags.Bool("h", false, "print help")
+	version   = flags.Bool("version", false, "print version")
+	tableName = flags.String("table-name", "", "Use custom goose version table name")
 )
 
 func main() {
@@ -27,6 +28,10 @@ func main() {
 	}
 	if *verbose {
 		goose.SetVerbose(true)
+	}
+
+	if *tableName != "" {
+		goose.SetTableName(*tableName)
 	}
 
 	args := flags.Args()


### PR DESCRIPTION
First, thank you for making and maintaining an awesome tool. 

We want to leverage the existing functionality for setting custom table name for goose schema versions through commandline, for our usecase we have multiple microservices having their own migrations in same database, so having custom schema version table name really helps us avoid conflicts.