### PR TITLE
Add NO_COLOR (-no-color) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Files output by tests
 /bin
+
+# Local testing
+.envrc

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,12 @@ test-clickhouse:
 
 docker-cleanup:
 	docker stop -t=0 $$(docker ps --filter="label=goose_test" -aq)
+
+start-postgres:
+	docker run --rm -d \
+		-e POSTGRES_USER=${GOOSE_POSTGRES_DB_USER} \
+		-e POSTGRES_PASSWORD=${GOOSE_POSTGRES_PASSWORD} \
+		-e POSTGRES_DB=${GOOSE_POSTGRES_DBNAME} \
+		-p ${GOOSE_POSTGRES_PORT}:5432 \
+		-l goose_test \
+		postgres:14-alpine

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -119,7 +119,7 @@ func main() {
 		arguments = append(arguments, args[3:]...)
 	}
 	options := []goose.OptionsFunc{}
-	if *noColor || isNoColor() {
+	if *noColor || checkNoColorFromEnv() {
 		options = append(options, goose.WithNoColor(true))
 	}
 	if *allowMissing {
@@ -139,13 +139,12 @@ func main() {
 	}
 }
 
-func isNoColor() bool {
-	s := os.Getenv(envNoColor)
-	if s == "" {
-		return false
+func checkNoColorFromEnv() bool {
+	if s := os.Getenv(envNoColor); s != "" {
+		ok, _ := strconv.ParseBool(s)
+		return ok
 	}
-	ok, _ := strconv.ParseBool(s)
-	return ok
+	return false
 }
 
 const (

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -27,7 +27,7 @@ var (
 	sslcert      = flags.String("ssl-cert", "", "file path to SSL certificates in pem format (only support on mysql)")
 	sslkey       = flags.String("ssl-key", "", "file path to SSL key in pem format (only support on mysql)")
 	noVersioning = flags.Bool("no-versioning", false, "apply migration commands with no versioning, in file order, from directory pointed to")
-	noColor      = flags.Bool("no-color", false, "disable color output (NO_COLOR supported)")
+	noColor      = flags.Bool("no-color", false, "disable color output (NO_COLOR env variable supported)")
 )
 var (
 	gooseVersion = ""

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"runtime/debug"
+	"strconv"
 	"text/template"
 
 	"github.com/pressly/goose/v3"
@@ -26,6 +27,7 @@ var (
 	sslcert      = flags.String("ssl-cert", "", "file path to SSL certificates in pem format (only support on mysql)")
 	sslkey       = flags.String("ssl-key", "", "file path to SSL key in pem format (only support on mysql)")
 	noVersioning = flags.Bool("no-versioning", false, "apply migration commands with no versioning, in file order, from directory pointed to")
+	noColor      = flags.Bool("no-color", false, "disable color output (NO_COLOR supported)")
 )
 var (
 	gooseVersion = ""
@@ -116,8 +118,10 @@ func main() {
 	if len(args) > 3 {
 		arguments = append(arguments, args[3:]...)
 	}
-
 	options := []goose.OptionsFunc{}
+	if *noColor || isNoColor() {
+		options = append(options, goose.WithNoColor(true))
+	}
 	if *allowMissing {
 		options = append(options, goose.WithAllowMissing())
 	}
@@ -135,10 +139,21 @@ func main() {
 	}
 }
 
+func isNoColor() bool {
+	s := os.Getenv(envNoColor)
+	if s == "" {
+		return false
+	}
+	ok, _ := strconv.ParseBool(s)
+	return ok
+}
+
 const (
 	envGooseDriver       = "GOOSE_DRIVER"
 	envGooseDBString     = "GOOSE_DBSTRING"
 	envGooseMigrationDir = "GOOSE_MIGRATION_DIR"
+	// https://no-color.org/
+	envNoColor = "NO_COLOR"
 )
 
 const (

--- a/goose.go
+++ b/goose.go
@@ -15,6 +15,7 @@ var (
 	maxVersion      = int64((1 << 63) - 1)
 	timestampFormat = "20060102150405"
 	verbose         = false
+	noColor         = false
 
 	// base fs to lookup migrations
 	baseFS fs.FS = osFS{}

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -113,7 +113,11 @@ const (
 
 func verboseInfo(s string, args ...interface{}) {
 	if verbose {
-		log.Printf(grayColor+s+resetColor, args...)
+		if noColor {
+			log.Printf(s, args...)
+		} else {
+			log.Printf(grayColor+s+resetColor, args...)
+		}
 	}
 }
 

--- a/up.go
+++ b/up.go
@@ -24,6 +24,10 @@ func WithNoVersioning() OptionsFunc {
 	return func(o *options) { o.noVersioning = true }
 }
 
+func WithNoColor(b bool) OptionsFunc {
+	return func(o *options) { noColor = b }
+}
+
 func withApplyUpByOne() OptionsFunc {
 	return func(o *options) { o.applyUpByOne = true }
 }


### PR DESCRIPTION
This PR adds a flag `-no-color` and an env variable `NO_COLOR` to disable colored output in logs.

Fix #405

