### PR TITLE
Add independent migrations for different databases

### DIFF
--- a/create.go
+++ b/create.go
@@ -18,6 +18,11 @@ type tmplVars struct {
 
 // Create writes a new blank migration file.
 func CreateWithTemplate(db *sql.DB, dir string, tmpl *template.Template, name, migrationType string) error {
+	return def.CreateWithTemplate(db, dir, tmpl, name, migrationType)
+}
+
+// Create writes a new blank migration file.
+func (in *Instance) CreateWithTemplate(db *sql.DB, dir string, tmpl *template.Template, name, migrationType string) error {
 	version := time.Now().Format(timestampFormat)
 	filename := fmt.Sprintf("%v_%v.%v", version, snakeCase(name), migrationType)
 
@@ -48,13 +53,18 @@ func CreateWithTemplate(db *sql.DB, dir string, tmpl *template.Template, name, m
 		return errors.Wrap(err, "failed to execute tmpl")
 	}
 
-	log.Printf("Created new file: %s\n", f.Name())
+	in.log.Printf("Created new file: %s\n", f.Name())
 	return nil
 }
 
 // Create writes a new blank migration file.
 func Create(db *sql.DB, dir, name, migrationType string) error {
-	return CreateWithTemplate(db, dir, nil, name, migrationType)
+	return def.Create(db, dir, name, migrationType)
+}
+
+// Create writes a new blank migration file.
+func (in *Instance) Create(db *sql.DB, dir, name, migrationType string) error {
+	return in.CreateWithTemplate(db, dir, nil, name, migrationType)
 }
 
 var sqlMigrationTemplate = template.Must(template.New("goose.sql-migration").Parse(`-- +goose Up

--- a/db.go
+++ b/db.go
@@ -8,7 +8,13 @@ import (
 // OpenDBWithDriver creates a connection a database, and modifies goose
 // internals to be compatible with the supplied driver by calling SetDialect.
 func OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
-	if err := SetDialect(driver); err != nil {
+	return def.OpenDBWithDriver(driver, dbstring)
+}
+
+// OpenDBWithDriver creates a connection a database, and modifies goose
+// internals to be compatible with the supplied driver by calling SetDialect.
+func (in *Instance) OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
+	if err := in.SetDialect(driver); err != nil {
 		return nil, err
 	}
 

--- a/down.go
+++ b/down.go
@@ -46,12 +46,12 @@ func (in *Instance) DownTo(db *sql.DB, dir string, version int64) error {
 
 		current, err := migrations.Current(currentVersion)
 		if err != nil {
-			log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
+			in.log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
 			return nil
 		}
 
 		if current.Version <= version {
-			log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
+			in.log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
 			return nil
 		}
 

--- a/down.go
+++ b/down.go
@@ -6,13 +6,16 @@ import (
 )
 
 // Down rolls back a single migration from the current version.
-func Down(db *sql.DB, dir string) error {
-	currentVersion, err := GetDBVersion(db)
+func Down(db *sql.DB, dir string) error { return def.Down(db, dir) }
+
+// Down rolls back a single migration from the current version.
+func (in *Instance) Down(db *sql.DB, dir string) error {
+	currentVersion, err := in.GetDBVersion(db)
 	if err != nil {
 		return err
 	}
 
-	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+	migrations, err := in.CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}
@@ -26,14 +29,17 @@ func Down(db *sql.DB, dir string) error {
 }
 
 // DownTo rolls back migrations to a specific version.
-func DownTo(db *sql.DB, dir string, version int64) error {
-	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+func DownTo(db *sql.DB, dir string, version int64) error { return def.DownTo(db, dir, version) }
+
+// DownTo rolls back migrations to a specific version.
+func (in *Instance) DownTo(db *sql.DB, dir string, version int64) error {
+	migrations, err := in.CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}
 
 	for {
-		currentVersion, err := GetDBVersion(db)
+		currentVersion, err := in.GetDBVersion(db)
 		if err != nil {
 			return err
 		}

--- a/fix.go
+++ b/fix.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 )
 
-func Fix(dir string) error {
-	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+func Fix(dir string) error { return def.Fix(dir) }
+
+func (in *Instance) Fix(dir string) error {
+	migrations, err := in.CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}

--- a/fix.go
+++ b/fix.go
@@ -40,7 +40,7 @@ func (in *Instance) Fix(dir string) error {
 			return err
 		}
 
-		log.Printf("RENAMED %s => %s", filepath.Base(oldPath), filepath.Base(newPath))
+		in.log.Printf("RENAMED %s => %s", filepath.Base(oldPath), filepath.Base(newPath))
 		version++
 	}
 

--- a/goose.go
+++ b/goose.go
@@ -14,12 +14,14 @@ var (
 	minVersion         = int64(0)
 	maxVersion         = int64((1 << 63) - 1)
 	timestampFormat    = "20060102150405"
-	verbose            = false
 )
 
 // SetVerbose set the goose verbosity mode
-func SetVerbose(v bool) {
-	verbose = v
+func SetVerbose(v bool) { def.SetVerbose(v) }
+
+// SetVerbose set the goose verbosity mode
+func (in *Instance) SetVerbose(v bool) {
+	in.verbose = v
 }
 
 // Run runs a goose command.
@@ -59,7 +61,7 @@ func (in *Instance) Run(command string, db *sql.DB, dir string, args ...string) 
 		if len(args) == 2 {
 			migrationType = args[1]
 		}
-		if err := Create(db, dir, args[0], migrationType); err != nil {
+		if err := in.Create(db, dir, args[0], migrationType); err != nil {
 			return err
 		}
 	case "down":

--- a/goose.go
+++ b/goose.go
@@ -24,13 +24,18 @@ func SetVerbose(v bool) {
 
 // Run runs a goose command.
 func Run(command string, db *sql.DB, dir string, args ...string) error {
+	return def.Run(command, db, dir, args...)
+}
+
+// Run runs a goose command.
+func (in *Instance) Run(command string, db *sql.DB, dir string, args ...string) error {
 	switch command {
 	case "up":
-		if err := Up(db, dir); err != nil {
+		if err := in.Up(db, dir); err != nil {
 			return err
 		}
 	case "up-by-one":
-		if err := UpByOne(db, dir); err != nil {
+		if err := in.UpByOne(db, dir); err != nil {
 			return err
 		}
 	case "up-to":
@@ -42,7 +47,7 @@ func Run(command string, db *sql.DB, dir string, args ...string) error {
 		if err != nil {
 			return fmt.Errorf("version must be a number (got '%s')", args[0])
 		}
-		if err := UpTo(db, dir, version); err != nil {
+		if err := in.UpTo(db, dir, version); err != nil {
 			return err
 		}
 	case "create":
@@ -58,7 +63,7 @@ func Run(command string, db *sql.DB, dir string, args ...string) error {
 			return err
 		}
 	case "down":
-		if err := Down(db, dir); err != nil {
+		if err := in.Down(db, dir); err != nil {
 			return err
 		}
 	case "down-to":
@@ -70,27 +75,27 @@ func Run(command string, db *sql.DB, dir string, args ...string) error {
 		if err != nil {
 			return fmt.Errorf("version must be a number (got '%s')", args[0])
 		}
-		if err := DownTo(db, dir, version); err != nil {
+		if err := in.DownTo(db, dir, version); err != nil {
 			return err
 		}
 	case "fix":
-		if err := Fix(dir); err != nil {
+		if err := in.Fix(dir); err != nil {
 			return err
 		}
 	case "redo":
-		if err := Redo(db, dir); err != nil {
+		if err := in.Redo(db, dir); err != nil {
 			return err
 		}
 	case "reset":
-		if err := Reset(db, dir); err != nil {
+		if err := in.Reset(db, dir); err != nil {
 			return err
 		}
 	case "status":
-		if err := Status(db, dir); err != nil {
+		if err := in.Status(db, dir); err != nil {
 			return err
 		}
 	case "version":
-		if err := Version(db, dir); err != nil {
+		if err := in.Version(db, dir); err != nil {
 			return err
 		}
 	default:

--- a/instance.go
+++ b/instance.go
@@ -1,0 +1,21 @@
+package goose
+
+var def = NewInstance()
+
+// Instance of goose for managing single database / migration directory.
+// Use if you've more than one database / migration directory compiled in
+// single Go binary.
+type Instance struct {
+	dialect                SQLDialect
+	registeredGoMigrations map[int64]*Migration
+	tableName              string
+}
+
+// NewInstance creates and returns new goose instance.
+func NewInstance() *Instance {
+	in := &Instance{}
+	in.dialect = &PostgresDialect{tableName: in.TableName}
+	in.registeredGoMigrations = make(map[int64]*Migration)
+	in.tableName = "goose_db_version"
+	return in
+}

--- a/instance.go
+++ b/instance.go
@@ -9,6 +9,8 @@ type Instance struct {
 	dialect                SQLDialect
 	registeredGoMigrations map[int64]*Migration
 	tableName              string
+	log                    Logger
+	verbose                bool
 }
 
 // NewInstance creates and returns new goose instance.
@@ -17,5 +19,7 @@ func NewInstance() *Instance {
 	in.dialect = &PostgresDialect{tableName: in.TableName}
 	in.registeredGoMigrations = make(map[int64]*Migration)
 	in.tableName = "goose_db_version"
+	in.log = &stdLogger{}
+	in.verbose = false
 	return in
 }

--- a/log.go
+++ b/log.go
@@ -4,8 +4,6 @@ import (
 	std "log"
 )
 
-var log Logger = &stdLogger{}
-
 // Logger is standard logger interface
 type Logger interface {
 	Fatal(v ...interface{})
@@ -16,8 +14,11 @@ type Logger interface {
 }
 
 // SetLogger sets the logger for package output
-func SetLogger(l Logger) {
-	log = l
+func SetLogger(l Logger) { def.SetLogger(l) }
+
+// SetLogger sets the logger for package output
+func (in *Instance) SetLogger(l Logger) {
+	in.log = l
 }
 
 // stdLogger is a default logger that outputs to a stdlib's log.std logger.

--- a/migrate.go
+++ b/migrate.go
@@ -304,8 +304,6 @@ func (in *Instance) EnsureDBVersion(db *sql.DB) (int64, error) {
 
 // Create the db version table
 // and insert the initial 0 value into it
-func createVersionTable(db *sql.DB) error { return def.createVersionTable(db) }
-
 func (in *Instance) createVersionTable(db *sql.DB) error {
 	txn, err := db.Begin()
 	if err != nil {

--- a/migration.go
+++ b/migration.go
@@ -64,7 +64,7 @@ func (m *Migration) run(db *sql.DB, direction bool) error {
 		}
 		defer f.Close()
 
-		statements, useTx, err := parseSQLMigration(f, direction)
+		statements, useTx, err := m.in.parseSQLMigration(f, direction)
 		if err != nil {
 			return errors.Wrapf(err, "ERROR %v: failed to parse SQL migration file", filepath.Base(m.Source))
 		}
@@ -74,9 +74,9 @@ func (m *Migration) run(db *sql.DB, direction bool) error {
 		}
 
 		if len(statements) > 0 {
-			log.Println("OK   ", filepath.Base(m.Source))
+			m.in.log.Println("OK   ", filepath.Base(m.Source))
 		} else {
-			log.Println("EMPTY", filepath.Base(m.Source))
+			m.in.log.Println("EMPTY", filepath.Base(m.Source))
 		}
 
 	case ".go":
@@ -118,9 +118,9 @@ func (m *Migration) run(db *sql.DB, direction bool) error {
 		}
 
 		if fn != nil {
-			log.Println("OK   ", filepath.Base(m.Source))
+			m.in.log.Println("OK   ", filepath.Base(m.Source))
 		} else {
-			log.Println("EMPTY", filepath.Base(m.Source))
+			m.in.log.Println("EMPTY", filepath.Base(m.Source))
 		}
 
 		return nil

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -16,6 +16,10 @@ import (
 // All statements following an Up or Down directive are grouped together
 // until another direction directive is found.
 func runSQLMigration(db *sql.DB, statements []string, useTx bool, v int64, direction bool) error {
+	return def.runSQLMigration(db, statements, useTx, v, direction)
+}
+
+func (in *Instance) runSQLMigration(db *sql.DB, statements []string, useTx bool, v int64, direction bool) error {
 	if useTx {
 		// TRANSACTION.
 
@@ -36,13 +40,13 @@ func runSQLMigration(db *sql.DB, statements []string, useTx bool, v int64, direc
 		}
 
 		if direction {
-			if _, err := tx.Exec(GetDialect().insertVersionSQL(), v, direction); err != nil {
+			if _, err := tx.Exec(in.GetDialect().insertVersionSQL(), v, direction); err != nil {
 				verboseInfo("Rollback transaction")
 				tx.Rollback()
 				return errors.Wrap(err, "failed to insert new goose version")
 			}
 		} else {
-			if _, err := tx.Exec(GetDialect().deleteVersionSQL(), v); err != nil {
+			if _, err := tx.Exec(in.GetDialect().deleteVersionSQL(), v); err != nil {
 				verboseInfo("Rollback transaction")
 				tx.Rollback()
 				return errors.Wrap(err, "failed to delete goose version")
@@ -64,7 +68,7 @@ func runSQLMigration(db *sql.DB, statements []string, useTx bool, v int64, direc
 			return errors.Wrapf(err, "failed to execute SQL query %q", clearStatement(query))
 		}
 	}
-	if _, err := db.Exec(GetDialect().insertVersionSQL(), v, direction); err != nil {
+	if _, err := db.Exec(in.GetDialect().insertVersionSQL(), v, direction); err != nil {
 		return errors.Wrap(err, "failed to insert new goose version")
 	}
 

--- a/redo.go
+++ b/redo.go
@@ -5,13 +5,16 @@ import (
 )
 
 // Redo rolls back the most recently applied migration, then runs it again.
-func Redo(db *sql.DB, dir string) error {
-	currentVersion, err := GetDBVersion(db)
+func Redo(db *sql.DB, dir string) error { return def.Redo(db, dir) }
+
+// Redo rolls back the most recently applied migration, then runs it again.
+func (in *Instance) Redo(db *sql.DB, dir string) error {
+	currentVersion, err := in.GetDBVersion(db)
 	if err != nil {
 		return err
 	}
 
-	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+	migrations, err := in.CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}

--- a/reset.go
+++ b/reset.go
@@ -34,8 +34,6 @@ func (in *Instance) Reset(db *sql.DB, dir string) error {
 	return nil
 }
 
-func dbMigrationsStatus(db *sql.DB) (map[int64]bool, error) { return def.dbMigrationsStatus(db) }
-
 func (in *Instance) dbMigrationsStatus(db *sql.DB) (map[int64]bool, error) {
 	rows, err := in.GetDialect().dbVersionQuery(db)
 	if err != nil {

--- a/reset.go
+++ b/reset.go
@@ -8,12 +8,15 @@ import (
 )
 
 // Reset rolls back all migrations
-func Reset(db *sql.DB, dir string) error {
-	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+func Reset(db *sql.DB, dir string) error { return def.Reset(db, dir) }
+
+// Reset rolls back all migrations
+func (in *Instance) Reset(db *sql.DB, dir string) error {
+	migrations, err := in.CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return errors.Wrap(err, "failed to collect migrations")
 	}
-	statuses, err := dbMigrationsStatus(db)
+	statuses, err := in.dbMigrationsStatus(db)
 	if err != nil {
 		return errors.Wrap(err, "failed to get status of migrations")
 	}
@@ -31,8 +34,10 @@ func Reset(db *sql.DB, dir string) error {
 	return nil
 }
 
-func dbMigrationsStatus(db *sql.DB) (map[int64]bool, error) {
-	rows, err := GetDialect().dbVersionQuery(db)
+func dbMigrationsStatus(db *sql.DB) (map[int64]bool, error) { return def.dbMigrationsStatus(db) }
+
+func (in *Instance) dbMigrationsStatus(db *sql.DB) (map[int64]bool, error) {
+	rows, err := in.GetDialect().dbVersionQuery(db)
 	if err != nil {
 		return map[int64]bool{}, nil
 	}

--- a/sql_parser_test.go
+++ b/sql_parser_test.go
@@ -56,7 +56,7 @@ func TestSplitStatements(t *testing.T) {
 
 	for i, test := range tt {
 		// up
-		stmts, _, err := parseSQLMigration(strings.NewReader(test.sql), true)
+		stmts, _, err := def.parseSQLMigration(strings.NewReader(test.sql), true)
 		if err != nil {
 			t.Error(errors.Wrapf(err, "tt[%v] unexpected error", i))
 		}
@@ -65,7 +65,7 @@ func TestSplitStatements(t *testing.T) {
 		}
 
 		// down
-		stmts, _, err = parseSQLMigration(strings.NewReader(test.sql), false)
+		stmts, _, err = def.parseSQLMigration(strings.NewReader(test.sql), false)
 		if err != nil {
 			t.Error(errors.Wrapf(err, "tt[%v] unexpected error", i))
 		}
@@ -94,7 +94,7 @@ func TestUseTransactions(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		_, useTx, err := parseSQLMigration(f, true)
+		_, useTx, err := def.parseSQLMigration(f, true)
 		if err != nil {
 			t.Error(err)
 		}
@@ -114,7 +114,7 @@ func TestParsingErrors(t *testing.T) {
 		downFirst,
 	}
 	for i, sql := range tt {
-		_, _, err := parseSQLMigration(strings.NewReader(sql), true)
+		_, _, err := def.parseSQLMigration(strings.NewReader(sql), true)
 		if err == nil {
 			t.Errorf("expected error on tt[%v] %q", i, sql)
 		}

--- a/status.go
+++ b/status.go
@@ -9,22 +9,25 @@ import (
 )
 
 // Status prints the status of all migrations.
-func Status(db *sql.DB, dir string) error {
+func Status(db *sql.DB, dir string) error { return def.Status(db, dir) }
+
+// Status prints the status of all migrations.
+func (in *Instance) Status(db *sql.DB, dir string) error {
 	// collect all migrations
-	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+	migrations, err := in.CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return errors.Wrap(err, "failed to collect migrations")
 	}
 
 	// must ensure that the version table exists if we're running on a pristine DB
-	if _, err := EnsureDBVersion(db); err != nil {
+	if _, err := in.EnsureDBVersion(db); err != nil {
 		return errors.Wrap(err, "failed to ensure DB version")
 	}
 
 	log.Println("    Applied At                  Migration")
 	log.Println("    =======================================")
 	for _, migration := range migrations {
-		if err := printMigrationStatus(db, migration.Version, filepath.Base(migration.Source)); err != nil {
+		if err := in.printMigrationStatus(db, migration.Version, filepath.Base(migration.Source)); err != nil {
 			return errors.Wrap(err, "failed to print status")
 		}
 	}
@@ -33,7 +36,11 @@ func Status(db *sql.DB, dir string) error {
 }
 
 func printMigrationStatus(db *sql.DB, version int64, script string) error {
-	q := GetDialect().migrationSQL()
+	return def.printMigrationStatus(db, version, script)
+}
+
+func (in *Instance) printMigrationStatus(db *sql.DB, version int64, script string) error {
+	q := in.GetDialect().migrationSQL()
 
 	var row MigrationRecord
 

--- a/status.go
+++ b/status.go
@@ -24,8 +24,8 @@ func (in *Instance) Status(db *sql.DB, dir string) error {
 		return errors.Wrap(err, "failed to ensure DB version")
 	}
 
-	log.Println("    Applied At                  Migration")
-	log.Println("    =======================================")
+	in.log.Println("    Applied At                  Migration")
+	in.log.Println("    =======================================")
 	for _, migration := range migrations {
 		if err := in.printMigrationStatus(db, migration.Version, filepath.Base(migration.Source)); err != nil {
 			return errors.Wrap(err, "failed to print status")
@@ -33,10 +33,6 @@ func (in *Instance) Status(db *sql.DB, dir string) error {
 	}
 
 	return nil
-}
-
-func printMigrationStatus(db *sql.DB, version int64, script string) error {
-	return def.printMigrationStatus(db, version, script)
 }
 
 func (in *Instance) printMigrationStatus(db *sql.DB, version int64, script string) error {
@@ -56,6 +52,6 @@ func (in *Instance) printMigrationStatus(db *sql.DB, version int64, script strin
 		appliedAt = "Pending"
 	}
 
-	log.Printf("    %-24s -- %v\n", appliedAt, script)
+	in.log.Printf("    %-24s -- %v\n", appliedAt, script)
 	return nil
 }

--- a/up.go
+++ b/up.go
@@ -23,7 +23,7 @@ func (in *Instance) UpTo(db *sql.DB, dir string, version int64) error {
 		next, err := migrations.Next(current)
 		if err != nil {
 			if err == ErrNoNextVersion {
-				log.Printf("goose: no migrations to run. current version: %d\n", current)
+				in.log.Printf("goose: no migrations to run. current version: %d\n", current)
 				return nil
 			}
 			return err
@@ -61,7 +61,7 @@ func (in *Instance) UpByOne(db *sql.DB, dir string) error {
 	next, err := migrations.Next(currentVersion)
 	if err != nil {
 		if err == ErrNoNextVersion {
-			log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
+			in.log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
 		}
 		return err
 	}

--- a/up.go
+++ b/up.go
@@ -5,14 +5,17 @@ import (
 )
 
 // UpTo migrates up to a specific version.
-func UpTo(db *sql.DB, dir string, version int64) error {
-	migrations, err := CollectMigrations(dir, minVersion, version)
+func UpTo(db *sql.DB, dir string, version int64) error { return def.UpTo(db, dir, version) }
+
+// UpTo migrates up to a specific version.
+func (in *Instance) UpTo(db *sql.DB, dir string, version int64) error {
+	migrations, err := in.CollectMigrations(dir, minVersion, version)
 	if err != nil {
 		return err
 	}
 
 	for {
-		current, err := GetDBVersion(db)
+		current, err := in.GetDBVersion(db)
 		if err != nil {
 			return err
 		}
@@ -33,18 +36,24 @@ func UpTo(db *sql.DB, dir string, version int64) error {
 }
 
 // Up applies all available migrations.
-func Up(db *sql.DB, dir string) error {
-	return UpTo(db, dir, maxVersion)
+func Up(db *sql.DB, dir string) error { return def.Up(db, dir) }
+
+// Up applies all available migrations.
+func (in *Instance) Up(db *sql.DB, dir string) error {
+	return in.UpTo(db, dir, maxVersion)
 }
 
 // UpByOne migrates up by a single version.
-func UpByOne(db *sql.DB, dir string) error {
-	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+func UpByOne(db *sql.DB, dir string) error { return def.UpByOne(db, dir) }
+
+// UpByOne migrates up by a single version.
+func (in *Instance) UpByOne(db *sql.DB, dir string) error {
+	migrations, err := in.CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
 	}
 
-	currentVersion, err := GetDBVersion(db)
+	currentVersion, err := in.GetDBVersion(db)
 	if err != nil {
 		return err
 	}

--- a/version.go
+++ b/version.go
@@ -14,7 +14,7 @@ func (in *Instance) Version(db *sql.DB, dir string) error {
 		return err
 	}
 
-	log.Printf("goose: version %v\n", current)
+	in.log.Printf("goose: version %v\n", current)
 	return nil
 }
 

--- a/version.go
+++ b/version.go
@@ -5,8 +5,11 @@ import (
 )
 
 // Version prints the current version of the database.
-func Version(db *sql.DB, dir string) error {
-	current, err := GetDBVersion(db)
+func Version(db *sql.DB, dir string) error { return def.Version(db, dir) }
+
+// Version prints the current version of the database.
+func (in *Instance) Version(db *sql.DB, dir string) error {
+	current, err := in.GetDBVersion(db)
 	if err != nil {
 		return err
 	}
@@ -15,14 +18,18 @@ func Version(db *sql.DB, dir string) error {
 	return nil
 }
 
-var tableName = "goose_db_version"
+// TableName returns goose db version table name
+func TableName() string { return def.TableName() }
 
 // TableName returns goose db version table name
-func TableName() string {
-	return tableName
+func (in *Instance) TableName() string {
+	return in.tableName
 }
 
 // SetTableName set goose db version table name
-func SetTableName(n string) {
-	tableName = n
+func SetTableName(n string) { def.SetTableName(n) }
+
+// SetTableName set goose db version table name
+func (in *Instance) SetTableName(n string) {
+	in.tableName = n
 }


### PR DESCRIPTION
Add goose instance to make it possible to have independent migrations for different databases in single custom binary.

The change is similar to one in @mactaggart fork (in v3/ directory), except I've implemented it without breaking current API compatibility.

While the PR might looks huge, the 99% of changes are mechanical ones, so it shouldn't be too hard to review.

Closes #114 