### PR TITLE
[WIP] - Add exclusive session level advisory lock (postgres only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ["1.18.x", "1.19.x", "1.20.x"]
+        go-version: ["1.19.x", "1.20.x"]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 # Local testing
 .envrc
 *.FAIL
+
+/x

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -35,7 +35,7 @@ var (
 	sslkey       = flags.String("ssl-key", "", "file path to SSL key in pem format (only support on mysql)")
 	noVersioning = flags.Bool("no-versioning", false, "apply migration commands with no versioning, in file order, from directory pointed to")
 	noColor      = flags.Bool("no-color", false, "disable color output (NO_COLOR env variable supported)")
-	lockSession  = flags.String("lock", "none", "acquire exclusive session level advisory lock before running migrations (postgres only)")
+	lock         = flags.String("lock", "none", "lock mode to use when running migrations: none (default) or session")
 )
 var (
 	gooseVersion = ""
@@ -149,7 +149,7 @@ func main() {
 	if *noVersioning {
 		options = append(options, goose.WithNoVersioning())
 	}
-	switch *lockSession {
+	switch *lock {
 	case "none":
 		options = append(options, goose.WithLock(goose.LockModeNone))
 	case "session":
@@ -157,7 +157,7 @@ func main() {
 	case "transaction":
 		log.Fatalf("goose: lock=transaction is not supported yet, use lock=session or omit flag to disable locking")
 	default:
-		log.Fatalf(`goose: invalid lock mode: %s, must be one of "none", "session", "transaction"`, *lockSession)
+		log.Fatalf(`goose: invalid lock mode: %s, must be one of "none", "session", "transaction"`, *lock)
 	}
 	if err := goose.RunWithOptions(
 		command,

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -35,6 +35,7 @@ var (
 	sslkey       = flags.String("ssl-key", "", "file path to SSL key in pem format (only support on mysql)")
 	noVersioning = flags.Bool("no-versioning", false, "apply migration commands with no versioning, in file order, from directory pointed to")
 	noColor      = flags.Bool("no-color", false, "disable color output (NO_COLOR env variable supported)")
+	lock         = flags.Bool("lock", false, "acquire a lock before running migrations (only supported on postgres)")
 )
 var (
 	gooseVersion = ""
@@ -147,6 +148,9 @@ func main() {
 	}
 	if *noVersioning {
 		options = append(options, goose.WithNoVersioning())
+	}
+	if *lock {
+		options = append(options, goose.WithLock())
 	}
 	if err := goose.RunWithOptions(
 		command,

--- a/down.go
+++ b/down.go
@@ -35,6 +35,9 @@ func Down(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 			if err := store.UnlockSession(ctx, conn); err != nil {
 				retErr = multierr.Append(retErr, err)
 			}
+			if err := conn.Close(); err != nil {
+				retErr = multierr.Append(retErr, err)
+			}
 		}()
 	case LockModeAdvisoryTransaction:
 		return errors.New("advisory level transaction lock is not supported")
@@ -83,6 +86,9 @@ func DownTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) (retErr 
 		}
 		defer func() {
 			if err := store.UnlockSession(ctx, conn); err != nil {
+				retErr = multierr.Append(retErr, err)
+			}
+			if err := conn.Close(); err != nil {
 				retErr = multierr.Append(retErr, err)
 			}
 		}()

--- a/down.go
+++ b/down.go
@@ -3,6 +3,7 @@ package goose
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"go.uber.org/multierr"
@@ -21,7 +22,8 @@ func Down(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 		return err
 	}
 
-	if option.lock {
+	switch option.lockMode {
+	case LockModeAdvisorySession:
 		conn, err := db.Conn(ctx)
 		if err != nil {
 			return err
@@ -34,6 +36,8 @@ func Down(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 				retErr = multierr.Append(retErr, err)
 			}
 		}()
+	case LockModeAdvisoryTransaction:
+		return errors.New("advisory level transaction lock is not supported")
 	}
 
 	if option.noVersioning {
@@ -68,7 +72,8 @@ func DownTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) (retErr 
 		return err
 	}
 
-	if option.lock {
+	switch option.lockMode {
+	case LockModeAdvisorySession:
 		conn, err := db.Conn(ctx)
 		if err != nil {
 			return err
@@ -81,6 +86,8 @@ func DownTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) (retErr 
 				retErr = multierr.Append(retErr, err)
 			}
 		}()
+	case LockModeAdvisoryTransaction:
+		return errors.New("advisory level transaction lock is not supported")
 	}
 
 	if option.noVersioning {

--- a/examples/sql-migrations/00003_no_transaction.sql
+++ b/examples/sql-migrations/00003_no_transaction.sql
@@ -7,7 +7,5 @@ CREATE TABLE post (
     PRIMARY KEY(id)
 );
 
-SELECT pg_sleep(30);
-
 -- +goose Down
 DROP TABLE post;

--- a/examples/sql-migrations/00003_no_transaction.sql
+++ b/examples/sql-migrations/00003_no_transaction.sql
@@ -7,5 +7,7 @@ CREATE TABLE post (
     PRIMARY KEY(id)
 );
 
+SELECT pg_sleep(30);
+
 -- +goose Down
 DROP TABLE post;

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pressly/goose/v3
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.7.0

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/jackc/pgx/v5 v5.3.1
 	github.com/ory/dockertest/v3 v3.9.1
+	github.com/sethvargo/go-retry v0.2.4
 	github.com/vertica/vertica-sql-go v1.3.1
 	github.com/ziutek/mymysql v1.5.4
+	go.uber.org/multierr v1.10.0
 	modernc.org/sqlite v1.21.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/sethvargo/go-retry v0.2.4 h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08Ocec=
+github.com/sethvargo/go-retry v0.2.4/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -184,6 +186,8 @@ go.opentelemetry.io/otel v1.14.0 h1:/79Huy8wbf5DnIPhemGB+zEPVwnN6fuQybr/SRXa6hM=
 go.opentelemetry.io/otel v1.14.0/go.mod h1:o4buv+dJzx8rohcUeRmWUZhqupFvzWis188WlggnNeU=
 go.opentelemetry.io/otel/trace v1.14.0 h1:wp2Mmvj41tDsyAJXiWDWpfNsOiIyd38fy85pyKcFq/M=
 go.opentelemetry.io/otel/trace v1.14.0/go.mod h1:8avnQLK+CG77yNLUae4ea2JDQ6iT+gozhnZjy/rw9G8=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/dialect/dialectquery/dialectquery.go
+++ b/internal/dialect/dialectquery/dialectquery.go
@@ -2,6 +2,9 @@ package dialectquery
 
 // Querier is the interface that wraps the basic methods to create a dialect
 // specific query.
+//
+// Important, if an implementation does not support a method, it should return
+// an empty string and the caller should handle it as an error.
 type Querier interface {
 	// CreateTable returns the SQL query string to create the db version table.
 	CreateTable() string

--- a/internal/dialect/dialectquery/postgres.go
+++ b/internal/dialect/dialectquery/postgres.go
@@ -38,3 +38,24 @@ func (p *Postgres) ListMigrations() string {
 	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, p.Table)
 }
+
+// AdvisoryLockSession returns the query to lock the database using an exclusive
+// session level advisory lock.
+func (p *Postgres) AdvisoryLockSession() string {
+	return `SELECT pg_advisory_lock($1)`
+}
+
+// AdvisoryUnlockSession returns the query to release  an exclusive session level
+// advisory lock.
+func (p *Postgres) AdvisoryUnlockSession() string {
+	return `SELECT pg_advisory_unlock($1)`
+}
+
+// AdvisoryLockTransaction returns the query to lock the database using an exclusive
+// transaction level advisory lock.
+//
+// The lock is automatically released at the end of the current transaction and cannot
+// be released explicitly.
+func (p *Postgres) AdvisoryLockTransaction() string {
+	return `SELECT pg_advisory_xact_lock($1)`
+}

--- a/internal/dialect/dialectquery/postgres.go
+++ b/internal/dialect/dialectquery/postgres.go
@@ -45,7 +45,7 @@ func (p *Postgres) AdvisoryLockSession() string {
 	return `SELECT pg_advisory_lock($1)`
 }
 
-// AdvisoryUnlockSession returns the query to release  an exclusive session level
+// AdvisoryUnlockSession returns the query to release an exclusive session level
 // advisory lock.
 func (p *Postgres) AdvisoryUnlockSession() string {
 	return `SELECT pg_advisory_unlock($1)`

--- a/internal/dialect/locker.go
+++ b/internal/dialect/locker.go
@@ -1,0 +1,83 @@
+package dialect
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"hash/crc64"
+
+	"github.com/pressly/goose/v3/internal/dialect/dialectquery"
+	"github.com/sethvargo/go-retry"
+)
+
+var (
+	// defaultLockID is the id used to lock the database for migrations. It is a
+	// crc64 hash of the string "goose". This is used to prevent multiple
+	// goose processes from running migrations at the same time.
+	//
+	// 5887940537704921958
+	defaultLockID = crc64.Checksum([]byte("goose"), crc64.MakeTable(crc64.ECMA))
+
+	// ErrLockNotImplemented is returned when the database does not support locking.
+	ErrLockNotImplemented = errors.New("lock not implemented")
+)
+
+// Locker defines the methods to lock and unlock the database.
+//
+// Locking is an experimental feature and the underlying implementation
+// may change in the future.
+//
+// The only database that currently supports locking is Postgres.
+//
+// Other databases will return ErrLockNotImplemented.
+type Locker interface {
+	// LockSession and UnlockSession are used to lock the database for the
+	// duration of a session.
+	//
+	// The session is defined as the duration of a single connection.
+	LockSession(ctx context.Context, conn *sql.Conn) error
+	UnlockSession(ctx context.Context, conn *sql.Conn) error
+
+	// LockTransaction is used to lock the database for the duration of a
+	// transaction.
+	LockTransaction(ctx context.Context, tx *sql.Tx) error
+}
+
+func (s *store) LockSession(ctx context.Context, conn *sql.Conn) error {
+	switch t := s.querier.(type) {
+	case *dialectquery.Postgres:
+		return retry.Do(ctx, s.retry, func(ctx context.Context) error {
+			if _, err := conn.ExecContext(ctx, t.AdvisoryLockSession(), defaultLockID); err != nil {
+				return retry.RetryableError(err)
+			}
+			return nil
+		})
+	}
+	return ErrLockNotImplemented
+}
+
+func (s *store) UnlockSession(ctx context.Context, conn *sql.Conn) error {
+	switch t := s.querier.(type) {
+	case *dialectquery.Postgres:
+		return retry.Do(ctx, s.retry, func(ctx context.Context) error {
+			if _, err := conn.ExecContext(ctx, t.AdvisoryUnlockSession(), defaultLockID); err != nil {
+				return retry.RetryableError(err)
+			}
+			return nil
+		})
+	}
+	return ErrLockNotImplemented
+}
+
+func (s *store) LockTransaction(ctx context.Context, tx *sql.Tx) error {
+	switch t := s.querier.(type) {
+	case *dialectquery.Postgres:
+		return retry.Do(ctx, s.retry, func(ctx context.Context) error {
+			if _, err := tx.ExecContext(ctx, t.AdvisoryLockTransaction(), defaultLockID); err != nil {
+				return retry.RetryableError(err)
+			}
+			return nil
+		})
+	}
+	return ErrLockNotImplemented
+}

--- a/internal/dialect/store.go
+++ b/internal/dialect/store.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pressly/goose/v3/internal/dialect/dialectquery"
+	"github.com/sethvargo/go-retry"
 )
 
 // Store is the interface that wraps the basic methods for a database dialect.
@@ -44,6 +45,10 @@ type Store interface {
 	//
 	// If there are no migrations, an empty slice is returned with no error.
 	ListMigrations(ctx context.Context, db *sql.DB) ([]*ListMigrationsResult, error)
+
+	// Locker defines the methods for locking the database. Some databases
+	// do not support locking, in which case ErrLockNotImplemented is returned.
+	Locker
 }
 
 // NewStore returns a new Store for the given dialect.
@@ -74,7 +79,13 @@ func NewStore(d Dialect, table string) (Store, error) {
 	default:
 		return nil, fmt.Errorf("unknown querier dialect: %v", d)
 	}
-	return &store{querier: querier}, nil
+	r := retry.NewFibonacci(1 * time.Second)
+	r = retry.WithCappedDuration(5*time.Second, r)
+	r = retry.WithMaxDuration(30*time.Second, r)
+	return &store{
+		querier: querier,
+		retry:   r,
+	}, nil
 }
 
 type GetMigrationResult struct {
@@ -89,6 +100,7 @@ type ListMigrationsResult struct {
 
 type store struct {
 	querier dialectquery.Querier
+	retry   retry.Backoff
 }
 
 var _ Store = (*store)(nil)

--- a/internal/migrationstats/migration_sql.go
+++ b/internal/migrationstats/migration_sql.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/pressly/goose/v3/internal/sqlparser"
 )
@@ -15,7 +14,7 @@ type sqlMigration struct {
 }
 
 func parseSQLFile(r io.Reader, debug bool) (*sqlMigration, error) {
-	by, err := ioutil.ReadAll(r)
+	by, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/redo.go
+++ b/redo.go
@@ -34,6 +34,9 @@ func Redo(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 			if err := store.UnlockSession(ctx, conn); err != nil {
 				retErr = multierr.Append(retErr, err)
 			}
+			if err := conn.Close(); err != nil {
+				retErr = multierr.Append(retErr, err)
+			}
 		}()
 	case LockModeAdvisoryTransaction:
 		return errors.New("advisory level transaction lock is not supported")

--- a/redo.go
+++ b/redo.go
@@ -3,6 +3,7 @@ package goose
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"go.uber.org/multierr"
 )
@@ -20,7 +21,8 @@ func Redo(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 		return err
 	}
 
-	if option.lock {
+	switch option.lockMode {
+	case LockModeAdvisorySession:
 		conn, err := db.Conn(ctx)
 		if err != nil {
 			return err
@@ -33,6 +35,8 @@ func Redo(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 				retErr = multierr.Append(retErr, err)
 			}
 		}()
+	case LockModeAdvisoryTransaction:
+		return errors.New("advisory level transaction lock is not supported")
 	}
 
 	var (

--- a/reset.go
+++ b/reset.go
@@ -3,6 +3,7 @@ package goose
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -21,7 +22,8 @@ func Reset(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 		return fmt.Errorf("failed to collect migrations: %w", err)
 	}
 
-	if option.lock {
+	switch option.lockMode {
+	case LockModeAdvisorySession:
 		conn, err := db.Conn(ctx)
 		if err != nil {
 			return err
@@ -34,6 +36,8 @@ func Reset(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 				retErr = multierr.Append(retErr, err)
 			}
 		}()
+	case LockModeAdvisoryTransaction:
+		return errors.New("advisory level transaction lock is not supported")
 	}
 
 	if option.noVersioning {

--- a/reset.go
+++ b/reset.go
@@ -35,6 +35,9 @@ func Reset(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 			if err := store.UnlockSession(ctx, conn); err != nil {
 				retErr = multierr.Append(retErr, err)
 			}
+			if err := conn.Close(); err != nil {
+				retErr = multierr.Append(retErr, err)
+			}
 		}()
 	case LockModeAdvisoryTransaction:
 		return errors.New("advisory level transaction lock is not supported")

--- a/status.go
+++ b/status.go
@@ -31,7 +31,8 @@ func Status(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 		return nil
 	}
 
-	if option.lock {
+	switch option.lockMode {
+	case LockModeAdvisorySession:
 		conn, err := db.Conn(ctx)
 		if err != nil {
 			return err
@@ -44,6 +45,8 @@ func Status(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 				retErr = multierr.Append(retErr, err)
 			}
 		}()
+	case LockModeAdvisoryTransaction:
+		return errors.New("advisory level transaction lock is not supported")
 	}
 
 	// must ensure that the version table exists if we're running on a pristine DB

--- a/status.go
+++ b/status.go
@@ -44,6 +44,9 @@ func Status(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 			if err := store.UnlockSession(ctx, conn); err != nil {
 				retErr = multierr.Append(retErr, err)
 			}
+			if err := conn.Close(); err != nil {
+				retErr = multierr.Append(retErr, err)
+			}
 		}()
 	case LockModeAdvisoryTransaction:
 		return errors.New("advisory level transaction lock is not supported")

--- a/up.go
+++ b/up.go
@@ -81,6 +81,9 @@ func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) (retErr er
 			if err := store.UnlockSession(ctx, conn); err != nil {
 				retErr = multierr.Append(retErr, err)
 			}
+			if err := conn.Close(); err != nil {
+				retErr = multierr.Append(retErr, err)
+			}
 		}()
 	case LockModeAdvisoryTransaction:
 		return errors.New("advisory level transaction lock is not supported")

--- a/version.go
+++ b/version.go
@@ -43,6 +43,9 @@ func Version(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 			if err := store.UnlockSession(ctx, conn); err != nil {
 				retErr = multierr.Append(retErr, err)
 			}
+			if err := conn.Close(); err != nil {
+				retErr = multierr.Append(retErr, err)
+			}
 		}()
 	case LockModeAdvisoryTransaction:
 		return errors.New("advisory level transaction lock is not supported")

--- a/version.go
+++ b/version.go
@@ -3,6 +3,7 @@ package goose
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"go.uber.org/multierr"
@@ -29,7 +30,8 @@ func Version(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 		return nil
 	}
 
-	if option.lock {
+	switch option.lockMode {
+	case LockModeAdvisorySession:
 		conn, err := db.Conn(ctx)
 		if err != nil {
 			return err
@@ -42,6 +44,8 @@ func Version(db *sql.DB, dir string, opts ...OptionsFunc) (retErr error) {
 				retErr = multierr.Append(retErr, err)
 			}
 		}()
+	case LockModeAdvisoryTransaction:
+		return errors.New("advisory level transaction lock is not supported")
 	}
 
 	current, err := GetDBVersion(db)


### PR DESCRIPTION
First pass to fix https://github.com/pressly/goose/issues/335

- postgres only with session level advisory lock
- transaction level advisory lock not implemented, likely outside the scope of this PR

The default is no lock mode, but `lock=session` (cli) and `goose.WithLock(...)` (pkg) are now functional.

EDIT: not overly happy with this implementation because it's awkward to thread the `*sql.Conn` through the rest of the functions and the `*Migration` methods. The interface seems fine to start and can be expanded to other databases.

This implementation is functional, but it does mean the max number of connections must be greater than 1. This probably solves the most common use case, but it's not ideal.

The long-term solution is uplifting goose and implementing this properly in a major version alongside https://github.com/pressly/goose/issues/379.

---

`goose` CLI:

```sh
goose ... -lock=session up
```

goose package:

```go

type LockMode int

const (
	LockModeNone LockMode = iota
	LockModeAdvisorySession
	LockModeAdvisoryTransaction
)

goose.WithLock(mode LockMode)
```

- [ ] Need to re-use the connection, otherwise if the `*sql.DB` was set with `db.SetMaxOpenConns(1)` it'll hang
- [ ] Add tests
- [ ] Remove the retry logic
- [ ] Remove `pg_advisory_unlock` value check
- [ ] If adding a provider abstraction, need to add a mutex to guard the lock 