### PR TITLE
Remove version row on down migrations outside txn

### DIFF
--- a/goose_test.go
+++ b/goose_test.go
@@ -52,6 +52,44 @@ func TestDefaultBinary(t *testing.T) {
 	}
 }
 
+func TestIssue293(t *testing.T) {
+	t.Parallel()
+	// https://github.com/pressly/goose/issues/293
+	commands := []string{
+		"go build -o ./bin/goose293 ./cmd/goose",
+		"./bin/goose293 -dir=examples/sql-migrations sqlite3 issue_293.db up",
+		"./bin/goose293 -dir=examples/sql-migrations sqlite3 issue_293.db version",
+		"./bin/goose293 -dir=examples/sql-migrations sqlite3 issue_293.db down",
+		"./bin/goose293 -dir=examples/sql-migrations sqlite3 issue_293.db down",
+		"./bin/goose293 -dir=examples/sql-migrations sqlite3 issue_293.db version",
+		"./bin/goose293 -dir=examples/sql-migrations sqlite3 issue_293.db up",
+		"./bin/goose293 -dir=examples/sql-migrations sqlite3 issue_293.db status",
+	}
+	t.Cleanup(func() {
+		if err := os.Remove("./bin/goose293"); err != nil {
+			t.Logf("failed to remove %s resources: %v", t.Name(), err)
+		}
+		if err := os.Remove("./issue_293.db"); err != nil {
+			t.Logf("failed to remove %s resources: %v", t.Name(), err)
+		}
+	})
+	for _, cmd := range commands {
+		args := strings.Split(cmd, " ")
+		command := args[0]
+		var params []string
+		if len(args) > 1 {
+			params = args[1:]
+		}
+
+		cmd := exec.Command(command, params...)
+		cmd.Env = os.Environ()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s:\n%v\n\n%s", err, cmd, out)
+		}
+	}
+}
+
 func TestLiteBinary(t *testing.T) {
 	t.Parallel()
 

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -64,8 +64,14 @@ func runSQLMigration(db *sql.DB, statements []string, useTx bool, v int64, direc
 			return errors.Wrapf(err, "failed to execute SQL query %q", clearStatement(query))
 		}
 	}
-	if _, err := db.Exec(GetDialect().insertVersionSQL(), v, direction); err != nil {
-		return errors.Wrap(err, "failed to insert new goose version")
+	if direction {
+		if _, err := db.Exec(GetDialect().insertVersionSQL(), v, direction); err != nil {
+			return errors.Wrap(err, "failed to insert new goose version")
+		}
+	} else {
+		if _, err := db.Exec(GetDialect().deleteVersionSQL(), v); err != nil {
+			return errors.Wrap(err, "failed to delete goose version")
+		}
 	}
 
 	return nil

--- a/tests/e2e/testdata/mysql/migrations/00002_b.sql
+++ b/tests/e2e/testdata/mysql/migrations/00002_b.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
 INSERT INTO owners(owner_id, owner_name, owner_type) 
-    VALUES (1, 'lucas', 'user'), (2, 'spacey', 'organization');
+    VALUES (1, 'lucas', 'user'), (2, 'space', 'organization');
 -- +goose StatementEnd
 
 -- +goose Down

--- a/tests/e2e/testdata/postgres/migrations/00002_b.sql
+++ b/tests/e2e/testdata/postgres/migrations/00002_b.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
 INSERT INTO owners(owner_id, owner_name, owner_type) 
-    VALUES (1, 'lucas', 'user'), (2, 'spacey', 'organization');
+    VALUES (1, 'lucas', 'user'), (2, 'space', 'organization');
 -- +goose StatementEnd
 
 -- +goose Down

--- a/tests/e2e/testdata/postgres/migrations/00009_i.sql
+++ b/tests/e2e/testdata/postgres/migrations/00009_i.sql
@@ -1,0 +1,6 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+CREATE UNIQUE INDEX CONCURRENTLY ON owners(owner_name);
+
+-- +goose Down
+DROP INDEX IF EXISTS owners_owner_name_idx;

--- a/tests/e2e/testdata/postgres/migrations/00009_i.sql
+++ b/tests/e2e/testdata/postgres/migrations/00009_i.sql
@@ -1,6 +1,9 @@
 -- +goose NO TRANSACTION
+
 -- +goose Up
+-- +goose StatementBegin
 CREATE UNIQUE INDEX CONCURRENTLY ON owners(owner_name);
+-- +goose StatementEnd
 
 -- +goose Down
 DROP INDEX IF EXISTS owners_owner_name_idx;

--- a/tests/e2e/testdata/postgres/migrations/00010_j.sql
+++ b/tests/e2e/testdata/postgres/migrations/00010_j.sql
@@ -1,4 +1,5 @@
 -- +goose NO TRANSACTION
+
 -- +goose Up
 DROP INDEX IF EXISTS owners_owner_name_idx;
 

--- a/tests/e2e/testdata/postgres/migrations/00010_j.sql
+++ b/tests/e2e/testdata/postgres/migrations/00010_j.sql
@@ -1,0 +1,6 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+DROP INDEX IF EXISTS owners_owner_name_idx;
+
+-- +goose Down
+CREATE UNIQUE INDEX CONCURRENTLY ON owners(owner_name);

--- a/tests/e2e/testdata/postgres/migrations/00011_k.sql
+++ b/tests/e2e/testdata/postgres/migrations/00011_k.sql
@@ -22,7 +22,5 @@ CREATE UNIQUE INDEX ON matview_stargazers_day (stargazer_repo_id, stars_day, rep
 
 REFRESH MATERIALIZED VIEW CONCURRENTLY matview_stargazers_day;
 
-RAISE EXCEPTION 'cannot have a negative salary';
-
 -- +goose Down
 DROP MATERIALIZED VIEW IF EXISTS matview_stargazers_day;

--- a/tests/e2e/testdata/postgres/migrations/00011_k.sql
+++ b/tests/e2e/testdata/postgres/migrations/00011_k.sql
@@ -20,7 +20,7 @@ ORDER BY
 
 CREATE UNIQUE INDEX ON matview_stargazers_day (stargazer_repo_id, stars_day, repo_owner_id, repo_full_name);
 
-REFRESH MATERIALIZED VIEW CONCURRENTLY matview_stargazers_day;
+REFRESH MATERIALIZED VIEW CONCURRENTLY matview_stargazers_day WITH DATA;
 
 -- +goose Down
 DROP MATERIALIZED VIEW IF EXISTS matview_stargazers_day;

--- a/tests/e2e/testdata/postgres/migrations/00011_k.sql
+++ b/tests/e2e/testdata/postgres/migrations/00011_k.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+CREATE MATERIALIZED VIEW IF NOT EXISTS matview_stargazers_day AS
+	SELECT
+		t.*,
+		repo_full_name,
+        repo_owner_id
+	FROM (
+	SELECT
+		date_trunc('day', stargazer_starred_at)::date AS stars_day,
+		count(*) AS total,
+		stargazer_repo_id
+	FROM
+		stargazers
+	GROUP BY
+		stars_day,
+		stargazer_repo_id) AS t
+	JOIN repos ON stargazer_repo_id = repo_id
+ORDER BY
+	stars_day;
+
+CREATE UNIQUE INDEX ON matview_stargazers_day (stargazer_repo_id, stars_day, repo_owner_id, repo_full_name);
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY matview_stargazers_day;
+
+RAISE EXCEPTION 'cannot have a negative salary';
+
+-- +goose Down
+DROP MATERIALIZED VIEW IF EXISTS matview_stargazers_day;


### PR DESCRIPTION
Fixes #293

As mentioned in https://github.com/pressly/goose/issues/293#issuecomment-991692027, we should be removing the version row instead of inserting a version row with `is_applied=false`. We've been wanting to deprecate this boolean (removing meaning), this gets us one step closer.

The `goose` logic doesn't use `is_applied` for anything meaningful, so this should be a backwards-compatible change.  Otherwise, it results in a bug as reported in #293 