### PR TITLE
option to use pgx instead pq

### DIFF
--- a/db.go
+++ b/db.go
@@ -22,7 +22,7 @@ func OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
 	}
 
 	switch driver {
-	case "postgres", "sqlite3", "mysql", "sqlserver", "clickhouse":
+	case "postgres", "pgx", "sqlite3", "mysql", "sqlserver", "clickhouse":
 		return sql.Open(driver, dbstring)
 	default:
 		return nil, fmt.Errorf("unsupported driver %s", driver)

--- a/dialect.go
+++ b/dialect.go
@@ -25,7 +25,7 @@ func GetDialect() SQLDialect {
 // SetDialect sets the SQLDialect
 func SetDialect(d string) error {
 	switch d {
-	case "postgres":
+	case "postgres", "pgx":
 		dialect = &PostgresDialect{}
 	case "mysql":
 		dialect = &MySQLDialect{}


### PR DESCRIPTION
pgx have https://github.com/jackc/pgx/tree/master/stdlib method to use it with std sql library, than i think this option should be in goose for projects which uses pgx as main driver