### PR TITLE
Close DB connection after migration is complete

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -59,6 +59,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("-dbstring=%q: %v\n", dbstring, err)
 	}
+	defer func() {
+		err := db.Close()
+		if err != nil {
+			log.Fatalf("goose: failed to close DB: %v\n", err)
+		}
+	}()
 
 	arguments := []string{}
 	if len(args) > 3 {

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -60,8 +60,7 @@ func main() {
 		log.Fatalf("-dbstring=%q: %v\n", dbstring, err)
 	}
 	defer func() {
-		err := db.Close()
-		if err != nil {
+		if err := db.Close(); err != nil {
 			log.Fatalf("goose: failed to close DB: %v\n", err)
 		}
 	}()

--- a/examples/go-migrations/main.go
+++ b/examples/go-migrations/main.go
@@ -34,8 +34,7 @@ func main() {
 	}
 
 	defer func() {
-		err := db.Close()
-		if err != nil {
+		if err := db.Close(); err != nil {
 			log.Fatalf("goose: failed to close DB: %v\n", err)
 		}
 	}()

--- a/examples/go-migrations/main.go
+++ b/examples/go-migrations/main.go
@@ -33,6 +33,13 @@ func main() {
 		log.Fatalf("goose: failed to open DB: %v\n", err)
 	}
 
+	defer func() {
+		err := db.Close()
+		if err != nil {
+			log.Fatalf("goose: failed to close DB: %v\n", err)
+		}
+	}()
+
 	arguments := []string{}
 	if len(args) > 3 {
 		arguments = append(arguments, args[3:]...)


### PR DESCRIPTION
Currently DB connection is not closed explicitly after migration is complete, which leaves idle connection hanging on the DB until they are closed by timeout
This should close connections gracefully as soon as migration is complete