### PR TITLE
Add duration of individual migration; up and down

### DIFF
--- a/migration.go
+++ b/migration.go
@@ -63,14 +63,16 @@ func (m *Migration) run(db *sql.DB, direction bool) error {
 			return fmt.Errorf("ERROR %v: failed to parse SQL migration file: %w", filepath.Base(m.Source), err)
 		}
 
+		start := time.Now()
 		if err := runSQLMigration(db, statements, useTx, m.Version, direction, m.noVersioning); err != nil {
 			return fmt.Errorf("ERROR %v: failed to run SQL migration: %w", filepath.Base(m.Source), err)
 		}
+		finish := truncateDuration(time.Since(start))
 
 		if len(statements) > 0 {
-			log.Println("OK   ", filepath.Base(m.Source))
+			log.Printf("OK   %s (%s)\n", filepath.Base(m.Source), finish)
 		} else {
-			log.Println("EMPTY", filepath.Base(m.Source))
+			log.Printf("EMPTY %s (%s)\n", filepath.Base(m.Source), finish)
 		}
 
 	case ".go":
@@ -107,15 +109,16 @@ func (m *Migration) run(db *sql.DB, direction bool) error {
 				}
 			}
 		}
-
+		start := time.Now()
 		if err := tx.Commit(); err != nil {
 			return fmt.Errorf("ERROR failed to commit transaction: %w", err)
 		}
+		finish := truncateDuration(time.Since(start))
 
 		if fn != nil {
-			log.Println("OK   ", filepath.Base(m.Source))
+			log.Printf("OK   %s (%s)\n", filepath.Base(m.Source), finish)
 		} else {
-			log.Println("EMPTY", filepath.Base(m.Source))
+			log.Printf("EMPTY %s (%s)\n", filepath.Base(m.Source), finish)
 		}
 
 		return nil
@@ -145,4 +148,17 @@ func NumericComponent(name string) (int64, error) {
 	}
 
 	return n, e
+}
+
+func truncateDuration(d time.Duration) time.Duration {
+	for _, v := range []time.Duration{
+		time.Second,
+		time.Millisecond,
+		time.Microsecond,
+	} {
+		if d > v {
+			return d.Round(v / time.Duration(100))
+		}
+	}
+	return d
 }


### PR DESCRIPTION
This PR adds duration output to each individual up and down migration, e.g.,

Note, the duration is truncated down to 2. I found the default precision overly long.

```
2022/10/20 17:21:28 OK   00001_a.sql (44.74ms)
2022/10/20 17:21:28 OK   00002_b.sql (7.52ms)
2022/10/20 17:21:28 OK   00003_c.sql (35.31ms)
2022/10/20 17:21:28 OK   00004_d.sql (4.17ms)
2022/10/20 17:21:28 OK   00005_e.sql (37.76ms)
2022/10/20 17:21:28 OK   00006_f.sql (9ms)
2022/10/20 17:21:28 OK   00007_g.sql (37.31ms)    <- microseconds
2022/10/20 17:21:40 OK   00008_h.sql (12.04s)     <- seconds
2022/10/20 17:22:42 OK   00009_i.sql (1m2.04s)    <- minutes
2022/10/20 17:22:42 OK   00010_j.sql (36.66ms)
2022/10/20 17:22:42 OK   00011_k.sql (79.72ms)
```

cc @VojtechVitek let me know if the output is good enough.

Fix  #388 