### PR TITLE
Clickhouse: set mutations_sync 2 at delete version to avoid apply down migration twice

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -322,7 +322,7 @@ func (m ClickHouseDialect) migrationSQL() string {
 }
 
 func (m ClickHouseDialect) deleteVersionSQL() string {
-	return fmt.Sprintf("ALTER TABLE %s DELETE WHERE version_id = $1", TableName())
+	return fmt.Sprintf("ALTER TABLE %s DELETE WHERE version_id = $1 SETTINGS mutations_sync = 2", TableName())
 }
 
 ////////////////////////////

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.17
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.2.0
-	github.com/avast/retry-go/v4 v4.3.2
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/jackc/pgx/v4 v4.17.2
@@ -56,6 +55,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20220927061507-ef77025ab5aa // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/avast/retry-go/v4 v4.3.2 h1:x4sTEu3jSwr7zNjya8NTdIN+U88u/jtO/q3OupBoDtM=
-github.com/avast/retry-go/v4 v4.3.2/go.mod h1:rg6XFaiuFYII0Xu3RDbZQkxCofFwruZKW8oEF1jpWiU=
 github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=


### PR DESCRIPTION
Got an error for `down-to` command, steps for reproduce:

1. Setup test env by blog post
https://pressly.github.io/goose/blog/2022/improving-clickhouse/#getting-started
2. Add one more migration file
```
≻ cat tests/clickhouse/testdata/migrations/00004_d.sql 
-- +goose Up
ALTER TABLE clickstream ADD COLUMN foo String;

-- +goose Down
ALTER TABLE clickstream DROP COLUMN foo;
```
3.  Up version
```
≻ GOOSE_DRIVER=clickhouse \
          GOOSE_DBSTRING="tcp://clickuser:password1@localhost:9000/clickdb" \
          GOOSE_MIGRATION_DIR="tests/clickhouse/testdata/migrations" \
          ./goose up
2023/01/26 12:23:15 OK   00004_d.sql (6.82ms)
2023/01/26 12:23:15 goose: no migrations to run. current version: 4
```
4. Down-to version 2
```
≻ GOOSE_DRIVER=clickhouse \
          GOOSE_DBSTRING="tcp://clickuser:password1@localhost:9000/clickdb" \
          GOOSE_MIGRATION_DIR="tests/clickhouse/testdata/migrations" \
          ./goose down-to 2
2023/01/26 12:23:18 OK   00004_d.sql (12.85ms)
2023/01/26 12:23:18 goose run: ERROR 00004_d.sql: failed to run SQL migration: failed to execute SQL query "ALTER TABLE clickstream DROP COLUMN foo;\n": code: 10, message: Wrong column name. Cannot find column `foo` to drop
```

Expected:
```
version 2, no error
```

Actual:
```
00004_d.sql down migrations applied twice
```

Fix:

```
set mutations_sync = 2 for delete version query (ALTER ... DELETE) to execute query synchronously 
```