### PR TITLE
Draft: exclude Go test files from migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,9 @@ func Down(tx *sql.Tx) error {
 }
 ```
 
+Note that Go migration files must begin with a numeric value, followed by an
+underscore, and must not end with `*_test.go`.
+
 # Development
 
 This can be used to build local `goose` binaries without having the latest Go version installed locally.

--- a/migrate.go
+++ b/migrate.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"runtime"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -232,6 +233,10 @@ func collectMigrationsFS(fsys fs.FS, dirpath string, current, target int64) (Mig
 		v, err := NumericComponent(file)
 		if err != nil {
 			continue // Skip any files that don't have version prefix.
+		}
+
+		if strings.HasSuffix(file, "_test.go") {
+			continue // Skip Go test files.
 		}
 
 		// Skip migrations already existing migrations registered via goose.AddMigration().


### PR DESCRIPTION
Database migrations reflect a critical part of an application's workflow. Adding tests for individual migrations following Golang's best practices of reusing the original source file name + appending `*_test.go` seems to be a reasonable choice.

However, reusing an existing file name that starts with a given numeric value and an underscore will cause problems with Goose, as the migration collector treats it as a regular migrations file, hence failing with:

```
panic: goose: duplicate version N detected:
```

This change suggests to blocklist any Go source files ending with the suffix `*_test.go` in order to mitigate this issue. The naming convention for Go migration files is also mentioned in the README.