### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/create_test.go
+++ b/create_test.go
@@ -13,12 +13,7 @@ import (
 func TestSequential(t *testing.T) {
 	t.Parallel()
 
-	dir, err := ioutil.TempDir("", "tmptest")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(dir)               // clean up
+	dir := t.TempDir()
 	defer os.Remove("./bin/create-goose") // clean up
 
 	commands := []string{

--- a/fix_test.go
+++ b/fix_test.go
@@ -13,12 +13,7 @@ import (
 func TestFix(t *testing.T) {
 	t.Parallel()
 
-	dir, err := ioutil.TempDir("", "tmptest")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(dir)            // clean up
+	dir := t.TempDir()
 	defer os.Remove("./bin/fix-goose") // clean up
 
 	commands := []string{

--- a/goose_test.go
+++ b/goose_test.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -93,14 +92,8 @@ func TestIssue293(t *testing.T) {
 func TestLiteBinary(t *testing.T) {
 	t.Parallel()
 
-	dir, err := ioutil.TempDir("", "tmptest")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	t.Cleanup(func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Logf("failed to remove %s resources: %v", t.Name(), err)
-		}
 		if err := os.Remove("./bin/lite-goose"); err != nil {
 			t.Logf("failed to remove %s resources: %v", t.Name(), err)
 		}
@@ -211,12 +204,7 @@ func TestEmbeddedMigrations(t *testing.T) {
 	})
 
 	t.Run("Create uses os fs", func(t *testing.T) {
-		tmpDir, err := os.MkdirTemp("", "test_create_osfs")
-		if err != nil {
-			t.Fatalf("Create temp dir failed: %s", err)
-		}
-
-		t.Cleanup(func() { os.RemoveAll(tmpDir) })
+		tmpDir := t.TempDir()
 
 		if err := Create(db, tmpDir, "test", "sql"); err != nil {
 			t.Errorf("Failed to create migration: %s", err)


### PR DESCRIPTION
A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir