### PR TITLE
fix trivial typo in CollectMigrations error string

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -145,7 +145,7 @@ func AddNamedMigration(filename string, up func(*sql.Tx) error, down func(*sql.T
 // migrations folder and go func registry, and key them by version.
 func CollectMigrations(dirpath string, current, target int64) (Migrations, error) {
 	if _, err := os.Stat(dirpath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("%s directory does not exists", dirpath)
+		return nil, fmt.Errorf("%s directory does not exist", dirpath)
 	}
 
 	var migrations Migrations


### PR DESCRIPTION
fixes trivial typo in error string when `CollectMigrations` gets a migrations directory that does not exist

`/Users/tristan/clone/test/migrations directory does not exists` to `/Users/tristan/clone/test/migrations directory does not exist`

thank you 