### PR TITLE
feat: add goose env command

### DIFF
--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -1,0 +1,39 @@
+package cfg
+
+import "os"
+
+var (
+	GOOSEDRIVER       = envOr("GOOSE_DRIVER", "")
+	GOOSEDBSTRING     = envOr("GOOSE_DBSTRING", "")
+	GOOSEMIGRATIONDIR = envOr("GOOSE_MIGRATION_DIR", DefaultMigrationDir)
+	// https://no-color.org/
+	GOOSENOCOLOR = envOr("NO_COLOR", "false")
+)
+
+var (
+	DefaultMigrationDir = "."
+)
+
+// An EnvVar is an environment variable Name=Value.
+type EnvVar struct {
+	Name  string
+	Value string
+}
+
+func List() []EnvVar {
+	return []EnvVar{
+		{Name: "GOOSE_DRIVER", Value: GOOSEDRIVER},
+		{Name: "GOOSE_DBSTRING", Value: GOOSEDBSTRING},
+		{Name: "GOOSE_MIGRATION_DIR", Value: GOOSEMIGRATIONDIR},
+		{Name: "NO_COLOR", Value: GOOSENOCOLOR},
+	}
+}
+
+// envOr returns os.Getenv(key) if set, or else default.
+func envOr(key, def string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		val = def
+	}
+	return val
+}


### PR DESCRIPTION
This PR moves all env config-related bits to an internal `cfg` package (inspired by the `go` command), and exposes a new command to see the available and set env variables. 

Example from the root of this repo set by direnv:

```sh
$ goose env
GOOSE_DRIVER="postgres"
GOOSE_DBSTRING="postgresql://dbuser:password1@localhost:5433/testdb?sslmode=disable"
GOOSE_MIGRATION_DIR="./tests/e2e/testdata/postgres/migrations"
NO_COLOR="false"
```

And when not set, here are the defaults:

```sh
$ goose env
GOOSE_DRIVER=""
GOOSE_DBSTRING=""
GOOSE_MIGRATION_DIR="."
NO_COLOR="false"
```

Closes #419