### PR TITLE
Updating readme and create command for v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ package migrations
 import (
 	"database/sql"
 
-	"github.com/pressly/goose"
+	"github.com/pressly/goose/v3"
 )
 
 func init() {

--- a/create.go
+++ b/create.go
@@ -101,7 +101,7 @@ var goSQLMigrationTemplate = template.Must(template.New("goose.go-migration").Pa
 
 import (
 	"database/sql"
-	"github.com/pressly/goose"
+	"github.com/pressly/goose/v3"
 )
 
 func init() {


### PR DESCRIPTION
Just found that create command wasn't giving a v3 import as compared to what the examples show in `examples/go-migrations`
