### PR TITLE
remove `tls` override from mysql dsn normalizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Options:
   -allow-missing
     	applies missing (out-of-order) migrations
   -certfile string
-    	file path to root CA's certificates in pem format (only support on mysql)
+    	file path to root CA's certificates in pem format (only supported on mysql)
   -dir string
     	directory with migration files (default ".")
   -h	print help
@@ -91,9 +91,9 @@ Options:
     	apply migration commands with no versioning, in file order, from directory pointed to
   -s	use sequential numbering for new migrations
   -ssl-cert string
-    	file path to SSL certificates in pem format (only support on mysql)
+    	file path to SSL certificates in pem format (only supported on mysql)
   -ssl-key string
-    	file path to SSL key in pem format (only support on mysql)
+    	file path to SSL key in pem format (only supported on mysql)
   -table string
     	migrations table name (default "goose_db_version")
   -v	enable verbose mode

--- a/cmd/goose/driver_mysql.go
+++ b/cmd/goose/driver_mysql.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"regexp"
 
 	"github.com/go-sql-driver/mysql"
 	_ "github.com/ziutek/mymysql/godrv"
@@ -21,7 +20,7 @@ import (
 // type.
 func normalizeDBString(driver string, str string, certfile string, sslcert string, sslkey string) string {
 	if driver == "mysql" {
-		var isTLS = certfile != ""
+		isTLS := certfile != ""
 		if isTLS {
 			if err := registerTLSConfig(certfile, sslcert, sslkey); err != nil {
 				log.Fatalf("goose run: %v", err)
@@ -38,12 +37,7 @@ func normalizeDBString(driver string, str string, certfile string, sslcert strin
 
 const tlsConfigKey = "custom"
 
-var tlsReg = regexp.MustCompile(`(\?|&)tls=[^&]*(?:&|$)`)
-
 func normalizeMySQLDSN(dsn string, tls bool) (string, error) {
-	// If we are sharing a DSN in a different environment, it may contain a TLS
-	// setting key with a value name that is not "custom," so clear it.
-	dsn = tlsReg.ReplaceAllString(dsn, `$1`)
 	config, err := mysql.ParseDSN(dsn)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fixes https://github.com/pressly/goose/issues/460

This PR removes the overriding of the `tls` parameter in the MySQL DSN. If I understand the code correctly, `goose` want's to use the `custom` TLS mode, if a cert file is provided. In the other cases, it should just let the DSN dictate what TLS mode to use. Please let me know what you think about this. For me, at least, this allows me to set `tls` to `true` again.