### PR TITLE
Add password parameter when connect to PostgreSQL on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Examples:
     goose sqlite3 ./foo.db create fetch_user_data go
     goose sqlite3 ./foo.db up
 
-    goose postgres "user=postgres dbname=postgres sslmode=disable" status
+    goose postgres "user=postgres password=postgres dbname=postgres sslmode=disable" status
     goose mysql "user:password@/dbname?parseTime=true" status
     goose redshift "postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" status
     goose tidb "user:password@/dbname?parseTime=true" status


### PR DESCRIPTION
I found that the password parameter is missing on README unlike any others, so I added password parameter on Postgres connection.

Thanks!