### PR TITLE
Add flag to retrieve N most recent migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Options:
     	migrations table name (default "goose_db_version")
   -h	print help
   -v	enable verbose mode
+  -n	retrieve the N most recent migrations
   -version
     	print version
 

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -18,6 +18,7 @@ var (
 	version    = flags.Bool("version", false, "print version")
 	certfile   = flags.String("certfile", "", "file path to root CA's certificates in pem format (only support on mysql)")
 	sequential = flags.Bool("s", false, "use sequential numbering for new migrations")
+	recent     = flags.Int("n", 0, "retrieve the N most recent migrations")
 )
 
 func main() {
@@ -33,6 +34,9 @@ func main() {
 	}
 	if *sequential {
 		goose.SetSequential(true)
+	}
+	if *recent > 0 {
+		goose.SetRecentLimit(*recent)
 	}
 	goose.SetTableName(*table)
 

--- a/migrate.go
+++ b/migrate.go
@@ -21,6 +21,9 @@ var (
 	MaxVersion int64 = 9223372036854775807 // max(int64)
 
 	registeredGoMigrations = map[int64]*Migration{}
+
+	// recent with value of 0 is no limit
+	recent = 0
 )
 
 // Migrations slice.
@@ -76,6 +79,20 @@ func (ms Migrations) Last() (*Migration, error) {
 	}
 
 	return ms[len(ms)-1], nil
+}
+
+// Last gets the last migration.
+func (ms Migrations) LastN(n int) (Migrations, error) {
+	if len(ms) == 0 {
+		return nil, ErrNoNextVersion
+	}
+
+	start := len(ms) - n - 1
+	if start < 0 {
+		start = 0
+	}
+
+	return ms[start : len(ms)-1], nil
 }
 
 // Versioned gets versioned migrations.
@@ -199,6 +216,13 @@ func CollectMigrations(dirpath string, current, target int64) (Migrations, error
 		}
 	}
 
+	if recent > 0 {
+		migrations, err = migrations.LastN(recent)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	migrations = sortAndConnectMigrations(migrations)
 
 	return migrations, nil
@@ -316,4 +340,8 @@ func GetDBVersion(db *sql.DB) (int64, error) {
 	}
 
 	return version, nil
+}
+
+func SetRecentLimit(r int) {
+	recent = r
 }


### PR DESCRIPTION
Resolves #254 

This PR adds a flag that allows the user to retrieve the N most recent migrations. This is useful when you have many migrations that you have created and it takes a long time to print them all out and you just want to see the last few to either make sure they have all been applied or to make sure that the new migration timestamp you are working on will still be applied when another collaborator may have created and merged a migration before you.

usage example:
`goose -n 10 mysql "[DB_String]" status`
This would return the 10 most recent migrations