### PR TITLE
[wip] - pg_dump schema (postgres only)

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/internal/cfg"
+	"github.com/pressly/goose/v3/internal/pgutil"
 )
 
 var (
@@ -137,6 +138,29 @@ func main() {
 	if *noVersioning {
 		options = append(options, goose.WithNoVersioning())
 	}
+
+	switch command {
+	case "dump":
+		if driver != "pgx" {
+			log.Fatalln("this command is only available for postgres")
+		}
+		connOptions, err := pgutil.NewConnectionOptions(dbstring)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		var clean bool
+		if len(args) == 4 && args[3] == "--clean" { // LOL
+			clean = true
+		}
+		out, err := pgutil.Dump(connOptions, clean)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		// TODO(mf): dump to stdout or to a file?
+		fmt.Fprintln(os.Stdout, out)
+		return
+	}
+
 	if err := goose.RunWithOptions(
 		command,
 		db,

--- a/internal/pgutil/pgutil.go
+++ b/internal/pgutil/pgutil.go
@@ -72,7 +72,7 @@ func cleanup(r io.Reader) (string, error) {
 	// TODO(mf): is there a bette way to do this?
 	// kudos: https://stackoverflow.com/a/71979673/3562607
 	result := rg.ReplaceAllString(b.String(), "\n\n")
-	return strings.TrimSpace(result), nil
+	return "\n" + strings.TrimSpace(result) + "\n", nil
 }
 
 func dump(w io.Writer, options ConnectionOptions) error {
@@ -139,7 +139,6 @@ func runPgDump(w io.Writer, pgDumpPath string, connOptions ConnectionOptions) er
 	cmd.Env = append(cmd.Env, "PGPASSWORD="+connOptions.Password)
 	cmd.Stdout = w
 	cmd.Stderr = os.Stderr
-	fmt.Println(cmd.String())
 	return cmd.Run()
 
 }

--- a/internal/pgutil/pgutil.go
+++ b/internal/pgutil/pgutil.go
@@ -1,0 +1,149 @@
+package pgutil
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+func Dump(options ConnectionOptions, clean bool) (string, error) {
+	var b bytes.Buffer
+	if err := dump(&b, options); err != nil {
+		return "", err
+	}
+	if clean {
+		return cleanup(&b)
+	}
+	return b.String(), nil
+}
+
+var matchIgnorePrefix = []string{
+	"--",
+	"COMMENT ON",
+	"REVOKE",
+	"GRANT",
+	"SET",
+	"ALTER DEFAULT PRIVILEGES",
+}
+
+var matchIgnoreContains = []string{
+	"ALTER DEFAULT PRIVILEGES",
+	"OWNER TO",
+}
+
+func ignore(input string) bool {
+	for _, v := range matchIgnorePrefix {
+		if strings.HasPrefix(input, v) {
+			return true
+		}
+	}
+	for _, v := range matchIgnoreContains {
+		if strings.Contains(input, v) {
+			return true
+		}
+	}
+	return false
+}
+
+var rg = regexp.MustCompile(`(\r\n?|\n){2,}`)
+
+func cleanup(r io.Reader) (string, error) {
+	var b strings.Builder
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := sc.Text()
+		if ignore(line) {
+			continue
+		}
+		if _, err := b.WriteString(line + "\n"); err != nil {
+			return "", fmt.Errorf("failed to write output: %w", err)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return "", err
+	}
+	// TODO(mf): is there a bette way to do this?
+	// kudos: https://stackoverflow.com/a/71979673/3562607
+	result := rg.ReplaceAllString(b.String(), "\n\n")
+	return strings.TrimSpace(result), nil
+}
+
+func dump(w io.Writer, options ConnectionOptions) error {
+	pgDumpPath, err := exec.LookPath("pg_dump")
+	if err != nil && !errors.Is(err, exec.ErrNotFound) {
+		return err
+	}
+	if pgDumpPath != "" {
+		return runPgDump(w, pgDumpPath, options)
+	}
+	dockerPath, err := exec.LookPath("docker")
+	if err != nil && !errors.Is(err, exec.ErrNotFound) {
+		return err
+	}
+	if dockerPath != "" {
+		return runDockerPgDump(dockerPath)
+	}
+	return fmt.Errorf("failed to find at least one exectuable: pg_dump, docker")
+}
+
+type ConnectionOptions struct {
+	DBname   string
+	Username string
+	Host     string
+	Port     string
+	Password string
+}
+
+func NewConnectionOptions(raw string) (ConnectionOptions, error) {
+	var opt ConnectionOptions
+	u, err := url.Parse(raw)
+	if err != nil {
+		return opt, err
+	}
+	if u.User == nil {
+		return opt, fmt.Errorf("invalid postgres connection string: missing username and password information")
+	}
+	// TODO(mf): we could ask the user for password with a prompt here.
+	pass, ok := u.User.Password()
+	if !ok {
+		return opt, fmt.Errorf("invalid postgres connection string: missing password information")
+	}
+	opt.Username = u.User.Username()
+	opt.Password = pass
+	opt.Host = u.Hostname()
+	opt.Port = u.Port()
+	opt.DBname = strings.TrimPrefix(u.Path, "/")
+	// TODO(mf): What about u.RawQuery to get at options after the ? .."sslmode=disable"
+	return opt, nil
+}
+
+func (c ConnectionOptions) Args() []string {
+	return []string{
+		"--dbname=" + c.DBname,
+		"--host=" + c.Host,
+		"--port=" + c.Port,
+		"--username=" + c.Username,
+	}
+}
+
+func runPgDump(w io.Writer, pgDumpPath string, connOptions ConnectionOptions) error {
+	args := append(connOptions.Args(), "--schema-only")
+	cmd := exec.Command(pgDumpPath, args...)
+	cmd.Env = append(cmd.Env, "PGPASSWORD="+connOptions.Password)
+	cmd.Stdout = w
+	cmd.Stderr = os.Stderr
+	fmt.Println(cmd.String())
+	return cmd.Run()
+
+}
+
+func runDockerPgDump(dockerPath string) error {
+	return errors.New("unimplemented")
+}


### PR DESCRIPTION
Close #278

This PR adds a `goose dump` command that shells out to either `pg_dump` or `docker` (latest stable postgres version). By default this dumps with `--schema-only` and preserves the raw output, but there is an optional goose flag `--clean` that effectively does what https://github.com/pressly/goose/issues/345#issuecomment-1121375847 describes:

```
pg_dump --schema-only |\
    grep -v -e '^--' -e '^COMMENT ON' -e '^REVOKE' -e '^GRANT' -e '^SET' \
    -e 'ALTER DEFAULT PRIVILEGES' -e 'OWNER TO' |\
    cat -s
````

### Example

From the root of this repository:

```sh
$ make docker-start-postgres

$ export GOOSE_MIGRATION_DIR=./examples/sql-migrations
$ go run ./cmd/goose up
$ go run ./cmd/goose status
2023/01/28 16:27:17     Applied At                  Migration
2023/01/28 16:27:17     =======================================
2023/01/28 16:27:17     Sat Jan 28 21:19:06 2023 -- 00001_create_users_table.sql
2023/01/28 16:27:17     Sat Jan 28 21:19:06 2023 -- 00002_rename_root.sql
2023/01/28 16:27:17     Sat Jan 28 21:19:06 2023 -- 00003_no_transaction.sql
```

Then dump the schema based on the example migrations with `pg_dump`, the sha256 is:

`6380fab48d773d69abcfa38a6c451b704b4b466e2b272b3f96778a2462f9a998`

And the resulting `go run ./cmd/goose dump --clean` command:

``6380fab48d773d69abcfa38a6c451b704b4b466e2b272b3f96778a2462f9a998``

```sql
SELECT pg_catalog.set_config('search_path', '', false);

CREATE TABLE public.goose_db_version (
    id integer NOT NULL,
    version_id bigint NOT NULL,
    is_applied boolean NOT NULL,
    tstamp timestamp without time zone DEFAULT now()
);

CREATE SEQUENCE public.goose_db_version_id_seq
    AS integer
    START WITH 1
    INCREMENT BY 1
    NO MINVALUE
    NO MAXVALUE
    CACHE 1;

ALTER SEQUENCE public.goose_db_version_id_seq OWNED BY public.goose_db_version.id;

CREATE TABLE public.post (
    id integer NOT NULL,
    title text,
    body text
);

CREATE TABLE public.users (
    id integer NOT NULL,
    username text,
    name text,
    surname text
);

ALTER TABLE ONLY public.goose_db_version ALTER COLUMN id SET DEFAULT nextval('public.goose_db_version_id_seq'::regclass);

ALTER TABLE ONLY public.goose_db_version
    ADD CONSTRAINT goose_db_version_pkey PRIMARY KEY (id);

ALTER TABLE ONLY public.post
    ADD CONSTRAINT post_pkey PRIMARY KEY (id);

ALTER TABLE ONLY public.users
    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
```

