### PR TITLE
apply only new migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Examples:
 
 Options:
 
+  -only-new
+        apply migration commands with only new migrations right after current
   -allow-missing
     	applies missing (out-of-order) migrations
   -certfile string

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -26,6 +26,7 @@ var (
 	sslcert      = flags.String("ssl-cert", "", "file path to SSL certificates in pem format (only support on mysql)")
 	sslkey       = flags.String("ssl-key", "", "file path to SSL key in pem format (only support on mysql)")
 	noVersioning = flags.Bool("no-versioning", false, "apply migration commands with no versioning, in file order, from directory pointed to")
+	onlyNew      = flags.Bool("only-new", false, "apply migration commands with only new migrations right after current")
 )
 
 var (
@@ -110,6 +111,9 @@ func main() {
 	}
 	if *noVersioning {
 		options = append(options, goose.WithNoVersioning())
+	}
+	if *onlyNew {
+		options = append(options, goose.WithOnlyNew())
 	}
 	if err := goose.RunWithOptions(
 		command,

--- a/dialect.go
+++ b/dialect.go
@@ -302,7 +302,7 @@ func (m ClickHouseDialect) createVersionTableSQL() string {
 }
 
 func (m ClickHouseDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
-	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied FROM %s ORDER BY tstamp DESC LIMIT 1", TableName()))
+	rows, err := db.Query(fmt.Sprintf("SELECT version_id, is_applied FROM %s ORDER BY tstamp DESC, version_id DESC LIMIT 1", TableName()))
 	if err != nil {
 		return nil, err
 	}

--- a/up.go
+++ b/up.go
@@ -12,9 +12,14 @@ type options struct {
 	allowMissing bool
 	applyUpByOne bool
 	noVersioning bool
+	onlyNew      bool
 }
 
 type OptionsFunc func(o *options)
+
+func WithOnlyNew() OptionsFunc {
+	return func(o *options) { o.onlyNew = true }
+}
 
 func WithAllowMissing() OptionsFunc {
 	return func(o *options) { o.allowMissing = true }
@@ -61,10 +66,7 @@ func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 
 	missingMigrations := findMissingMigrations(dbMigrations, foundMigrations)
 
-	// feature(mf): It is very possible someone may want to apply ONLY new migrations
-	// and skip missing migrations altogether. At the moment this is not supported,
-	// but leaving this comment because that's where that logic will be handled.
-	if len(missingMigrations) > 0 && !option.allowMissing {
+	if len(missingMigrations) > 0 && !option.allowMissing && !option.onlyNew {
 		var collected []string
 		for _, m := range missingMigrations {
 			output := fmt.Sprintf("version %d: %s", m.Version, m.Source)


### PR DESCRIPTION
It's possible situation in clickhouse when version_id differs with the same tstamp. Ex
```
version_id, is_applied, date, tstamp
11,1,2022-03-01,2022-03-01 16:34:41
12,1,2022-03-01,2022-03-01 16:34:41
13,1,2022-03-01,2022-03-01 16:34:41
14,1,2022-03-01,2022-03-01 16:34:41
15,1,2022-03-01,2022-03-01 16:34:41
```
It can be assumed that we want to get latest version_id, not random. Thats why I added version_id desc sorting.

Second thing is that situation can changed and reapplying "missing" migration could fail. For example, I have 15 migrations starting from 1. When I migrate first time from 1 to 15 everything is fine. But what if migration 14 has difference that broke the scheme for migration 3? When I try to repeat migration from 1 to 15 it will break at migration 3. So, I need a need an opportunity to apply only migrations and dont touch missing.