### PR TITLE
exit with error 1 without required arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 .DS_Store
 *.swp
 *.test

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -51,10 +51,17 @@ func main() {
 	goose.SetTableName(*table)
 
 	args := flags.Args()
-	if len(args) == 0 || *help {
+
+	if *help {
 		flags.Usage()
 		return
 	}
+
+	if len(args) == 0 {
+		flags.Usage()
+		os.Exit(1)
+	}
+
 	// The -dir option has not been set, check whether the env variable is set
 	// before defaulting to ".".
 	if *dir == defaultMigrationDir && os.Getenv(envGooseMigrationDir) != "" {

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -82,7 +82,7 @@ func main() {
 	args = mergeArgs(args)
 	if len(args) < 3 {
 		flags.Usage()
-		return
+		os.Exit(1)
 	}
 
 	driver, dbstring, command := args[0], args[1], args[2]


### PR DESCRIPTION
When no argument or variable is given, the program exits with an exit code of 0 as if the migration process was successfully completed.

You must exit with exit code 1 to determine that the migration failed.