### PR TITLE
clickhouse: Fixed get db version query

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -304,7 +304,7 @@ func (m ClickHouseDialect) createVersionTableSQL() string {
 }
 
 func (m ClickHouseDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied FROM %s ORDER BY tstamp DESC LIMIT 1", TableName()))
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied FROM %s ORDER BY version_id DESC", TableName()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
2 bugs with current query:
 - `reset` command [resets only last applied](https://github.com/pressly/goose/blob/master/reset.go#L35) migrations , because `LIMIT 1`;
 - not deterministic result for migrations applied with same `tstamp`, because `ORDER BY tstamp`;


@huynguyenh,  please take a look)