### PR TITLE
Add support for azuresql dialect

### DIFF
--- a/db.go
+++ b/db.go
@@ -22,7 +22,7 @@ func OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
 	}
 
 	switch driver {
-	case "postgres", "pgx", "sqlite3", "sqlite", "mysql", "sqlserver", "clickhouse", "vertica":
+	case "postgres", "pgx", "sqlite3", "sqlite", "mysql", "sqlserver", "clickhouse", "vertica", "azuresql":
 		return sql.Open(driver, dbstring)
 	default:
 		return nil, fmt.Errorf("unsupported driver %s", driver)

--- a/dialect.go
+++ b/dialect.go
@@ -22,7 +22,7 @@ func SetDialect(s string) error {
 		d = dialect.Mysql
 	case "sqlite3", "sqlite":
 		d = dialect.Sqlite3
-	case "mssql":
+	case "mssql", "azuresql":
 		d = dialect.Sqlserver
 	case "redshift":
 		d = dialect.Redshift


### PR DESCRIPTION
The MSSQL driver has different driver names based on whether your connecting with a ManagedIdentity or by password.  

This corresponds to https://github.com/microsoft/go-mssqldb/tree/main/azuread

This small patch adds support for `azuresql` driver and treats it as a synonym to `sqlserver`


