### PR TITLE
Fix: Do not require MySQL when --tags="no_mysql",

### DIFF
--- a/cmd/goose/driver_no_mysql.go
+++ b/cmd/goose/driver_no_mysql.go
@@ -2,11 +2,6 @@
 
 package main
 
-import (
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/ziutek/mymysql/godrv"
-)
-
 func normalizeDBString(driver string, str string, certfile string) string {
 	return str
 }


### PR DESCRIPTION
The `go build -tags='no_mysql' -i -o goose ./cmd/goose` doesn't work properly, still imports MySQL.

Deleted imports are already in `driver_mysql.go`, they shouldn't be in `driver_no_mysql.go`.

Fixes for me #223.