### PR TITLE
Avoid to ignore empty lines in SQL files

### DIFF
--- a/sql_parser.go
+++ b/sql_parser.go
@@ -28,6 +28,7 @@ type stateMachine parserState
 func (s *stateMachine) Get() parserState {
 	return parserState(*s)
 }
+
 func (s *stateMachine) Set(new parserState) {
 	verboseInfo("StateMachine: %v => %v", *s, new)
 	*s = stateMachine(new)
@@ -64,6 +65,7 @@ func parseSQLMigration(r io.Reader, direction bool) (stmts []string, useTx bool,
 	stateMachine := stateMachine(start)
 	useTx = true
 
+	firstLineFound := false
 	for scanner.Scan() {
 		line := scanner.Text()
 		if verbose {
@@ -71,6 +73,7 @@ func parseSQLMigration(r io.Reader, direction bool) (stmts []string, useTx bool,
 		}
 
 		if strings.HasPrefix(line, "--") {
+			firstLineFound = true
 			cmd := strings.TrimSpace(strings.TrimPrefix(line, "--"))
 
 			switch cmd {
@@ -124,8 +127,8 @@ func parseSQLMigration(r io.Reader, direction bool) (stmts []string, useTx bool,
 			}
 		}
 
-		// Ignore empty lines.
-		if matchEmptyLines.MatchString(line) {
+		// Ignore empty lines until first line is found.
+		if !firstLineFound && matchEmptyLines.MatchString(line) {
 			verboseInfo("StateMachine: ignore empty line")
 			continue
 		}

--- a/sql_parser.go
+++ b/sql_parser.go
@@ -73,11 +73,11 @@ func parseSQLMigration(r io.Reader, direction bool) (stmts []string, useTx bool,
 		}
 
 		if strings.HasPrefix(line, "--") {
-			firstLineFound = true
 			cmd := strings.TrimSpace(strings.TrimPrefix(line, "--"))
 
 			switch cmd {
 			case "+goose Up":
+				firstLineFound = true
 				switch stateMachine.Get() {
 				case start:
 					stateMachine.Set(gooseUp)
@@ -87,6 +87,7 @@ func parseSQLMigration(r io.Reader, direction bool) (stmts []string, useTx bool,
 				continue
 
 			case "+goose Down":
+				firstLineFound = true
 				switch stateMachine.Get() {
 				case gooseUp, gooseStatementEndUp:
 					stateMachine.Set(gooseDown)
@@ -96,6 +97,7 @@ func parseSQLMigration(r io.Reader, direction bool) (stmts []string, useTx bool,
 				continue
 
 			case "+goose StatementBegin":
+				firstLineFound = true
 				switch stateMachine.Get() {
 				case gooseUp, gooseStatementEndUp:
 					stateMachine.Set(gooseStatementBeginUp)
@@ -107,6 +109,7 @@ func parseSQLMigration(r io.Reader, direction bool) (stmts []string, useTx bool,
 				continue
 
 			case "+goose StatementEnd":
+				firstLineFound = true
 				switch stateMachine.Get() {
 				case gooseStatementBeginUp:
 					stateMachine.Set(gooseStatementEndUp)

--- a/sql_parser_test.go
+++ b/sql_parser_test.go
@@ -75,6 +75,25 @@ func TestSplitStatements(t *testing.T) {
 	}
 }
 
+func TestKeepEmptyLines(t *testing.T) {
+	stmts, _, err := parseSQLMigration(strings.NewReader(emptyLineSQL), true)
+	if err != nil {
+		t.Error(errors.Wrapf(err, "unexpected error"))
+	}
+	expected := `INSERT INTO post (id, title, body)
+VALUES ('id_01', 'my_title', '
+this is an insert statement including empty lines.
+
+empty (blank) lines can be meaningful.
+
+leave the lines to keep the text syntax.
+');
+`
+	if stmts[0] != expected {
+		t.Errorf("incorrect stmts. got %v, want %v", stmts, expected)
+	}
+}
+
 func TestUseTransactions(t *testing.T) {
 	t.Parallel()
 
@@ -137,6 +156,20 @@ SELECT 4;           -- 4th stmt
 -- +goose Down
 -- comment
 DROP TABLE post;    -- 1st stmt
+`
+
+var emptyLineSQL = `-- +goose Up
+INSERT INTO post (id, title, body)
+VALUES ('id_01', 'my_title', '
+this is an insert statement including empty lines.
+
+empty (blank) lines can be meaningful.
+
+leave the lines to keep the text syntax.
+');
+
+-- +goose Down
+TRUNCATE TABLE post; 
 `
 
 var functxt = `-- +goose Up

--- a/sql_parser_test.go
+++ b/sql_parser_test.go
@@ -78,7 +78,7 @@ func TestSplitStatements(t *testing.T) {
 func TestKeepEmptyLines(t *testing.T) {
 	stmts, _, err := parseSQLMigration(strings.NewReader(emptyLineSQL), true)
 	if err != nil {
-		t.Error(errors.Wrapf(err, "unexpected error"))
+		t.Errorf("Failed to parse SQL migration. %v", err)
 	}
 	expected := `INSERT INTO post (id, title, body)
 VALUES ('id_01', 'my_title', '


### PR DESCRIPTION
The current implementation ignores blank lines in the migration sql file.

But in my use case, this behavior produced unexpected results.
In some cases, a blank line in the SQL may be meaningful.
The following code is an example of SQL using the _E string syntax_ in PostgreSQL.

```sql
INSERT INTO article (id, content) VALUES ('id_0001',  E'# My markdown doc

first paragraph

second paragraph');
```

In this markdown text, empty lines must NOT be removed.

As far as I could check, the same behavior was not observed in command line mode. it occurs only in the case of library use.
Therefore, If there is no strong motivation to ignore blank lines, this behavior should be fixed.

I would love to hear your opinion. Thanks for the great library.
