### PR TITLE
Migrate all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /go.mod
 /go.sum
 
+*go.mod 
+*go.sum

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Commands:
     up                   Migrate the DB to the most recent version available
     up-by-one            Migrate the DB up by 1
     up-to VERSION        Migrate the DB to a specific VERSION
-    up-all.              Migrate all migrations that have not been run
+    up-all               Migrate all migrations that have not been run
     down                 Roll back the version by 1
     down-to VERSION      Roll back to a specific VERSION
     redo                 Re-run the latest migration

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Commands:
     up                   Migrate the DB to the most recent version available
     up-by-one            Migrate the DB up by 1
     up-to VERSION        Migrate the DB to a specific VERSION
+    up-all.              Migrate all migrations that have not been run
     down                 Roll back the version by 1
     down-to VERSION      Roll back to a specific VERSION
     redo                 Re-run the latest migration
@@ -121,6 +122,14 @@ Migrate up a single migration from the current version
 
     $ goose up-by-one
     $ OK    20170614145246_change_type.sql
+
+## up-all
+
+Migrate all migrations that have not been run
+
+    $ goose up-to 20170506082420
+    $ OK    20170506082420_create_table.sql
+    $ OK    20170506082840_next.sql
 
 ## down
 

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/pressly/goose"
+	"github.com/quinnwinterfluid/goose"
 )
 
 var (
@@ -154,6 +154,7 @@ Commands:
     up                   Migrate the DB to the most recent version available
     up-by-one            Migrate the DB up by 1
     up-to VERSION        Migrate the DB to a specific VERSION
+    up-all               Migrate all migrations that have not been run
     down                 Roll back the version by 1
     down-to VERSION      Roll back to a specific VERSION
     redo                 Re-run the latest migration

--- a/goose.go
+++ b/goose.go
@@ -9,10 +9,10 @@ import (
 const VERSION = "v2.7.0-rc3"
 
 var (
-	minVersion         = int64(0)
-	maxVersion         = int64((1 << 63) - 1)
-	timestampFormat    = "20060102150405"
-	verbose            = false
+	minVersion      = int64(0)
+	maxVersion      = int64((1 << 63) - 1)
+	timestampFormat = "20060102150405"
+	verbose         = false
 )
 
 // SetVerbose set the goose verbosity mode
@@ -41,6 +41,10 @@ func Run(command string, db *sql.DB, dir string, args ...string) error {
 			return fmt.Errorf("version must be a number (got '%s')", args[0])
 		}
 		if err := UpTo(db, dir, version); err != nil {
+			return err
+		}
+	case "up-all":
+		if err := UpAll(db, dir); err != nil {
 			return err
 		}
 	case "create":

--- a/migration.go
+++ b/migration.go
@@ -146,3 +146,17 @@ func NumericComponent(name string) (int64, error) {
 
 	return n, e
 }
+
+// Return true if migration has been applied, false otherwise
+func IsApplied(db *sql.DB, version int64) (bool, error) {
+	q := GetDialect().migrationSQL()
+
+	var row MigrationRecord
+
+	err := db.QueryRow(q, version).Scan(&row.TStamp, &row.IsApplied)
+	if err != nil && err != sql.ErrNoRows {
+		return false, errors.Wrap(err, "failed to query latest migration")
+	}
+
+	return row.IsApplied, nil
+}

--- a/up.go
+++ b/up.go
@@ -63,3 +63,27 @@ func UpByOne(db *sql.DB, dir string) error {
 
 	return nil
 }
+
+// UpAll runs all migrations that have not been run
+func UpAll(db *sql.DB, dir string) error {
+	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range migrations {
+		isApplied, err := IsApplied(db, m.Version)
+		if err != nil {
+			return err
+		}
+
+		// if migration has not been applied, run migration
+		if !isApplied {
+			if err := m.Up(db); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
New up-all command to offer a solution to the versioning issue.

`up-all` checks all the migrations and applies any that have not been run yet. 

This helps to solve the versioning issue since with the current `up` command if there is a more recent migration that has already been run, all pending migrations that were created before will stay in a pending state and not be run.