### PR TITLE
Fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Goose supports [embedding SQL migrations](#embedded-sql-migrations), which means
 
 # Install
 
-    $ go get -u github.com/pressly/goose/v3/cmd/goose
+    $ go install github.com/pressly/goose/v3/cmd/goose@latest
 
 This will install the `goose` binary to your `$GOPATH/bin` directory.
 

--- a/examples/sql-migrations/README.md
+++ b/examples/sql-migrations/README.md
@@ -3,7 +3,7 @@
 See [this example](../go-migrations) for Go migrations.
 
 ```bash
-$ go get -u github.com/pressly/goose/cmd/goose
+$ go install github.com/pressly/goose/v3/cmd/goose@latest
 ```
 
 ```bash


### PR DESCRIPTION
`Deprecation of 'go get' for installing executables`

https://go.dev/doc/go-get-install-deprecation

