### PR TITLE
Adds ability to apply migrations without versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Goose supports [embedding SQL migrations](#embedded-sql-migrations), which means
     - goose pkg doesn't have any vendor dependencies anymore
 - We use timestamped migrations by default but recommend a hybrid approach of using timestamps in the development process and sequential versions in production.
 - Supports missing (out-of-order) migrations with the `-allow-missing` flag, or if using as a library supply the functional option `goose.WithAllowMissing()` to Up, UpTo or UpByOne.
+- Supports applying ad-hoc migrations without tracking them in the schema table. Useful for seeding a database after migrations have been applied. Use `-no-versioning` flag or the functional option `goose.WithNoVersioning()`.
 
 # Install
 
@@ -41,6 +42,9 @@ For a lite version of the binary without DB connection dependent commands, use t
 
     $ go build -tags='no_postgres no_mysql no_sqlite3' -i -o goose ./cmd/goose
 
+For macOS users `goose` is available as a [Homebrew Formulae](https://formulae.brew.sh/formula/goose#default):
+
+    $ brew install goose 
 
 # Usage
 
@@ -70,23 +74,26 @@ Examples:
     goose mssql "sqlserver://user:password@dbname:1433?database=master" status
 
 Options:
+
   -allow-missing
-        applies missing (out-of-order) migrations
+    	applies missing (out-of-order) migrations
   -certfile string
-        file path to root CA's certificates in pem format (only support on mysql)
-  -sslcert string
-        file path to SSL certificates in pem format (only support on mysql)
-  -sslkey string
-        file path to SSL key in pem format (only support on mysql)
+    	file path to root CA's certificates in pem format (only support on mysql)
   -dir string
-        directory with migration files (default ".")
-  -h    print help
-  -s    use sequential numbering for new migrations
+    	directory with migration files (default ".")
+  -h	print help
+  -no-versioning
+    	apply migration commands with no versioning, in file order, from directory pointed to
+  -s	use sequential numbering for new migrations
+  -ssl-cert string
+    	file path to SSL certificates in pem format (only support on mysql)
+  -ssl-key string
+    	file path to SSL key in pem format (only support on mysql)
   -table string
-        migrations table name (default "goose_db_version")
-  -v    enable verbose mode
+    	migrations table name (default "goose_db_version")
+  -v	enable verbose mode
   -version
-        print version
+    	print version
 
 Commands:
     up                   Migrate the DB to the most recent version available

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -22,6 +22,7 @@ var (
 	allowMissing = flags.Bool("allow-missing", false, "applies missing (out-of-order) migrations")
 	sslcert      = flags.String("ssl-cert", "", "file path to SSL certificates in pem format (only support on mysql)")
 	sslkey       = flags.String("ssl-key", "", "file path to SSL key in pem format (only support on mysql)")
+	noVersioning = flags.Bool("no-versioning", false, "run up or down commands without versioning, in file order, from directory pointed to")
 )
 
 var (
@@ -98,6 +99,9 @@ func main() {
 	options := []goose.OptionsFunc{}
 	if *allowMissing {
 		options = append(options, goose.WithAllowMissing())
+	}
+	if *noVersioning {
+		options = append(options, goose.WithNoVersioning())
 	}
 	if err := goose.RunWithOptions(
 		command,

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -22,7 +22,7 @@ var (
 	allowMissing = flags.Bool("allow-missing", false, "applies missing (out-of-order) migrations")
 	sslcert      = flags.String("ssl-cert", "", "file path to SSL certificates in pem format (only support on mysql)")
 	sslkey       = flags.String("ssl-key", "", "file path to SSL key in pem format (only support on mysql)")
-	noVersioning = flags.Bool("no-versioning", false, "run up or down commands without versioning, in file order, from directory pointed to")
+	noVersioning = flags.Bool("no-versioning", false, "apply migration commands with no versioning, in file order, from directory pointed to")
 )
 
 var (

--- a/down.go
+++ b/down.go
@@ -19,7 +19,7 @@ func Down(db *sql.DB, dir string, opts ...OptionsFunc) error {
 		if len(migrations) == 0 {
 			return nil
 		}
-		return downNoVersioning(db, migrations, migrations[len(migrations)-1].Version)
+		return downToNoVersioning(db, migrations, migrations[len(migrations)-1].Version)
 	}
 	currentVersion, err := GetDBVersion(db)
 	if err != nil {
@@ -43,7 +43,7 @@ func DownTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 		return err
 	}
 	if option.noVersioning {
-		return downNoVersioning(db, migrations, version)
+		return downToNoVersioning(db, migrations, version)
 	}
 
 	for {
@@ -69,11 +69,9 @@ func DownTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 	}
 }
 
-func downNoVersioning(db *sql.DB, migrations Migrations, version int64) error {
-	// TODO(mf): we're not tracking the seed migrations in the database,
-	// which means subsequent "down" operations will always start from the
-	// highest seed file.
-	// Also, should target version always be 0 and error otherwise?
+// downToNoVersioning applies down migrations down to, but not including, the
+// target version.
+func downToNoVersioning(db *sql.DB, migrations Migrations, version int64) error {
 	var finalVersion int64
 	for i := len(migrations) - 1; i >= 0; i-- {
 		if version >= migrations[i].Version {
@@ -85,6 +83,6 @@ func downNoVersioning(db *sql.DB, migrations Migrations, version int64) error {
 			return err
 		}
 	}
-	log.Printf("goose: current version: %d\n", finalVersion)
+	log.Printf("goose: down to current file version: %d\n", finalVersion)
 	return nil
 }

--- a/down.go
+++ b/down.go
@@ -19,7 +19,9 @@ func Down(db *sql.DB, dir string, opts ...OptionsFunc) error {
 		if len(migrations) == 0 {
 			return nil
 		}
-		return downToNoVersioning(db, migrations, migrations[len(migrations)-1].Version)
+		currentVersion := migrations[len(migrations)-1].Version
+		// Migrate only the latest migration down.
+		return downToNoVersioning(db, migrations, currentVersion-1)
 	}
 	currentVersion, err := GetDBVersion(db)
 	if err != nil {

--- a/down.go
+++ b/down.go
@@ -3,33 +3,48 @@ package goose
 import (
 	"database/sql"
 	"fmt"
+	"sort"
 )
 
 // Down rolls back a single migration from the current version.
-func Down(db *sql.DB, dir string) error {
+func Down(db *sql.DB, dir string, opts ...OptionsFunc) error {
+	option := &options{}
+	for _, f := range opts {
+		f(option)
+	}
+	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+	if err != nil {
+		return err
+	}
+	if option.noVersioning {
+		if len(migrations) == 0 {
+			return nil
+		}
+		return downNoVersioning(db, migrations, migrations[len(migrations)-1].Version)
+	}
 	currentVersion, err := GetDBVersion(db)
 	if err != nil {
 		return err
 	}
-
-	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
-	if err != nil {
-		return err
-	}
-
 	current, err := migrations.Current(currentVersion)
 	if err != nil {
 		return fmt.Errorf("no migration %v", currentVersion)
 	}
-
 	return current.Down(db)
 }
 
 // DownTo rolls back migrations to a specific version.
-func DownTo(db *sql.DB, dir string, version int64) error {
+func DownTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
+	option := &options{}
+	for _, f := range opts {
+		f(option)
+	}
 	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
+	}
+	if option.noVersioning {
+		return downNoVersioning(db, migrations, version)
 	}
 
 	for {
@@ -53,4 +68,28 @@ func DownTo(db *sql.DB, dir string, version int64) error {
 			return err
 		}
 	}
+}
+
+func downNoVersioning(db *sql.DB, migrations Migrations, version int64) error {
+	// TODO(mf): we're not tracking the seed migrations in the database,
+	// which means subsequent "down" operations will always start from the
+	// highest seed file.
+	// Also, should target version always be 0 and error otherwise?
+	sort.Sort(sort.Reverse(migrations))
+
+	var finalVersion int64
+	for _, current := range migrations {
+		if current.Version <= version {
+			log.Printf("goose: current version: %d\n", current.Version)
+			return nil
+		}
+		current.noVersioning = true
+		if err := current.Down(db); err != nil {
+			return err
+		}
+		finalVersion = current.Version
+	}
+	finalVersion--
+	log.Printf("goose: current version: %d\n", finalVersion)
+	return nil
 }

--- a/goose.go
+++ b/goose.go
@@ -101,11 +101,11 @@ func run(command string, db *sql.DB, dir string, args []string, options ...Optio
 			return err
 		}
 	case "redo":
-		if err := Redo(db, dir); err != nil {
+		if err := Redo(db, dir, options...); err != nil {
 			return err
 		}
 	case "reset":
-		if err := Reset(db, dir); err != nil {
+		if err := Reset(db, dir, options...); err != nil {
 			return err
 		}
 	case "status":

--- a/goose.go
+++ b/goose.go
@@ -81,7 +81,7 @@ func run(command string, db *sql.DB, dir string, args []string, options ...Optio
 			return err
 		}
 	case "down":
-		if err := Down(db, dir); err != nil {
+		if err := Down(db, dir, options...); err != nil {
 			return err
 		}
 	case "down-to":
@@ -93,7 +93,7 @@ func run(command string, db *sql.DB, dir string, args []string, options ...Optio
 		if err != nil {
 			return fmt.Errorf("version must be a number (got '%s')", args[0])
 		}
-		if err := DownTo(db, dir, version); err != nil {
+		if err := DownTo(db, dir, version, options...); err != nil {
 			return err
 		}
 	case "fix":

--- a/goose.go
+++ b/goose.go
@@ -109,11 +109,11 @@ func run(command string, db *sql.DB, dir string, args []string, options ...Optio
 			return err
 		}
 	case "status":
-		if err := Status(db, dir); err != nil {
+		if err := Status(db, dir, options...); err != nil {
 			return err
 		}
 	case "version":
-		if err := Version(db, dir); err != nil {
+		if err := Version(db, dir, options...); err != nil {
 			return err
 		}
 	default:

--- a/redo.go
+++ b/redo.go
@@ -5,29 +5,40 @@ import (
 )
 
 // Redo rolls back the most recently applied migration, then runs it again.
-func Redo(db *sql.DB, dir string) error {
-	currentVersion, err := GetDBVersion(db)
-	if err != nil {
-		return err
+func Redo(db *sql.DB, dir string, opts ...OptionsFunc) error {
+	option := &options{}
+	for _, f := range opts {
+		f(option)
 	}
-
 	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return err
+	}
+	var (
+		currentVersion int64
+	)
+	if option.noVersioning {
+		if len(migrations) == 0 {
+			return nil
+		}
+		currentVersion = migrations[len(migrations)-1].Version
+	} else {
+		if currentVersion, err = GetDBVersion(db); err != nil {
+			return err
+		}
 	}
 
 	current, err := migrations.Current(currentVersion)
 	if err != nil {
 		return err
 	}
+	current.noVersioning = option.noVersioning
 
 	if err := current.Down(db); err != nil {
 		return err
 	}
-
 	if err := current.Up(db); err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/reset.go
+++ b/reset.go
@@ -8,11 +8,19 @@ import (
 )
 
 // Reset rolls back all migrations
-func Reset(db *sql.DB, dir string) error {
+func Reset(db *sql.DB, dir string, opts ...OptionsFunc) error {
+	option := &options{}
+	for _, f := range opts {
+		f(option)
+	}
 	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return errors.Wrap(err, "failed to collect migrations")
 	}
+	if option.noVersioning {
+		return DownTo(db, dir, minVersion, opts...)
+	}
+
 	statuses, err := dbMigrationsStatus(db)
 	if err != nil {
 		return errors.Wrap(err, "failed to get status of migrations")

--- a/status.go
+++ b/status.go
@@ -9,11 +9,22 @@ import (
 )
 
 // Status prints the status of all migrations.
-func Status(db *sql.DB, dir string) error {
-	// collect all migrations
+func Status(db *sql.DB, dir string, opts ...OptionsFunc) error {
+	option := &options{}
+	for _, f := range opts {
+		f(option)
+	}
 	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return errors.Wrap(err, "failed to collect migrations")
+	}
+	if option.noVersioning {
+		log.Println("    Applied At                  Migration")
+		log.Println("    =======================================")
+		for _, current := range migrations {
+			log.Printf("    %-24s -- %v\n", "no versioning", filepath.Base(current.Source))
+		}
+		return nil
 	}
 
 	// must ensure that the version table exists if we're running on a pristine DB

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -51,6 +51,8 @@ var (
 	// migrationsDir is a global that points to a ./testdata/{dialect}/migrations folder.
 	// It is set in TestMain based on the current dialect.
 	migrationsDir = ""
+	// seedDir is similar to migrationsDir but contains seed data
+	seedDir = ""
 
 	// known tables are the tables (including goose table) created by
 	// running all migration files. If you add a table, make sure to
@@ -74,6 +76,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	migrationsDir = filepath.Join("testdata", *dialect, "migrations")
+	seedDir = filepath.Join("testdata", *dialect, "seed")
 
 	exitCode := m.Run()
 	// Useful for debugging test services.

--- a/tests/e2e/no_versioning_test.go
+++ b/tests/e2e/no_versioning_test.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/matryer/is"
+	"github.com/pressly/goose/v3"
+)
+
+func TestUpNoVersioning(t *testing.T) {
+	if *dialect != dialectPostgres {
+		t.SkipNow()
+	}
+	const (
+		wantSeedOwnerCount = 250
+		// These are owners created by migration files.
+		wantOwnerCount = 4
+	)
+	is := is.New(t)
+	db, err := newDockerDB(t)
+	is.NoErr(err)
+	goose.SetDialect(*dialect)
+
+	err = goose.Up(db, migrationsDir)
+	is.NoErr(err)
+	baseVersion, err := goose.GetDBVersion(db)
+	is.NoErr(err)
+
+	// Run (all) up migrations from the seed dir
+	{
+		err = goose.Up(db, seedDir, goose.WithNoVersioning())
+		is.NoErr(err)
+		// Confirm no changes to the versioned schema in the DB
+		currentVersion, err := goose.GetDBVersion(db)
+		is.NoErr(err)
+		is.Equal(baseVersion, currentVersion)
+		seedOwnerCount, err := countSeedOwners(db)
+		is.NoErr(err)
+		is.Equal(seedOwnerCount, wantSeedOwnerCount)
+	}
+
+	// Run (all) down migrations from the seed dir
+	{
+		err = goose.DownTo(db, seedDir, 0, goose.WithNoVersioning())
+		is.NoErr(err)
+		// Confirm no changes to the versioned schema in the DB
+		currentVersion, err := goose.GetDBVersion(db)
+		is.NoErr(err)
+		is.Equal(baseVersion, currentVersion)
+		seedOwnerCount, err := countSeedOwners(db)
+		is.NoErr(err)
+		is.Equal(seedOwnerCount, 0)
+	}
+
+	// The migrations added 4 non-seed owners, they must remain
+	// in the database afterwards
+	ownerCount, err := countOwners(db)
+	is.NoErr(err)
+	is.Equal(ownerCount, wantOwnerCount)
+}
+
+func countSeedOwners(db *sql.DB) (int, error) {
+	q := `SELECT count(*)FROM owners WHERE owner_name LIKE'seed-user-%'`
+	var count int
+	if err := db.QueryRow(q).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func countOwners(db *sql.DB) (int, error) {
+	q := `SELECT count(*)FROM owners`
+	var count int
+	if err := db.QueryRow(q).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/tests/e2e/no_versioning_test.go
+++ b/tests/e2e/no_versioning_test.go
@@ -8,11 +8,12 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
-func TestUpNoVersioning(t *testing.T) {
+func TestNoVersioning(t *testing.T) {
 	if *dialect != dialectPostgres {
 		t.SkipNow()
 	}
 	const (
+		// Total owners created by the seed files.
 		wantSeedOwnerCount = 250
 		// These are owners created by migration files.
 		wantOwnerCount = 4
@@ -27,37 +28,111 @@ func TestUpNoVersioning(t *testing.T) {
 	baseVersion, err := goose.GetDBVersion(db)
 	is.NoErr(err)
 
-	// Run (all) up migrations from the seed dir
-	{
-		err = goose.Up(db, seedDir, goose.WithNoVersioning())
-		is.NoErr(err)
-		// Confirm no changes to the versioned schema in the DB
-		currentVersion, err := goose.GetDBVersion(db)
-		is.NoErr(err)
-		is.Equal(baseVersion, currentVersion)
-		seedOwnerCount, err := countSeedOwners(db)
-		is.NoErr(err)
-		is.Equal(seedOwnerCount, wantSeedOwnerCount)
-	}
+	t.Run("seed-up-down-to-zero", func(t *testing.T) {
+		is := is.NewRelaxed(t)
+		// Run (all) up migrations from the seed dir
+		{
+			err = goose.Up(db, seedDir, goose.WithNoVersioning())
+			is.NoErr(err)
+			// Confirm no changes to the versioned schema in the DB
+			currentVersion, err := goose.GetDBVersion(db)
+			is.NoErr(err)
+			is.Equal(baseVersion, currentVersion)
+			seedOwnerCount, err := countSeedOwners(db)
+			is.NoErr(err)
+			is.Equal(seedOwnerCount, wantSeedOwnerCount)
+		}
 
-	// Run (all) down migrations from the seed dir
-	{
-		err = goose.DownTo(db, seedDir, 0, goose.WithNoVersioning())
-		is.NoErr(err)
-		// Confirm no changes to the versioned schema in the DB
-		currentVersion, err := goose.GetDBVersion(db)
-		is.NoErr(err)
-		is.Equal(baseVersion, currentVersion)
-		seedOwnerCount, err := countSeedOwners(db)
-		is.NoErr(err)
-		is.Equal(seedOwnerCount, 0)
-	}
+		// Run (all) down migrations from the seed dir
+		{
+			err = goose.DownTo(db, seedDir, 0, goose.WithNoVersioning())
+			is.NoErr(err)
+			// Confirm no changes to the versioned schema in the DB
+			currentVersion, err := goose.GetDBVersion(db)
+			is.NoErr(err)
+			is.Equal(baseVersion, currentVersion)
+			seedOwnerCount, err := countSeedOwners(db)
+			is.NoErr(err)
+			is.Equal(seedOwnerCount, 0)
+		}
 
-	// The migrations added 4 non-seed owners, they must remain
-	// in the database afterwards
-	ownerCount, err := countOwners(db)
-	is.NoErr(err)
-	is.Equal(ownerCount, wantOwnerCount)
+		// The migrations added 4 non-seed owners, they must remain
+		// in the database afterwards
+		ownerCount, err := countOwners(db)
+		is.NoErr(err)
+		is.Equal(ownerCount, wantOwnerCount)
+	})
+
+	t.Run("test-seed-up-reset", func(t *testing.T) {
+		is := is.NewRelaxed(t)
+		// Run (all) up migrations from the seed dir
+		{
+			err = goose.Up(db, seedDir, goose.WithNoVersioning())
+			is.NoErr(err)
+			// Confirm no changes to the versioned schema in the DB
+			currentVersion, err := goose.GetDBVersion(db)
+			is.NoErr(err)
+			is.Equal(baseVersion, currentVersion)
+			seedOwnerCount, err := countSeedOwners(db)
+			is.NoErr(err)
+			is.Equal(seedOwnerCount, wantSeedOwnerCount)
+		}
+
+		// Run reset (effectively the same as down-to 0)
+		{
+			err = goose.Reset(db, seedDir, goose.WithNoVersioning())
+			is.NoErr(err)
+			// Confirm no changes to the versioned schema in the DB
+			currentVersion, err := goose.GetDBVersion(db)
+			is.NoErr(err)
+			is.Equal(baseVersion, currentVersion)
+			seedOwnerCount, err := countSeedOwners(db)
+			is.NoErr(err)
+			is.Equal(seedOwnerCount, 0)
+		}
+
+		// The migrations added 4 non-seed owners, they must remain
+		// in the database afterwards
+		ownerCount, err := countOwners(db)
+		is.NoErr(err)
+		is.Equal(ownerCount, wantOwnerCount)
+	})
+
+	t.Run("test-seed-up-redo", func(t *testing.T) {
+		is := is.NewRelaxed(t)
+		// Run (all) up migrations from the seed dir
+		{
+			err = goose.Up(db, seedDir, goose.WithNoVersioning())
+			is.NoErr(err)
+			// Confirm no changes to the versioned schema in the DB
+			currentVersion, err := goose.GetDBVersion(db)
+			is.NoErr(err)
+			is.Equal(baseVersion, currentVersion)
+			seedOwnerCount, err := countSeedOwners(db)
+			is.NoErr(err)
+			is.Equal(seedOwnerCount, wantSeedOwnerCount)
+		}
+
+		// Run reset (effectively the same as down-to 0)
+		{
+			err = goose.Redo(db, seedDir, goose.WithNoVersioning())
+			is.NoErr(err)
+			// Confirm no changes to the versioned schema in the DB
+			currentVersion, err := goose.GetDBVersion(db)
+			is.NoErr(err)
+			is.Equal(baseVersion, currentVersion)
+			seedOwnerCount, err := countSeedOwners(db)
+			is.NoErr(err)
+			is.Equal(seedOwnerCount, wantSeedOwnerCount) // owners should be unchanged
+		}
+
+		// The migrations added 4 non-seed owners, they must remain
+		// in the database afterwards along with the 250 seed owners for a
+		// total of 254.
+		ownerCount, err := countOwners(db)
+		is.NoErr(err)
+		is.Equal(ownerCount, wantOwnerCount+wantSeedOwnerCount)
+	})
 }
 
 func countSeedOwners(db *sql.DB) (int, error) {

--- a/tests/e2e/testdata/mysql/migrations/00002_b.sql
+++ b/tests/e2e/testdata/mysql/migrations/00002_b.sql
@@ -1,10 +1,10 @@
 -- +goose Up
 -- +goose StatementBegin
-INSERT INTO owners(owner_id, owner_name, owner_type) 
-    VALUES (1, 'lucas', 'user'), (2, 'space', 'organization');
+INSERT INTO owners(owner_name, owner_type) 
+    VALUES ('lucas', 'user'), ('space', 'organization');
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DELETE FROM owners WHERE owner_id IN (1, 2);
+DELETE FROM owners;
 -- +goose StatementEnd

--- a/tests/e2e/testdata/mysql/migrations/00003_c.sql
+++ b/tests/e2e/testdata/mysql/migrations/00003_c.sql
@@ -1,10 +1,10 @@
 -- +goose Up
 -- +goose StatementBegin
-INSERT INTO owners(owner_id, owner_name, owner_type) 
-    VALUES (3, 'james', 'user'), (4, 'pressly', 'organization');
+INSERT INTO owners(owner_name, owner_type) 
+    VALUES ('james', 'user'), ('pressly', 'organization');
 
-INSERT INTO repos(repo_id, repo_full_name, repo_owner_id) 
-    VALUES (1, 'james/rover', 3), (2, 'pressly/goose', 4);
+INSERT INTO repos(repo_full_name, repo_owner_id) 
+    VALUES ('james/rover', 3), ('pressly/goose', 4);
 -- +goose StatementEnd
 
 -- +goose Down

--- a/tests/e2e/testdata/postgres/migrations/00001_a.sql
+++ b/tests/e2e/testdata/postgres/migrations/00001_a.sql
@@ -9,7 +9,7 @@ CREATE TABLE owners (
 );
 
 CREATE TABLE IF NOT EXISTS repos (
-    repo_id bigint UNIQUE NOT NULL,
+    repo_id BIGSERIAL NOT NULL,
     repo_full_name text NOT NULL,
     repo_owner_id bigint NOT NULL REFERENCES owners(owner_id) ON DELETE CASCADE,
 

--- a/tests/e2e/testdata/postgres/migrations/00002_b.sql
+++ b/tests/e2e/testdata/postgres/migrations/00002_b.sql
@@ -1,10 +1,10 @@
 -- +goose Up
 -- +goose StatementBegin
-INSERT INTO owners(owner_id, owner_name, owner_type) 
-    VALUES (1, 'lucas', 'user'), (2, 'space', 'organization');
+INSERT INTO owners(owner_name, owner_type) 
+    VALUES ('lucas', 'user'), ('space', 'organization');
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DELETE FROM owners WHERE owner_id IN (1, 2);
+DELETE FROM owners;
 -- +goose StatementEnd

--- a/tests/e2e/testdata/postgres/migrations/00003_c.sql
+++ b/tests/e2e/testdata/postgres/migrations/00003_c.sql
@@ -1,10 +1,10 @@
 -- +goose Up
 -- +goose StatementBegin
-INSERT INTO owners(owner_id, owner_name, owner_type) 
-    VALUES (3, 'james', 'user'), (4, 'pressly', 'organization');
+INSERT INTO owners(owner_name, owner_type) 
+    VALUES ('james', 'user'), ('pressly', 'organization');
 
-INSERT INTO repos(repo_id, repo_full_name, repo_owner_id) 
-    VALUES (1, 'james/rover', 3), (2, 'pressly/goose', 4);
+INSERT INTO repos(repo_full_name, repo_owner_id) 
+    VALUES ('james/rover', 3), ('pressly/goose', 4);
 -- +goose StatementEnd
 
 -- +goose Down

--- a/tests/e2e/testdata/postgres/seed/00001_a.sql
+++ b/tests/e2e/testdata/postgres/seed/00001_a.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
 
--- insert 100 owners
+-- Insert 100 owners.
 INSERT INTO owners (owner_name, owner_type)
 SELECT
 	'seed-user-' || i,
@@ -12,6 +12,7 @@ FROM
 
 -- +goose Down
 -- +goose StatementBegin
-DELETE FROM owners where owner_name LIKE 'seed-user-%' AND owner_id <= 100;
+-- NOTE: there are 4 existing users from the migrations, that's why owner_id starts at 5
+DELETE FROM owners where owner_name LIKE 'seed-user-%' AND owner_id BETWEEN 5 AND 104;
 SELECT setval('owners_owner_id_seq', COALESCE((SELECT MAX(owner_id)+1 FROM owners), 1), false);
 -- +goose StatementEnd

--- a/tests/e2e/testdata/postgres/seed/00001_a.sql
+++ b/tests/e2e/testdata/postgres/seed/00001_a.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- insert 100 owners
+INSERT INTO owners (owner_name, owner_type)
+SELECT
+	'seed-user-' || i,
+	(SELECT('{user,organization}'::owner_type []) [MOD(i, 2)+1])
+FROM
+	generate_series(1, 100) s (i);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM owners where owner_name LIKE 'seed-user-%' AND owner_id <= 100;
+SELECT setval('owners_owner_id_seq', COALESCE((SELECT MAX(owner_id)+1 FROM owners), 1), false);
+-- +goose StatementEnd

--- a/tests/e2e/testdata/postgres/seed/00002_b.sql
+++ b/tests/e2e/testdata/postgres/seed/00002_b.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- insert 150 more owners
+INSERT INTO owners (owner_name, owner_type)
+SELECT
+	'seed-user-' || i,
+	(SELECT('{user,organization}'::owner_type []) [MOD(i, 2)+1])
+FROM
+	generate_series(1, 150) s (i);
+
+-- +goose Down
+DELETE FROM owners where owner_name LIKE 'seed-user-%' AND owner_id > 100;
+SELECT setval('owners_owner_id_seq', max(owner_id)) FROM owners;

--- a/tests/e2e/testdata/postgres/seed/00002_b.sql
+++ b/tests/e2e/testdata/postgres/seed/00002_b.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 
--- insert 150 more owners
+-- Insert 150 more owners.
 INSERT INTO owners (owner_name, owner_type)
 SELECT
 	'seed-user-' || i,
@@ -9,5 +9,6 @@ FROM
 	generate_series(101, 250) s (i);
 
 -- +goose Down
-DELETE FROM owners where owner_name LIKE 'seed-user-%' AND owner_id > 100;
+-- NOTE: there are 4 migration owners and 100 seed owners, that's why owner_id starts at 105
+DELETE FROM owners where owner_name LIKE 'seed-user-%' AND owner_id BETWEEN 105 AND 254;
 SELECT setval('owners_owner_id_seq', max(owner_id)) FROM owners;

--- a/tests/e2e/testdata/postgres/seed/00002_b.sql
+++ b/tests/e2e/testdata/postgres/seed/00002_b.sql
@@ -6,7 +6,7 @@ SELECT
 	'seed-user-' || i,
 	(SELECT('{user,organization}'::owner_type []) [MOD(i, 2)+1])
 FROM
-	generate_series(101, 150) s (i);
+	generate_series(101, 250) s (i);
 
 -- +goose Down
 DELETE FROM owners where owner_name LIKE 'seed-user-%' AND owner_id > 100;

--- a/tests/e2e/testdata/postgres/seed/00002_b.sql
+++ b/tests/e2e/testdata/postgres/seed/00002_b.sql
@@ -6,7 +6,7 @@ SELECT
 	'seed-user-' || i,
 	(SELECT('{user,organization}'::owner_type []) [MOD(i, 2)+1])
 FROM
-	generate_series(1, 150) s (i);
+	generate_series(101, 150) s (i);
 
 -- +goose Down
 DELETE FROM owners where owner_name LIKE 'seed-user-%' AND owner_id > 100;

--- a/up.go
+++ b/up.go
@@ -11,6 +11,7 @@ import (
 type options struct {
 	allowMissing bool
 	applyUpByOne bool
+	noVersioning bool
 }
 
 type OptionsFunc func(o *options)
@@ -19,21 +20,30 @@ func WithAllowMissing() OptionsFunc {
 	return func(o *options) { o.allowMissing = true }
 }
 
+func WithNoVersioning() OptionsFunc {
+	return func(o *options) { o.noVersioning = true }
+}
+
 func withApplyUpByOne() OptionsFunc {
 	return func(o *options) { o.applyUpByOne = true }
 }
 
 // UpTo migrates up to a specific version.
 func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
-	if _, err := EnsureDBVersion(db); err != nil {
-		return err
-	}
 	option := &options{}
 	for _, f := range opts {
 		f(option)
 	}
 	foundMigrations, err := CollectMigrations(dir, minVersion, version)
 	if err != nil {
+		return err
+	}
+
+	if option.noVersioning {
+		return upToNoVersioning(db, foundMigrations, version)
+	}
+
+	if _, err := EnsureDBVersion(db); err != nil {
 		return err
 	}
 	dbMigrations, err := listAllDBVersions(db)
@@ -95,6 +105,22 @@ func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 	if option.applyUpByOne {
 		return ErrNoNextVersion
 	}
+	return nil
+}
+
+func upToNoVersioning(db *sql.DB, migrations Migrations, version int64) error {
+	var finalVersion int64
+	for _, current := range migrations {
+		if current.Version > version {
+			break
+		}
+		current.noVersioning = true
+		if err := current.Up(db); err != nil {
+			return err
+		}
+		finalVersion = current.Version
+	}
+	log.Printf("goose: current version: %d\n", finalVersion)
 	return nil
 }
 

--- a/up.go
+++ b/up.go
@@ -108,6 +108,8 @@ func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 	return nil
 }
 
+// upToNoVersioning applies up migrations up to, and including, the
+// target version.
 func upToNoVersioning(db *sql.DB, migrations Migrations, version int64) error {
 	var finalVersion int64
 	for _, current := range migrations {
@@ -120,7 +122,7 @@ func upToNoVersioning(db *sql.DB, migrations Migrations, version int64) error {
 		}
 		finalVersion = current.Version
 	}
-	log.Printf("goose: current version: %d\n", finalVersion)
+	log.Printf("goose: up to current file version: %d\n", finalVersion)
 	return nil
 }
 

--- a/up.go
+++ b/up.go
@@ -40,6 +40,14 @@ func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 	}
 
 	if option.noVersioning {
+		if len(foundMigrations) == 0 {
+			return nil
+		}
+		if option.applyUpByOne {
+			// For up-by-one this means keep re-applying the first
+			// migration over and over.
+			version = foundMigrations[0].Version
+		}
 		return upToNoVersioning(db, foundMigrations, version)
 	}
 


### PR DESCRIPTION
Closes #259. 

This implementation adds `no-versioning` support to all existing commands, effectively treating the provided directory as a source of truth. There should be no behaviour changes to existing (versioned) migrations.

_No version means "apply migrations without tracking them in the schema table"._

A common use case might be (see linked ticker for even more context):

1. Apply versioned migrations
2. Apply not versioned seed data (from a different directory)
3. Reset the database by migrating all the seed data down

There are some limitations of `no-versioning` because we're not storing the history of applied migrations. Example:

Say you have 5 seed migrations and are running the following commands repeatedly: `down` will only ever apply the _last_ migration down. Running `up-by-one` will only ever apply the _first_ migration up. Also, running `up-to` and then a `down-to` won't work, since _all_ unversioned migrations start at either the first or last migration.

This limitation is expected, and most users will likely run `up` followed by `reset` with the `--no-versioning` flag **(CLI)**  or `WithNoVersioning()` **library** functional option.

- [x] Fix output to make sense when versioning is disabled
- [x] Add e2e tests for seeding / checking both up and down commands 