### PR TITLE
fix test race condition; remove verbose global

### DIFF
--- a/internal/sqlparser/parser.go
+++ b/internal/sqlparser/parser.go
@@ -89,7 +89,7 @@ var bufferPool = sync.Pool{
 // within a statement. For these cases, we provide the explicit annotations
 // 'StatementBegin' and 'StatementEnd' to allow the script to
 // tell us to ignore semicolons.
-func ParseSQLMigration(r io.Reader, direction, verbose bool) (stmts []string, useTx bool, err error) {
+func ParseSQLMigration(r io.Reader, direction Direction, verbose bool) (stmts []string, useTx bool, err error) {
 	scanBufPtr := bufferPool.Get().(*[]byte)
 	scanBuf := *scanBufPtr
 	defer bufferPool.Put(scanBufPtr)
@@ -120,7 +120,7 @@ func ParseSQLMigration(r io.Reader, direction, verbose bool) (stmts []string, us
 				case start:
 					sm.set(gooseUp)
 				default:
-					return nil, false, fmt.Errorf("duplicate '-- +goose Up' annotations; stateMachine=%v, see https://github.com/pressly/goose#sql-migrations", sm)
+					return nil, false, fmt.Errorf("duplicate '-- +goose Up' annotations; stateMachine=%d, see https://github.com/pressly/goose#sql-migrations", sm.state)
 				}
 				continue
 
@@ -129,7 +129,7 @@ func ParseSQLMigration(r io.Reader, direction, verbose bool) (stmts []string, us
 				case gooseUp, gooseStatementEndUp:
 					sm.set(gooseDown)
 				default:
-					return nil, false, fmt.Errorf("must start with '-- +goose Up' annotation, stateMachine=%v, see https://github.com/pressly/goose#sql-migrations", sm)
+					return nil, false, fmt.Errorf("must start with '-- +goose Up' annotation, stateMachine=%d, see https://github.com/pressly/goose#sql-migrations", sm.state)
 				}
 				continue
 
@@ -140,7 +140,7 @@ func ParseSQLMigration(r io.Reader, direction, verbose bool) (stmts []string, us
 				case gooseDown, gooseStatementEndDown:
 					sm.set(gooseStatementBeginDown)
 				default:
-					return nil, false, fmt.Errorf("'-- +goose StatementBegin' must be defined after '-- +goose Up' or '-- +goose Down' annotation, stateMachine=%v, see https://github.com/pressly/goose#sql-migrations", sm)
+					return nil, false, fmt.Errorf("'-- +goose StatementBegin' must be defined after '-- +goose Up' or '-- +goose Down' annotation, stateMachine=%d, see https://github.com/pressly/goose#sql-migrations", sm.state)
 				}
 				continue
 

--- a/internal/sqlparser/parser.go
+++ b/internal/sqlparser/parser.go
@@ -54,7 +54,7 @@ func (m *stateMachine) get() parserState {
 }
 
 func (m *stateMachine) set(new parserState) {
-	m.print("StateMachine: %d => %d", m.state, new)
+	m.print("set %d => %d", m.state, new)
 	m.state = new
 }
 

--- a/internal/sqlparser/parser.go
+++ b/internal/sqlparser/parser.go
@@ -49,13 +49,13 @@ func newStateMachine(begin parserState, verbose bool) *stateMachine {
 	}
 }
 
-func (m *stateMachine) get() parserState {
-	return m.state
+func (s *stateMachine) get() parserState {
+	return s.state
 }
 
-func (m *stateMachine) set(new parserState) {
-	m.print("set %d => %d", m.state, new)
-	m.state = new
+func (s *stateMachine) set(new parserState) {
+	s.print("set %d => %d", s.state, new)
+	s.state = new
 }
 
 const (
@@ -63,9 +63,9 @@ const (
 	resetColor = "\033[00m"
 )
 
-func (m *stateMachine) print(msg string, args ...interface{}) {
+func (s *stateMachine) print(msg string, args ...interface{}) {
 	msg = "StateMachine: " + msg
-	if m.verbose {
+	if s.verbose {
 		log.Printf(grayColor+msg+resetColor, args...)
 	}
 }

--- a/internal/sqlparser/parser.go
+++ b/internal/sqlparser/parser.go
@@ -54,7 +54,7 @@ func (m *stateMachine) get() parserState {
 }
 
 func (m *stateMachine) set(new parserState) {
-	m.print("StateMachine: %v => %v", m.state, new)
+	m.print("StateMachine: %d => %d", m.state, new)
 	m.state = new
 }
 

--- a/migration.go
+++ b/migration.go
@@ -61,8 +61,7 @@ func (m *Migration) run(db *sql.DB, direction bool) error {
 		}
 		defer f.Close()
 
-		sqlparser.SetVersbose(verbose)
-		statements, useTx, err := sqlparser.ParseSQLMigration(f, direction)
+		statements, useTx, err := sqlparser.ParseSQLMigration(f, sqlparser.FromBool(direction), verbose)
 		if err != nil {
 			return fmt.Errorf("ERROR %v: failed to parse SQL migration file: %w", filepath.Base(m.Source), err)
 		}

--- a/tests/e2e/allow_missing_test.go
+++ b/tests/e2e/allow_missing_test.go
@@ -321,8 +321,6 @@ func setupTestDB(t *testing.T, version int64) *sql.DB {
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
 
-	check.NoError(t, goose.SetDialect(*dialect))
-
 	// Create goose table.
 	current, err := goose.EnsureDBVersion(db)
 	check.NoError(t, err)

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/internal/check"
 	"github.com/pressly/goose/v3/internal/testdb"
 )
@@ -72,6 +73,11 @@ func TestMain(m *testing.M) {
 	}
 	migrationsDir = filepath.Join("testdata", *dialect, "migrations")
 	seedDir = filepath.Join("testdata", *dialect, "seed")
+
+	if err := goose.SetDialect(*dialect); err != nil {
+		log.Printf("failed to set dialect %q: %v\n", *dialect, err)
+		os.Exit(1)
+	}
 
 	exitCode := m.Run()
 	// Useful for debugging test services.

--- a/tests/e2e/migrations_test.go
+++ b/tests/e2e/migrations_test.go
@@ -17,7 +17,6 @@ func TestMigrateUpWithReset(t *testing.T) {
 
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	check.NoError(t, goose.SetDialect(*dialect))
 	migrations, err := goose.CollectMigrations(migrationsDir, 0, goose.MaxVersion)
 	check.NoError(t, err)
 	check.NumberNotZero(t, len(migrations))
@@ -46,7 +45,6 @@ func TestMigrateUpWithRedo(t *testing.T) {
 
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	check.NoError(t, goose.SetDialect(*dialect))
 	migrations, err := goose.CollectMigrations(migrationsDir, 0, goose.MaxVersion)
 	check.NoError(t, err)
 
@@ -84,7 +82,6 @@ func TestMigrateUpTo(t *testing.T) {
 	)
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	check.NoError(t, goose.SetDialect(*dialect))
 	migrations, err := goose.CollectMigrations(migrationsDir, 0, goose.MaxVersion)
 	check.NoError(t, err)
 	check.NumberNotZero(t, len(migrations))
@@ -106,7 +103,6 @@ func TestMigrateUpByOne(t *testing.T) {
 
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	check.NoError(t, goose.SetDialect(*dialect))
 	migrations, err := goose.CollectMigrations(migrationsDir, 0, goose.MaxVersion)
 	check.NoError(t, err)
 	check.NumberNotZero(t, len(migrations))
@@ -137,7 +133,6 @@ func TestMigrateFull(t *testing.T) {
 
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	check.NoError(t, goose.SetDialect(*dialect))
 	migrations, err := goose.CollectMigrations(migrationsDir, 0, goose.MaxVersion)
 	check.NoError(t, err)
 	check.NumberNotZero(t, len(migrations))

--- a/tests/e2e/no_versioning_test.go
+++ b/tests/e2e/no_versioning_test.go
@@ -20,7 +20,6 @@ func TestNoVersioning(t *testing.T) {
 	)
 	db, err := newDockerDB(t)
 	check.NoError(t, err)
-	check.NoError(t, goose.SetDialect(*dialect))
 
 	err = goose.Up(db, migrationsDir)
 	check.NoError(t, err)


### PR DESCRIPTION
I noticed a race condition in the tests, having to do with setting verbose globally in `sqlparser`.

https://github.com/pressly/goose/actions/runs/4032205783/jobs/6931938495

This PR updates the internal/sqlparser. Changes the `stateMachine` to a well-defined struct which we pass around as a pointer. The caller sets the direction (well-defined) and the verbose bool, no more global state in sqlparser.

For convenience, one can set env `DEBUG_TEST=true` in tests to see those verbose parsing statements.

```sh
DEBUG_TEST=true go test -race -count=1 -v -timeout=10m ./internal/sqlparser/...
```