### PR TITLE
DownTo returns error if no matching migration file is found

### DIFF
--- a/down.go
+++ b/down.go
@@ -54,12 +54,12 @@ func DownTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 			return err
 		}
 
+		if currentVersion == 0 {
+			log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
+			return nil
+		}
 		current, err := migrations.Current(currentVersion)
 		if err != nil {
-			if currentVersion == 0 {
-				log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
-				return nil
-			}
 			log.Printf("goose: migration file not found for current version (%d), error: %s,\n", currentVersion, err)
 			return err
 		}

--- a/down.go
+++ b/down.go
@@ -56,8 +56,12 @@ func DownTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 
 		current, err := migrations.Current(currentVersion)
 		if err != nil {
-			log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
-			return nil
+			if currentVersion == 0 {
+				log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
+				return nil
+			}
+			log.Printf("goose: migration file not found for current version (%d), error: %s,\n", currentVersion, err)
+			return err
 		}
 
 		if current.Version <= version {

--- a/down.go
+++ b/down.go
@@ -60,7 +60,7 @@ func DownTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 		}
 		current, err := migrations.Current(currentVersion)
 		if err != nil {
-			log.Printf("goose: migration file not found for current version (%d), error: %s,\n", currentVersion, err)
+			log.Printf("goose: migration file not found for current version (%d), error: %s\n", currentVersion, err)
 			return err
 		}
 


### PR DESCRIPTION
### Fixes
- Don't silently fail if the migration file is not found in `DownTo` (#311) 
