### PR TITLE
ci: drop go1.17, add go1.20-rc.3, improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,18 +13,20 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17, 1.18, 1.19]
+        go-version: [1.18, 1.19, '1.20.0-rc.3']
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
       - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v3
+          check-latest: true
+          cache: true
       - name: Check Go code formatting
         run: |
           if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,14 +17,14 @@ jobs:
         dialect: ["postgres", "mysql", "vertica", "clickhouse"]
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
       - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version: "1.19"
           check-latest: true
           cache: true
-      - name: Checkout code
-        uses: actions/checkout@v3
       - name: Run e2e ${{ matrix.dialect }} tests
         run: |
           make test-e2e-${{ matrix.dialect }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,13 +14,12 @@ jobs:
     strategy:
       matrix:
         dialect: ["postgres", "mysql"]
-        go-version: "1.19"
 
     steps:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.19"
           check-latest: true
           cache: true
       - name: Checkout code
@@ -38,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.19"
           check-latest: true
           cache: true
       - name: Run clickhouse test
@@ -53,7 +52,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.19"
           check-latest: true
           cache: true
       - name: Run vertica test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,9 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 2
       matrix:
-        dialect: ["postgres", "mysql"]
+        dialect: ["postgres", "mysql", "vertica", "clickhouse"]
 
     steps:
       - name: Install Go
@@ -27,33 +28,3 @@ jobs:
       - name: Run e2e ${{ matrix.dialect }} tests
         run: |
           make test-e2e-${{ matrix.dialect }}
-  test-clickhouse:
-    name: Run clickhouse tests
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.19"
-          check-latest: true
-          cache: true
-      - name: Run clickhouse test
-        run: make test-clickhouse
-  test-vertica:
-    name: Run vertica tests
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.19"
-          check-latest: true
-          cache: true
-      - name: Run vertica test
-        run: make test-vertica

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         dialect: ["postgres", "mysql"]
-        go-version: 1.19
+        go-version: "1.19"
 
     steps:
       - name: Install Go

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,12 +14,15 @@ jobs:
     strategy:
       matrix:
         dialect: ["postgres", "mysql"]
+        go-version: 1.19
 
     steps:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache: true
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Run e2e ${{ matrix.dialect }} tests
@@ -35,7 +38,9 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache: true
       - name: Run clickhouse test
         run: make test-clickhouse
   test-vertica:
@@ -48,6 +53,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache: true
       - name: Run vertica test
         run: make test-vertica

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
+          check-latest: true
+          cache: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -9,7 +9,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19.x


### PR DESCRIPTION
With a stable go1.20 around the corner, we can start testing the latest release candidate.

This PR drops testing go1.17 in tests, replaced with go1.20-rc.3.