### PR TITLE
Introduce registered migrations API

### DIFF
--- a/examples/compiled-migrations/README.md
+++ b/examples/compiled-migrations/README.md
@@ -1,0 +1,37 @@
+# Compiled Go migrations
+
+## This example: Custom binary with compiled Go migrations
+
+```bash
+$ go build -o migrate main.go
+```
+
+```
+$ ./migrate sqlite3 ./foo.db up
+
+$ ./goose sqlite3 ./foo.db up
+OK    00001_create_users_table.sql
+OK    00002_rename_root.go
+goose: no migrations to run. current version: 2
+
+$
+    Applied At                  Migration
+    =======================================
+    Mon Jun 19 21:56:00 2017 -- 00001_create_users_table.sql
+    Mon Jun 19 21:56:00 2017 -- 00002_rename_root.go
+```
+
+## Best practice: Split migrations into a standalone package
+
+1. Move [main.go](main.go) into your `cmd/` directory
+
+2. Rename package name in all `*_.go` migration files from `main` to `migrations`.
+
+3. Import this `migrations` package from your custom [cmd/main.go](main.go) file:
+
+    ```go
+    import (
+        // Invoke init() functions within migrations pkg.
+        _ "github.com/pressly/goose/example/migrations-go"
+    )
+    ```

--- a/examples/compiled-migrations/README.md
+++ b/examples/compiled-migrations/README.md
@@ -2,36 +2,16 @@
 
 ## This example: Custom binary with compiled Go migrations
 
+
+You can migrate all of your generate `*.go` migrations by calling `goose.Registered().Up(...)`. This function performs all of the Go migrations that were registered with `goose.AddMigration()`, which is called in the `init` block of generate Go migration files.
+
+### Example 
 ```bash
 $ go build -o migrate main.go
 ```
 
 ```
 $ ./migrate sqlite3 ./foo.db up
-
-$ ./goose sqlite3 ./foo.db up
-OK    00001_create_users_table.sql
 OK    00002_rename_root.go
-goose: no migrations to run. current version: 2
-
-$
-    Applied At                  Migration
-    =======================================
-    Mon Jun 19 21:56:00 2017 -- 00001_create_users_table.sql
-    Mon Jun 19 21:56:00 2017 -- 00002_rename_root.go
+goose: no migrations to run. current version: 1
 ```
-
-## Best practice: Split migrations into a standalone package
-
-1. Move [main.go](main.go) into your `cmd/` directory
-
-2. Rename package name in all `*_.go` migration files from `main` to `migrations`.
-
-3. Import this `migrations` package from your custom [cmd/main.go](main.go) file:
-
-    ```go
-    import (
-        // Invoke init() functions within migrations pkg.
-        _ "github.com/pressly/goose/example/migrations-go"
-    )
-    ```

--- a/examples/compiled-migrations/main.go
+++ b/examples/compiled-migrations/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+	"os"
+
+	"github.com/pressly/goose"
+
+	// Import package so migrations are registered via init()
+	_ "migrations"
+)
+
+func main() {
+	driver, dbstring, command := os.Args[1], os.Args[2], os.Args[3]
+	if len(os.Args) != 3 {
+		log.Fatalf("unexpected arguments. please use ./binary [driver] [conn_string] [command]")
+	}
+
+	db, err := sql.Open(driver, dbstring)
+	if err != nil {
+		log.Fatalf("goose: failed to open DB: %v\n", err)
+	}
+
+	err := goose.Registered().Run(command, db)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+}

--- a/examples/compiled-migrations/migrations/00002_rename_root.go
+++ b/examples/compiled-migrations/migrations/00002_rename_root.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose"
+)
+
+func init() {
+	goose.AddMigration(Up00002, Down00002)
+}
+
+func Up00002(tx *sql.Tx) error {
+	_, err := tx.Exec("UPDATE users SET username='admin' WHERE username='root';")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func Down00002(tx *sql.Tx) error {
+	_, err := tx.Exec("UPDATE users SET username='root' WHERE username='admin';")
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/register.go
+++ b/register.go
@@ -1,0 +1,101 @@
+package goose
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrNoRegisteredMigrations = errors.New("goose: no registered migrations to run.")
+)
+
+// Register contains a map of Go migrations that have been registered via goose.AddMigration()
+type Register struct {
+	goMigrations map[int64]*Migration
+}
+
+// globalRegister of Go migrations.
+var globalRegister = &Register{
+	goMigrations: map[int64]*Migration{},
+}
+
+// Registered returns registered go migrations
+func Registered() *Register {
+	return globalRegister
+}
+
+func (r *Register) Run(command string, db *sql.DB) error {
+	switch command {
+	case "up":
+		return r.Up(db)
+
+	case "down":
+		return r.Down(db)
+
+	default:
+		return fmt.Errorf("%q: no such command", command)
+	}
+}
+
+// Up runs an up migration of all registered migrations.
+func (r *Register) Up(db *sql.DB) error {
+	// Ensure there are registered migrations
+	if len(globalRegister.goMigrations) == 0 {
+		return ErrNoRegisteredMigrations
+	}
+
+	// Create migrations from our registered go migrations.
+	var migrations Migrations
+	for _, migration := range globalRegister.goMigrations {
+		migrations = append(migrations, migration)
+	}
+
+	for {
+		current, err := GetDBVersion(db)
+		if err != nil {
+			return err
+		}
+
+		next, err := migrations.Next(current)
+		if err != nil {
+			if err == ErrNoNextVersion {
+				log.Printf("goose: no migrations to run. current version: %d\n", current)
+				return nil
+			}
+			return err
+		}
+
+		if err = next.Up(db); err != nil {
+			return err
+		}
+	}
+}
+
+// Down rolls back a single migration from the current version.
+func (r *Register) Down(db *sql.DB) error {
+	currentVersion, err := GetDBVersion(db)
+	if err != nil {
+		return err
+	}
+
+	// Go migrations registered via goose.AddMigration().
+	var migrations Migrations
+	for _, migration := range globalRegister.goMigrations {
+		v, err := NumericComponent(migration.Source)
+		if err != nil {
+			return err
+		}
+		if versionFilter(v, minVersion, maxVersion) {
+			migrations = append(migrations, migration)
+		}
+	}
+
+	current, err := migrations.Current(currentVersion)
+	if err != nil {
+		return fmt.Errorf("no migration %v", currentVersion)
+	}
+
+	return current.Down(db)
+}


### PR DESCRIPTION
Towards #142.

**W.I.P**

This pull request introduces the concept of the `register`. The register is where all Go migrations registered with `goose.AddMigration()` live - and can be accessed (and thus migrated on) through `goose.Registered()...`.

*Notes:*
If this Register for added Go migrations is going to support _all_ commands, there's going to be a lot of re-writing the `Up, Down, UpTo, DownTo, ...` commands to completely omit the directory string, which can be traced to https://github.com/pressly/goose/blob/master/migrate.go#L147-L149

My main goal is to avoid breaking the current API, but maybe this is a good place to theorise how to reduce code duplication and introduce the concept of file based vs. registered migrations.