### PR TITLE
Add check for pending migrations

### DIFF
--- a/tests/clickhouse/clickhouse_test.go
+++ b/tests/clickhouse/clickhouse_test.go
@@ -60,12 +60,18 @@ func TestClickUpDownAll(t *testing.T) {
 	currentVersion, err := goose.GetDBVersion(db)
 	check.NoError(t, err)
 	check.Number(t, currentVersion, 0)
+	hasPending, err := goose.HasPending(db, migrationDir)
+	check.NoError(t, err)
+	check.Bool(t, hasPending, true)
 
 	err = goose.Up(db, migrationDir)
 	check.NoError(t, err)
 	currentVersion, err = goose.GetDBVersion(db)
 	check.NoError(t, err)
 	check.Number(t, currentVersion, len(migrations))
+	hasPending, err = goose.HasPending(db, migrationDir)
+	check.NoError(t, err)
+	check.Bool(t, hasPending, false)
 
 	err = goose.DownTo(db, migrationDir, 0)
 	check.NoError(t, err)
@@ -78,6 +84,9 @@ func TestClickUpDownAll(t *testing.T) {
 	currentVersion, err = goose.GetDBVersion(db)
 	check.NoError(t, err)
 	check.Number(t, currentVersion, 0)
+	hasPending, err = goose.HasPending(db, migrationDir)
+	check.NoError(t, err)
+	check.Bool(t, hasPending, true)
 }
 
 func TestClickHouseFirstThree(t *testing.T) {
@@ -164,6 +173,9 @@ func TestRemoteImportMigration(t *testing.T) {
 	check.NoError(t, err)
 	_, err = goose.GetDBVersion(db)
 	check.NoError(t, err)
+	hasPending, err := goose.HasPending(db, migrationDir)
+	check.NoError(t, err)
+	check.Bool(t, hasPending, false)
 
 	var count int
 	err = db.QueryRow(`SELECT count(*) FROM taxi_zone_dictionary`).Scan(&count)

--- a/tests/e2e/migrations_test.go
+++ b/tests/e2e/migrations_test.go
@@ -27,6 +27,9 @@ func TestMigrateUpWithReset(t *testing.T) {
 	currentVersion, err := goose.GetDBVersion(db)
 	check.NoError(t, err)
 	check.Number(t, currentVersion, migrations[len(migrations)-1].Version)
+	hasPending, err := goose.HasPending(db, migrationsDir)
+	check.NoError(t, err)
+	check.Bool(t, hasPending, false)
 	// Validate the db migration version actually matches what goose claims it is
 	gotVersion, err := getCurrentGooseVersion(db, goose.TableName())
 	check.NoError(t, err)
@@ -39,6 +42,9 @@ func TestMigrateUpWithReset(t *testing.T) {
 	currentVersion, err = goose.GetDBVersion(db)
 	check.NoError(t, err)
 	check.Number(t, currentVersion, 0)
+	hasPending, err = goose.HasPending(db, migrationsDir)
+	check.NoError(t, err)
+	check.Bool(t, hasPending, true)
 }
 
 func TestMigrateUpWithRedo(t *testing.T) {
@@ -54,6 +60,9 @@ func TestMigrateUpWithRedo(t *testing.T) {
 	startingVersion, err := goose.EnsureDBVersion(db)
 	check.NoError(t, err)
 	check.Number(t, startingVersion, 0)
+	hasPending, err := goose.HasPending(db, migrationsDir)
+	check.NoError(t, err)
+	check.Bool(t, hasPending, true)
 	// Migrate all
 	for _, migration := range migrations {
 		err = migration.Up(db)
@@ -74,6 +83,9 @@ func TestMigrateUpWithRedo(t *testing.T) {
 	currentVersion, err := goose.GetDBVersion(db)
 	check.NoError(t, err)
 	check.Number(t, currentVersion, maxVersion)
+	hasPending, err = goose.HasPending(db, migrationsDir)
+	check.NoError(t, err)
+	check.Bool(t, hasPending, false)
 }
 
 func TestMigrateUpTo(t *testing.T) {
@@ -174,6 +186,9 @@ func TestMigrateFull(t *testing.T) {
 		currentVersion, err := goose.GetDBVersion(db)
 		check.NoError(t, err)
 		check.Number(t, currentVersion, migrations[len(migrations)-1].Version)
+		hasPending, err := goose.HasPending(db, migrationsDir)
+		check.NoError(t, err)
+		check.Bool(t, hasPending, false)
 		// Validate the db migration version actually matches what goose claims it is
 		gotVersion, err := getCurrentGooseVersion(db, goose.TableName())
 		check.NoError(t, err)


### PR DESCRIPTION
First, thank you for creating nice library.

### Summary
Compare existing migration files and migration version of DB to check if there is pending migration.

Tests were added as follows
- The test case of applying all migrations
  - Expect that No pending migrations exist (return false)
- The test case of rollbacking all migrations
  - Expect that pending migrations exist (return true)

Thank you!