### PR TITLE
allow to specify migrations table 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Options:
 
   -dir string
     	directory with migration files (default ".")
+  -table string
+    	migrations table name (default "goose_db_version")
   -h	print help
   -v	enable verbose mode
   -version

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -11,7 +11,8 @@ import (
 
 var (
 	flags   = flag.NewFlagSet("goose", flag.ExitOnError)
-	dir     = flags.String("dir", ".", "directory with migration files")
+	dir     = flags.String("dir", "", "directory with migration files")
+	table   = flags.String("table", "goose_db_version", "migrations table name")
 	verbose = flags.Bool("v", false, "enable verbose mode")
 	help    = flags.Bool("h", false, "print help")
 	version = flags.Bool("version", false, "print version")
@@ -28,6 +29,7 @@ func main() {
 	if *verbose {
 		goose.SetVerbose(true)
 	}
+	goose.SetTableName(*table)
 
 	args := flags.Args()
 	if len(args) == 0 || *help {


### PR DESCRIPTION
Sometimes you need to have two set of migrations per database:  data corrections and migrations. This PR allows to have them simultaneously by allowing to specify table name to store migrations.