### PR TITLE
migrations statuses func

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -27,6 +27,10 @@ type Migration struct {
 	UpFn         func(*sql.Tx) error // Up go migration function
 	DownFn       func(*sql.Tx) error // Down go migration function
 	noVersioning bool
+
+	// state
+	IsApplied bool
+	TStamp    time.Time
 }
 
 func (m *Migration) String() string {

--- a/migration.go
+++ b/migration.go
@@ -28,9 +28,7 @@ type Migration struct {
 	DownFn       func(*sql.Tx) error // Down go migration function
 	noVersioning bool
 
-	// state
-	IsApplied bool
-	TStamp    time.Time
+	IsApplied bool // fills only in DetailedStatus func
 }
 
 func (m *Migration) String() string {

--- a/status.go
+++ b/status.go
@@ -2,6 +2,7 @@ package goose
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -43,22 +44,70 @@ func Status(db *sql.DB, dir string, opts ...OptionsFunc) error {
 }
 
 func printMigrationStatus(db *sql.DB, version int64, script string) error {
-	q := GetDialect().migrationSQL()
-
-	var row MigrationRecord
-
-	err := db.QueryRow(q, version).Scan(&row.TStamp, &row.IsApplied)
-	if err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("failed to query the latest migration: %w", err)
+	row, err := GetMigrationRecord(db, version)
+	if err != nil {
+		return err
 	}
 
-	var appliedAt string
-	if row.IsApplied {
+	appliedAt := "Pending"
+	if row != nil && row.IsApplied {
 		appliedAt = row.TStamp.Format(time.ANSIC)
-	} else {
-		appliedAt = "Pending"
 	}
 
 	log.Printf("    %-24s -- %v\n", appliedAt, script)
 	return nil
+}
+
+func DetailedStatus(db *sql.DB, dir string, opts ...OptionsFunc) (Migrations, error) {
+	option := &options{}
+	for _, f := range opts {
+		f(option)
+	}
+	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect migrations: %w", err)
+	}
+	if option.noVersioning {
+		return migrations, nil
+	}
+
+	// must ensure that the version table exists if we're running on a pristine DB
+	if _, err := EnsureDBVersion(db); err != nil {
+		return nil, fmt.Errorf("failed to ensure DB version: %w", err)
+	}
+
+	for i := range migrations {
+		record, err := GetMigrationRecord(db, migrations[i].Version)
+		if err != nil {
+			return nil, err
+		}
+
+		if record == nil {
+			migrations[i].IsApplied = false
+			continue
+		}
+
+		migrations[i].IsApplied = record.IsApplied
+		migrations[i].TStamp = record.TStamp
+	}
+
+	return migrations, nil
+}
+
+// GetMigrationRecord - returns the migration record for a given version.
+// If no record is found, returns nil.
+func GetMigrationRecord(db *sql.DB, version int64) (*MigrationRecord, error) {
+	q := GetDialect().migrationSQL()
+
+	row := MigrationRecord{VersionID: version}
+
+	err := db.QueryRow(q, version).Scan(&row.TStamp, &row.IsApplied)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return nil, nil
+	case err != nil:
+		return nil, fmt.Errorf("failed to query the latest migration: %w", err)
+	}
+
+	return &row, nil
 }

--- a/tests/e2e/status_test.go
+++ b/tests/e2e/status_test.go
@@ -1,0 +1,148 @@
+package e2e
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+	"github.com/pressly/goose/v3/internal/check"
+)
+
+func TestDetailedStatus(t *testing.T) {
+	t.Parallel()
+
+	db, err := newDockerDB(t)
+	check.NoError(t, err)
+	goose.SetDialect(*dialect)
+
+	migrationsBefore, err := goose.DetailedStatus(db, migrationsDir)
+	check.NoError(t, err)
+	// check statuses befor apply
+	for _, m := range migrationsBefore {
+		check.Equal(t, m.IsApplied, false)
+	}
+
+	{
+		// Apply all up migrations
+		err = goose.Up(db, migrationsDir)
+		check.NoError(t, err)
+		currentVersion, err := goose.GetDBVersion(db)
+		check.NoError(t, err)
+		check.Number(t, currentVersion, migrationsBefore[len(migrationsBefore)-1].Version)
+	}
+
+	// after full migration
+	migrations1, err := goose.DetailedStatus(db, migrationsDir)
+	check.NoError(t, err)
+
+	dbMigrations1 := getDbMigrations(t, db)
+	// should have all migrations applied
+	check.Equal(t, len(dbMigrations1), len(migrations1))
+	compareMigrationsStatuses(t, migrations1, dbMigrations1)
+
+	// number migrations to undo
+	n := 3
+
+	{
+		// undo migrations
+		for i := len(migrationsBefore) - 1; i >= len(migrationsBefore)-n; i-- {
+			err := migrationsBefore[i].Down(db)
+			check.NoError(t, err)
+		}
+	}
+
+	migrations2, err := goose.DetailedStatus(db, migrationsDir)
+	check.NoError(t, err)
+	compareMigrationsStatuses(t, migrations2, getDbMigrations(t, db))
+
+	{
+		// redo all migrations
+		for i := len(migrationsBefore) - n; i < len(migrationsBefore); i++ {
+			err := migrationsBefore[i].Up(db)
+			check.NoError(t, err)
+		}
+	}
+
+	migrations3, err := goose.DetailedStatus(db, migrationsDir)
+	check.NoError(t, err)
+	compareMigrationsStatuses(t, migrations3, getDbMigrations(t, db))
+}
+
+func compareMigrationsStatuses(t *testing.T, m goose.Migrations, d map[int64]goose.MigrationRecord) {
+	t.Log(logMigrationsStatus(m, d))
+	for _, record := range m {
+		if !record.IsApplied {
+			continue
+		}
+		dbM, exists := d[record.Version]
+
+		check.Equal(t, exists, true) // no migration in db
+		check.Equal(t, dbM.IsApplied, record.IsApplied)
+	}
+}
+
+func logMigrationsStatus(m goose.Migrations, d map[int64]goose.MigrationRecord) string {
+	s := "\nstatus:\n"
+
+	applied := make([]int64, 0, len(m))
+	notApplied := make([]int64, 0, len(m))
+	for i := range m {
+		if m[i].IsApplied {
+			applied = append(applied, m[i].Version)
+		} else {
+			notApplied = append(notApplied, m[i].Version)
+		}
+	}
+	s += fmt.Sprintf("applied - %v\n", applied)
+	s += fmt.Sprintf("NOT applied - %v\n", notApplied)
+
+	s += "db:\n"
+
+	keys := make([]int64, 0, len(d))
+	for i := range d {
+		keys = append(keys, i)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
+	applied = make([]int64, 0, len(m))
+	notApplied = make([]int64, 0, len(m))
+	for _, i := range keys {
+		if d[i].IsApplied {
+			applied = append(applied, d[i].VersionID)
+		} else {
+			notApplied = append(notApplied, d[i].VersionID)
+		}
+	}
+	s += fmt.Sprintf("applied - %v\n", applied)
+	s += fmt.Sprintf("NOT applied - %v\n", notApplied)
+
+	return s
+}
+
+func getDbMigrations(t *testing.T, db *sql.DB) map[int64]goose.MigrationRecord {
+	q := fmt.Sprintf("SELECT version_id, tstamp, is_applied FROM %s;", goose.TableName())
+
+	rows, err := db.Query(q)
+	check.NoError(t, err)
+
+	defer rows.Close()
+
+	result := make(map[int64]goose.MigrationRecord, 20)
+
+	for rows.Next() {
+		var row goose.MigrationRecord
+		err = rows.Scan(&row.VersionID, &row.TStamp, &row.IsApplied)
+		check.NoError(t, err)
+		if row.VersionID == 0 {
+			continue
+		}
+
+		result[row.VersionID] = row
+	}
+
+	check.NoError(t, rows.Err())
+
+	return result
+}

--- a/up.go
+++ b/up.go
@@ -231,7 +231,8 @@ func listAllDBVersions(db *sql.DB) (Migrations, error) {
 			return nil, err
 		}
 		all = append(all, &Migration{
-			Version: versionID,
+			Version:   versionID,
+			IsApplied: isApplied,
 		})
 	}
 	if err := rows.Close(); err != nil {


### PR DESCRIPTION
Hi!
Someone asked in [#255](https://github.com/pressly/goose/issues/225#issuecomment-1134717767) about having function for getting migration statuses.

So if you want to have this func we can discuss it, because I have some thoughts additionally to the changes.

1) looks like the `Migrations` type should have this function
```go
func (ms Migrations) Records() ([]MigrationRecord, error) {}
```

2) add a tstamp to query in `dbVersionQuery(db *sql.DB)` in case that someone needs it. 
