### PR TITLE
ci: add golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: golangci
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+          check-latest: true
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.50.1
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the all caching functionality will be complete disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,11 @@ start-postgres:
 .PHONY: clean
 clean:
 	@find . -type f -name '*.FAIL' -delete
+
+.PHONY: lint
+lint: tools
+	@golangci-lint run ./... --fix
+
+.PHONY: tools
+tools:
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -36,7 +36,10 @@ var (
 
 func main() {
 	flags.Usage = usage
-	flags.Parse(os.Args[1:])
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		log.Fatalf("failed to parse args: %v", err)
+		return
+	}
 
 	if *version {
 		if buildInfo, ok := debug.ReadBuildInfo(); ok && buildInfo != nil && gooseVersion == "" {

--- a/goose_test.go
+++ b/goose_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pressly/goose/v3/internal/check"
 	_ "modernc.org/sqlite"
 )
 
@@ -172,7 +173,7 @@ func TestEmbeddedMigrations(t *testing.T) {
 	}
 
 	SetBaseFS(fsys)
-	SetDialect("sqlite3")
+	check.NoError(t, SetDialect("sqlite3"))
 	t.Cleanup(func() { SetBaseFS(nil) })
 
 	t.Run("Migration cycle", func(t *testing.T) {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -84,11 +84,3 @@ func reflectToInt64(v interface{}) (int64, error) {
 	}
 	return 0, fmt.Errorf("invalid number: must be int64 type: got:%T", v)
 }
-
-func reflectToStr(v interface{}) (string, error) {
-	switch typ := v.(type) {
-	case string:
-		return reflect.ValueOf(typ).String(), nil
-	}
-	return "", fmt.Errorf("invalid string: got:%T", v)
-}

--- a/migrate.go
+++ b/migrate.go
@@ -346,14 +346,14 @@ func createVersionTable(db *sql.DB) error {
 	d := GetDialect()
 
 	if _, err := txn.Exec(d.createVersionTableSQL()); err != nil {
-		txn.Rollback()
+		_ = txn.Rollback()
 		return err
 	}
 
 	version := 0
 	applied := true
 	if _, err := txn.Exec(d.insertVersionSQL(), version, applied); err != nil {
-		txn.Rollback()
+		_ = txn.Rollback()
 		return err
 	}
 

--- a/migration.go
+++ b/migration.go
@@ -164,13 +164,13 @@ func runGoMigration(
 	if fn != nil {
 		// Run go migration function.
 		if err := fn(tx); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("failed to run go migration: %w", err)
 		}
 	}
 	if recordVersion {
 		if err := insertOrDeleteVersion(tx, version, direction); err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("failed to update version: %w", err)
 		}
 	}

--- a/tests/clickhouse/clickhouse_test.go
+++ b/tests/clickhouse/clickhouse_test.go
@@ -21,7 +21,7 @@ func TestClickUpDownAll(t *testing.T) {
 	check.NoError(t, err)
 	t.Cleanup(cleanup)
 
-	goose.SetDialect("clickhouse")
+	check.NoError(t, goose.SetDialect("clickhouse"))
 
 	retryCheckTableMutation := func(table string) func() error {
 		return func() error {
@@ -88,7 +88,7 @@ func TestClickHouseFirstThree(t *testing.T) {
 	check.NoError(t, err)
 	t.Cleanup(cleanup)
 
-	goose.SetDialect("clickhouse")
+	check.NoError(t, goose.SetDialect("clickhouse"))
 
 	err = goose.Up(db, migrationDir)
 	check.NoError(t, err)
@@ -158,7 +158,7 @@ func TestRemoteImportMigration(t *testing.T) {
 	check.NoError(t, err)
 	t.Cleanup(cleanup)
 
-	goose.SetDialect("clickhouse")
+	check.NoError(t, goose.SetDialect("clickhouse"))
 
 	err = goose.Up(db, migrationDir)
 	check.NoError(t, err)

--- a/tests/e2e/allow_missing_test.go
+++ b/tests/e2e/allow_missing_test.go
@@ -321,7 +321,7 @@ func setupTestDB(t *testing.T, version int64) *sql.DB {
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
 
-	goose.SetDialect(*dialect)
+	check.NoError(t, goose.SetDialect(*dialect))
 
 	// Create goose table.
 	current, err := goose.EnsureDBVersion(db)

--- a/tests/e2e/migrations_test.go
+++ b/tests/e2e/migrations_test.go
@@ -17,7 +17,7 @@ func TestMigrateUpWithReset(t *testing.T) {
 
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	goose.SetDialect(*dialect)
+	check.NoError(t, goose.SetDialect(*dialect))
 	migrations, err := goose.CollectMigrations(migrationsDir, 0, goose.MaxVersion)
 	check.NoError(t, err)
 	check.NumberNotZero(t, len(migrations))
@@ -46,7 +46,7 @@ func TestMigrateUpWithRedo(t *testing.T) {
 
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	goose.SetDialect(*dialect)
+	check.NoError(t, goose.SetDialect(*dialect))
 	migrations, err := goose.CollectMigrations(migrationsDir, 0, goose.MaxVersion)
 	check.NoError(t, err)
 
@@ -84,7 +84,7 @@ func TestMigrateUpTo(t *testing.T) {
 	)
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	goose.SetDialect(*dialect)
+	check.NoError(t, goose.SetDialect(*dialect))
 	migrations, err := goose.CollectMigrations(migrationsDir, 0, goose.MaxVersion)
 	check.NoError(t, err)
 	check.NumberNotZero(t, len(migrations))
@@ -106,7 +106,7 @@ func TestMigrateUpByOne(t *testing.T) {
 
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	goose.SetDialect(*dialect)
+	check.NoError(t, goose.SetDialect(*dialect))
 	migrations, err := goose.CollectMigrations(migrationsDir, 0, goose.MaxVersion)
 	check.NoError(t, err)
 	check.NumberNotZero(t, len(migrations))
@@ -137,7 +137,7 @@ func TestMigrateFull(t *testing.T) {
 
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	goose.SetDialect(*dialect)
+	check.NoError(t, goose.SetDialect(*dialect))
 	migrations, err := goose.CollectMigrations(migrationsDir, 0, goose.MaxVersion)
 	check.NoError(t, err)
 	check.NumberNotZero(t, len(migrations))

--- a/tests/e2e/no_versioning_test.go
+++ b/tests/e2e/no_versioning_test.go
@@ -20,7 +20,7 @@ func TestNoVersioning(t *testing.T) {
 	)
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	goose.SetDialect(*dialect)
+	check.NoError(t, goose.SetDialect(*dialect))
 
 	err = goose.Up(db, migrationsDir)
 	check.NoError(t, err)

--- a/tests/vertica/vertica_test.go
+++ b/tests/vertica/vertica_test.go
@@ -26,7 +26,7 @@ func TestVerticaUpDownAll(t *testing.T) {
 	check.NoError(t, err)
 	t.Cleanup(cleanup)
 
-	goose.SetDialect("vertica")
+	check.NoError(t, goose.SetDialect("vertica"))
 
 	goose.SetTableName("goose_db_version")
 


### PR DESCRIPTION
Fix #453 

This PR introduces [golangci-lint](https://github.com/golangci/golangci-lint) to the project, which is run on every push to master/main and on every PR. The full documentation can be [found here](https://golangci-lint.run/), and we can tune it as things come up.

If we don't like it, we'll remove it.

There are also two helpful make targets:

```
make tools
make lint
```

^ this should is effectively what CI will run.

The default linters are already pretty helpful:

```
errcheck
gosimple
govet
ineffassign
staticcheck
typecheck
unused
```