### PR TITLE
Update deprecated query in createVersionTableSQL for new ClickHouse versions since 22.7

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -298,7 +298,9 @@ func (m ClickHouseDialect) createVersionTableSQL() string {
       is_applied UInt8,
       date Date default now(),
       tstamp DateTime default now()
-    ) Engine = MergeTree(date, (date), 8192)`, TableName())
+    )
+	ENGINE = MergeTree()
+	  ORDER BY (version_id)`, TableName())
 }
 
 func (m ClickHouseDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {

--- a/dialect.go
+++ b/dialect.go
@@ -300,7 +300,7 @@ func (m ClickHouseDialect) createVersionTableSQL() string {
       tstamp DateTime default now()
     )
 	ENGINE = MergeTree()
-	  ORDER BY (version_id)`, TableName())
+	  ORDER BY (date)`, TableName())
 }
 
 func (m ClickHouseDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {

--- a/internal/testdb/clickhouse.go
+++ b/internal/testdb/clickhouse.go
@@ -16,7 +16,7 @@ import (
 const (
 	// https://hub.docker.com/r/clickhouse/clickhouse-server/
 	CLICKHOUSE_IMAGE   = "clickhouse/clickhouse-server"
-	CLICKHOUSE_VERSION = "22.6-alpine"
+	CLICKHOUSE_VERSION = "22.9-alpine"
 
 	CLICKHOUSE_DB                        = "clickdb"
 	CLICKHOUSE_USER                      = "clickuser"


### PR DESCRIPTION
Fixes https://github.com/pressly/goose/issues/392