### PR TITLE
Fix potential index out of range error

### DIFF
--- a/examples/go-migrations/main.go
+++ b/examples/go-migrations/main.go
@@ -20,7 +20,7 @@ func main() {
 	flags.Parse(os.Args[1:])
 	args := flags.Args()
 
-	if len(args) < 2 {
+	if len(args) < 3 {
 		flags.Usage()
 		return
 	}


### PR DESCRIPTION
If only two arguments are provided, line 28 will throw an error when it attempts to read `args[2]`.