### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "saturday"
     assignees:
       - "mfridman"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "saturday"
     assignees:
       - "mfridman"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "saturday"
+    assignees:
+      - "mfridman"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "saturday"
+    assignees:
+      - "mfridman"


### PR DESCRIPTION
Let's keep the project dependencies up-to-date with dependabot.yml. It has become the de-facto way of automating this process.

~The current interval is monthly, but we can consider dropping it down to weekly. We can tweak the settings to see what makes senes.~ Changed to weekly, if it's too bothersome we'll bump it to monthly.