### PR TITLE
[/v4] - Add session level advisory lock (postgres only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 # Local testing
 .envrc
 *.FAIL
+/scripts

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docker-start-postgres:
 		-l goose_test \
 		postgres:14-alpine -c log_statement=all
 
-comments:
+todo:
 	rg --type go --ignore-case '//.*(todo|feat)\('
 
 gh-links:

--- a/down.go
+++ b/down.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pressly/goose/v4/internal/sqlparser"
+	"go.uber.org/multierr"
 )
 
 // Down rolls back the most recently applied migration.
@@ -30,25 +31,22 @@ func (p *Provider) DownTo(ctx context.Context, version int64) ([]*MigrationResul
 	return p.down(ctx, false, version)
 }
 
-func (p *Provider) down(ctx context.Context, downByOne bool, version int64) ([]*MigrationResult, error) {
+func (p *Provider) down(ctx context.Context, downByOne bool, version int64) (_ []*MigrationResult, retErr error) {
 	if version < 0 {
 		return nil, fmt.Errorf("version must be a number greater than or equal zero: %d", version)
 	}
 
-	conn, err := p.db.Conn(ctx)
+	conn, cleanup, err := p.initialize(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
-
-	// feat(mf): this is where a session level advisory lock would be acquired to ensure that only
-	// one goose process is running at a time. Also need to lock the Provider itself with a mutex.
-	// https://github.com/pressly/goose/issues/335
-
+	defer func() {
+		retErr = multierr.Append(retErr, cleanup())
+	}()
+	// Ensure version table exists.
 	if err := p.ensureVersionTable(ctx, conn); err != nil {
 		return nil, err
 	}
-
 	if p.opt.NoVersioning {
 		if downByOne && len(p.migrations) == 0 {
 			return nil, ErrNoNextVersion

--- a/down.go
+++ b/down.go
@@ -47,6 +47,7 @@ func (p *Provider) down(ctx context.Context, downByOne bool, version int64) (_ [
 	if err := p.ensureVersionTable(ctx, conn); err != nil {
 		return nil, err
 	}
+
 	if p.opt.NoVersioning {
 		if downByOne && len(p.migrations) == 0 {
 			return nil, ErrNoNextVersion
@@ -65,7 +66,7 @@ func (p *Provider) down(ctx context.Context, downByOne bool, version int64) (_ [
 		return nil, err
 	}
 	if dbMigrations[0].Version == 0 {
-		return nil, ErrNoCurrentVersion
+		return nil, nil
 	}
 
 	// This is the sequential path.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/jackc/pgx/v5 v5.3.1
 	github.com/ory/dockertest/v3 v3.9.1
+	github.com/sethvargo/go-retry v0.2.4
 	github.com/vertica/vertica-sql-go v1.3.1
 	github.com/ziutek/mymysql v1.5.4
 	go.uber.org/multierr v1.10.0
@@ -66,6 +67,7 @@ require (
 	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/tools v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/sethvargo/go-retry v0.2.4 h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08Ocec=
+github.com/sethvargo/go-retry v0.2.4/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -212,6 +214,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/dialectadapter/dialectquery/postgres.go
+++ b/internal/dialectadapter/dialectquery/postgres.go
@@ -39,23 +39,22 @@ func (p *Postgres) ListMigrations() string {
 	return fmt.Sprintf(q, p.Table)
 }
 
-// AdvisoryLockSession returns the query to lock the database using an exclusive
-// session level advisory lock.
+// AdvisoryLockSession returns the query to lock the database using an exclusive session level
+// advisory lock.
 func (p *Postgres) AdvisoryLockSession() string {
 	return `SELECT pg_advisory_lock($1)`
 }
 
-// AdvisoryUnlockSession returns the query to release an exclusive session level
-// advisory lock.
+// AdvisoryUnlockSession returns the query to release an exclusive session level advisory lock.
 func (p *Postgres) AdvisoryUnlockSession() string {
 	return `SELECT pg_advisory_unlock($1)`
 }
 
-// AdvisoryLockTransaction returns the query to lock the database using an exclusive
-// transaction level advisory lock.
+// AdvisoryLockTransaction returns the query to lock the database using an exclusive transaction
+// level advisory lock.
 //
-// The lock is automatically released at the end of the current transaction and cannot
-// be released explicitly.
+// The lock is automatically released at the end of the current transaction and cannot be released
+// explicitly.
 func (p *Postgres) AdvisoryLockTransaction() string {
 	return `SELECT pg_advisory_xact_lock($1)`
 }

--- a/internal/dialectadapter/dialectquery/postgres.go
+++ b/internal/dialectadapter/dialectquery/postgres.go
@@ -38,3 +38,24 @@ func (p *Postgres) ListMigrations() string {
 	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, p.Table)
 }
+
+// AdvisoryLockSession returns the query to lock the database using an exclusive
+// session level advisory lock.
+func (p *Postgres) AdvisoryLockSession() string {
+	return `SELECT pg_advisory_lock($1)`
+}
+
+// AdvisoryUnlockSession returns the query to release an exclusive session level
+// advisory lock.
+func (p *Postgres) AdvisoryUnlockSession() string {
+	return `SELECT pg_advisory_unlock($1)`
+}
+
+// AdvisoryLockTransaction returns the query to lock the database using an exclusive
+// transaction level advisory lock.
+//
+// The lock is automatically released at the end of the current transaction and cannot
+// be released explicitly.
+func (p *Postgres) AdvisoryLockTransaction() string {
+	return `SELECT pg_advisory_xact_lock($1)`
+}

--- a/internal/dialectadapter/locker.go
+++ b/internal/dialectadapter/locker.go
@@ -11,9 +11,8 @@ import (
 )
 
 var (
-	// defaultLockID is the id used to lock the database for migrations. It is a
-	// crc64 hash of the string "goose". This is used to prevent multiple
-	// goose processes from running migrations at the same time.
+	// defaultLockID is the id used to lock the database for migrations. It is a crc64 hash of the
+	// string "goose". This is used to ensure that the lock is unique to goose.
 	//
 	// 5887940537704921958
 	defaultLockID = crc64.Checksum([]byte("goose"), crc64.MakeTable(crc64.ECMA))
@@ -24,25 +23,21 @@ var (
 
 // Locker defines the methods to lock and unlock the database.
 //
-// Locking is an experimental feature and the underlying implementation
-// may change in the future.
+// Locking is an experimental feature and the underlying implementation may change in the future.
 //
-// The only database that currently supports locking is Postgres.
-//
-// Other databases will return ErrLockNotImplemented.
+// The only database that currently supports locking is Postgres. Other databases will return
+// ErrLockNotImplemented.
 type Locker interface {
 	// IsLockingEnabled returns true if the database supports locking.
 	IsLockingEnabled() bool
 
-	// LockSession and UnlockSession are used to lock the database for the
-	// duration of a session.
+	// LockSession and UnlockSession are used to lock the database for the duration of a session.
 	//
 	// The session is defined as the duration of a single connection.
 	LockSession(ctx context.Context, conn *sql.Conn) error
 	UnlockSession(ctx context.Context, conn *sql.Conn) error
 
-	// LockTransaction is used to lock the database for the duration of a
-	// transaction.
+	// LockTransaction is used to lock the database for the duration of a transaction.
 	LockTransaction(ctx context.Context, tx *sql.Tx) error
 }
 
@@ -58,13 +53,13 @@ func (s *store) IsLockingEnabled() bool {
 func (s *store) LockSession(ctx context.Context, conn *sql.Conn) error {
 	switch t := s.querier.(type) {
 	case *dialectquery.Postgres:
-		// TODO(mf): need to be VERY careful about the retry logic here to avoid
-		// stacking locks on top of each other. We need to make sure that we
-		// only retry if the lock is not already held.
+		// TODO(mf): need to be VERY careful about the retry logic here to avoid stacking locks on
+		// top of each other. We need to make sure that we only retry if the lock is not already
+		// held.
 		//
-		// This retry is a bit pointless because if we can't get the lock, chances
-		// are another process is holding the lock and we will just spin here
-		// forever. We should probably just remove this retry.
+		// This retry is a bit pointless because if we can't get the lock, chances are another
+		// process is holding the lock and we will just spin here forever. We should probably just
+		// remove this retry.
 		//
 		// At best this might help with a transient network issue.
 		return retry.Do(ctx, s.retry, func(ctx context.Context) error {
@@ -87,24 +82,26 @@ func (s *store) UnlockSession(ctx context.Context, conn *sql.Conn) error {
 				return retry.RetryableError(err)
 			}
 			if !unlocked {
-				// TODO(mf): provide the user with some documentation on how they can unlock
-				// the session manually. Although this is probably not be an issue for 99.9%
-				// of users since pg_advisory_unlock_all() will release all session level
-				// advisory locks held by the current session. (This function is implicitly
-				// invoked at session end, even if the client disconnects ungracefully.)
+
+				// TODO(mf): provide the user with some documentation on how they can unlock the
+				// session manually. Although this is probably an issue for 99.9% of users
+				// since pg_advisory_unlock_all() will release all session level advisory locks held
+				// by the current session. (This function is implicitly invoked at session end, even
+				// if the client disconnects ungracefully.)
 				//
-				// TODO(mf): - we may not want to bother checking the return value and just
-				// assume that the lock was released. This would simplify the code and
-				// remove the need for the unlocked bool.
+				// TODO(mf): - we may not want to bother checking the return value and just assume
+				// that the lock was released. This would simplify the code and remove the need for
+				// the unlocked bool.
 				//
-				// SELECT pid,granted,((classid::bigint<<32)|objid::bigint)AS goose_lock_id FROM pg_locks WHERE locktype='advisory';
+				// SELECT pid,granted,((classid::bigint<<32)|objid::bigint)AS goose_lock_id FROM
+				// pg_locks WHERE locktype='advisory';
 				//
 				// | pid | granted | goose_lock_id       |
 				// |-----|---------|---------------------|
 				// | 191 | t       | 5887940537704921958 |
 				//
-				// A more forceful way to unlock the session is to terminate the process:
-				// SELECT pg_terminate_backend(120);
+				// A more forceful way to unlock the session is to terminate the process: SELECT
+				// pg_terminate_backend(120);
 
 				return errors.New("failed to unlock session")
 			}

--- a/internal/dialectadapter/locker.go
+++ b/internal/dialectadapter/locker.go
@@ -28,8 +28,8 @@ var (
 // The only database that currently supports locking is Postgres. Other databases will return
 // ErrLockNotImplemented.
 type Locker interface {
-	// IsLockingEnabled returns true if the database supports locking.
-	IsLockingEnabled() bool
+	// IsSupported returns true if the database supports locking.
+	IsSupported() bool
 
 	// LockSession and UnlockSession are used to lock the database for the duration of a session.
 	//
@@ -41,7 +41,7 @@ type Locker interface {
 	LockTransaction(ctx context.Context, tx *sql.Tx) error
 }
 
-func (s *store) IsLockingEnabled() bool {
+func (s *store) IsSupported() bool {
 	switch s.querier.(type) {
 	case *dialectquery.Postgres:
 		return true

--- a/internal/dialectadapter/locker.go
+++ b/internal/dialectadapter/locker.go
@@ -1,0 +1,128 @@
+package dialectadapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"hash/crc64"
+
+	"github.com/pressly/goose/v4/internal/dialectadapter/dialectquery"
+	"github.com/sethvargo/go-retry"
+)
+
+var (
+	// defaultLockID is the id used to lock the database for migrations. It is a
+	// crc64 hash of the string "goose". This is used to prevent multiple
+	// goose processes from running migrations at the same time.
+	//
+	// 5887940537704921958
+	defaultLockID = crc64.Checksum([]byte("goose"), crc64.MakeTable(crc64.ECMA))
+
+	// ErrLockNotImplemented is returned when the database does not support locking.
+	ErrLockNotImplemented = errors.New("lock not implemented")
+)
+
+// Locker defines the methods to lock and unlock the database.
+//
+// Locking is an experimental feature and the underlying implementation
+// may change in the future.
+//
+// The only database that currently supports locking is Postgres.
+//
+// Other databases will return ErrLockNotImplemented.
+type Locker interface {
+	// IsLockingEnabled returns true if the database supports locking.
+	IsLockingEnabled() bool
+
+	// LockSession and UnlockSession are used to lock the database for the
+	// duration of a session.
+	//
+	// The session is defined as the duration of a single connection.
+	LockSession(ctx context.Context, conn *sql.Conn) error
+	UnlockSession(ctx context.Context, conn *sql.Conn) error
+
+	// LockTransaction is used to lock the database for the duration of a
+	// transaction.
+	LockTransaction(ctx context.Context, tx *sql.Tx) error
+}
+
+func (s *store) IsLockingEnabled() bool {
+	switch s.querier.(type) {
+	case *dialectquery.Postgres:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *store) LockSession(ctx context.Context, conn *sql.Conn) error {
+	switch t := s.querier.(type) {
+	case *dialectquery.Postgres:
+		// TODO(mf): need to be VERY careful about the retry logic here to avoid
+		// stacking locks on top of each other. We need to make sure that we
+		// only retry if the lock is not already held.
+		//
+		// This retry is a bit pointless because if we can't get the lock, chances
+		// are another process is holding the lock and we will just spin here
+		// forever. We should probably just remove this retry.
+		//
+		// At best this might help with a transient network issue.
+		return retry.Do(ctx, s.retry, func(ctx context.Context) error {
+			if _, err := conn.ExecContext(ctx, t.AdvisoryLockSession(), defaultLockID); err != nil {
+				return retry.RetryableError(err)
+			}
+			return nil
+		})
+	}
+	return ErrLockNotImplemented
+}
+
+func (s *store) UnlockSession(ctx context.Context, conn *sql.Conn) error {
+	switch t := s.querier.(type) {
+	case *dialectquery.Postgres:
+		return retry.Do(ctx, s.retry, func(ctx context.Context) error {
+			var unlocked bool
+			row := conn.QueryRowContext(ctx, t.AdvisoryUnlockSession(), defaultLockID)
+			if err := row.Scan(&unlocked); err != nil {
+				return retry.RetryableError(err)
+			}
+			if !unlocked {
+				// TODO(mf): provide the user with some documentation on how they can unlock
+				// the session manually. Although this is probably not be an issue for 99.9%
+				// of users since pg_advisory_unlock_all() will release all session level
+				// advisory locks held by the current session. (This function is implicitly
+				// invoked at session end, even if the client disconnects ungracefully.)
+				//
+				// TODO(mf): - we may not want to bother checking the return value and just
+				// assume that the lock was released. This would simplify the code and
+				// remove the need for the unlocked bool.
+				//
+				// SELECT pid,granted,((classid::bigint<<32)|objid::bigint)AS goose_lock_id FROM pg_locks WHERE locktype='advisory';
+				//
+				// | pid | granted | goose_lock_id       |
+				// |-----|---------|---------------------|
+				// | 191 | t       | 5887940537704921958 |
+				//
+				// A more forceful way to unlock the session is to terminate the process:
+				// SELECT pg_terminate_backend(120);
+
+				return errors.New("failed to unlock session")
+			}
+			return nil
+		})
+	}
+	return ErrLockNotImplemented
+}
+
+func (s *store) LockTransaction(ctx context.Context, tx *sql.Tx) error {
+	switch t := s.querier.(type) {
+	case *dialectquery.Postgres:
+		return retry.Do(ctx, s.retry, func(ctx context.Context) error {
+			if _, err := tx.ExecContext(ctx, t.AdvisoryLockTransaction(), defaultLockID); err != nil {
+				return retry.RetryableError(err)
+			}
+			return nil
+		})
+	}
+	return ErrLockNotImplemented
+}

--- a/locking.go
+++ b/locking.go
@@ -1,0 +1,5 @@
+package goose
+
+func (p *Provider) lock() error {
+	return nil
+}

--- a/locking.go
+++ b/locking.go
@@ -1,5 +1,0 @@
-package goose
-
-func (p *Provider) lock() error {
-	return nil
-}

--- a/options.go
+++ b/options.go
@@ -142,7 +142,6 @@ const (
 	LockModeNone LockMode = iota
 	LockModeAdvisorySession
 	LockModeAdvisoryTransaction
-	LockModeFile
 )
 
 func (l LockMode) String() string {
@@ -153,8 +152,6 @@ func (l LockMode) String() string {
 		return "advisory-session"
 	case LockModeAdvisoryTransaction:
 		return "advisory-transaction"
-	case LockModeFile:
-		return "file"
 	default:
 		return "unknown"
 	}

--- a/options.go
+++ b/options.go
@@ -25,8 +25,9 @@ type Options struct {
 	Filesystem fs.FS
 
 	// Commonly modified options.
-	Logger  Logger
-	Verbose bool
+	Logger   Logger
+	Verbose  bool
+	LockMode LockMode
 
 	// Features.
 	AllowMissing bool
@@ -132,5 +133,39 @@ func (o Options) SetDebug(b bool) Options {
 // Default: include all migrations.
 func (o Options) SetExcludeFilenames(filenames ...string) Options {
 	o.ExcludeFilenames = filenames
+	return o
+}
+
+type LockMode int
+
+const (
+	LockModeNone LockMode = iota
+	LockModeAdvisorySession
+	LockModeAdvisoryTransaction
+	LockModeFile
+)
+
+func (l LockMode) String() string {
+	switch l {
+	case LockModeNone:
+		return "none"
+	case LockModeAdvisorySession:
+		return "advisory-session"
+	case LockModeAdvisoryTransaction:
+		return "advisory-transaction"
+	case LockModeFile:
+		return "file"
+	default:
+		return "unknown"
+	}
+}
+
+// SetLockMode returns a new Options value with LockMode set to the given value. LockMode is the
+// locking mode to use when applying migrations. Locking is used to prevent multiple instances of
+// goose from applying migrations concurrently.
+//
+// Default: LockModeNone
+func (o Options) SetLockMode(m LockMode) Options {
+	o.LockMode = m
 	return o
 }

--- a/provider.go
+++ b/provider.go
@@ -68,6 +68,15 @@ func (p *Provider) ListMigrations() []*Migration {
 	return migrations
 }
 
+// GetLastVersion returns the version of the last migration found in the migrations directory
+// (sorted by version). If there are no migrations, then 0 is returned.
+func (p *Provider) GetLastVersion() int64 {
+	if len(p.migrations) == 0 {
+		return 0
+	}
+	return p.migrations[len(p.migrations)-1].version
+}
+
 // Ping attempts to ping the database to verify a connection is available.
 func (p *Provider) Ping(ctx context.Context) error {
 	return p.db.PingContext(ctx)

--- a/run.go
+++ b/run.go
@@ -234,7 +234,7 @@ func (p *Provider) initializeWithLock(ctx context.Context) (*sql.Conn, func() er
 }
 
 func (p *Provider) initialize(ctx context.Context) (*sql.Conn, func() error, error) {
-	if p.store.IsLockingEnabled() {
+	if p.store.IsSupported() {
 		return p.initializeWithLock(ctx)
 	}
 	conn, err := p.db.Conn(ctx)

--- a/run.go
+++ b/run.go
@@ -226,8 +226,6 @@ func (p *Provider) initializeWithLock(ctx context.Context) (*sql.Conn, func() er
 			return conn.Close()
 		}
 		return conn, cleanup, nil
-	case LockModeFile:
-		return nil, nil, fmt.Errorf("file lock mode is not supported")
 	default:
 		return nil, nil, fmt.Errorf("invalid lock mode: %d", p.opt.LockMode)
 	}

--- a/run.go
+++ b/run.go
@@ -206,3 +206,40 @@ func (p *Provider) runGoNoTx(
 	}
 	return p.store.InsertOrDeleteNoTx(ctx, p.db, direction.ToBool(), m.version)
 }
+
+func (p *Provider) initializeWithLock(ctx context.Context) (*sql.Conn, func() error, error) {
+	conn, err := p.db.Conn(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	switch p.opt.LockMode {
+	case LockModeAdvisorySession:
+		if err := p.store.LockSession(ctx, conn); err != nil {
+			return nil, nil, err
+		}
+		cleanup := func() error {
+			return multierr.Append(p.store.UnlockSession(ctx, conn), conn.Close())
+		}
+		return conn, cleanup, nil
+	case LockModeNone, LockModeAdvisoryTransaction:
+		cleanup := func() error {
+			return conn.Close()
+		}
+		return conn, cleanup, nil
+	case LockModeFile:
+		return nil, nil, fmt.Errorf("file lock mode is not supported")
+	default:
+		return nil, nil, fmt.Errorf("invalid lock mode: %d", p.opt.LockMode)
+	}
+}
+
+func (p *Provider) initialize(ctx context.Context) (*sql.Conn, func() error, error) {
+	if p.store.IsLockingEnabled() {
+		return p.initializeWithLock(ctx)
+	}
+	conn, err := p.db.Conn(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, conn.Close, nil
+}

--- a/tests/e2e/postgres/allow_missing_test.go
+++ b/tests/e2e/postgres/allow_missing_test.go
@@ -205,9 +205,8 @@ func TestAllowMissingUpWithReset(t *testing.T) {
 
 		current, err := p.GetDBVersion(ctx)
 		check.NoError(t, err)
-		maxVersionID := all[len(all)-1].Version
 		// Expecting max(version_id) to be highest version in testdata
-		check.Number(t, current, maxVersionID)
+		check.Number(t, current, p.GetLastVersion())
 	}
 	// Migrate everything down using Reset.
 	{

--- a/tests/e2e/postgres/locking_test.go
+++ b/tests/e2e/postgres/locking_test.go
@@ -30,7 +30,7 @@ func TestLockModeAdvisorySession(t *testing.T) {
 	check.NoError(t, err)
 
 	migrations := provider1.ListMigrations()
-	wantVersion := migrations[len(migrations)-1].Version
+	maxVersion := provider1.GetLastVersion()
 
 	// Since the lock mode is advisory session, only one of these providers is expected to apply ALL
 	// the migrations. The other provider should apply NO migrations. The test MUST fail if both
@@ -46,7 +46,7 @@ func TestLockModeAdvisorySession(t *testing.T) {
 			res1 = len(results)
 			currentVersion, err := provider1.GetDBVersion(ctx)
 			check.NoError(t, err)
-			check.Number(t, currentVersion, wantVersion)
+			check.Number(t, currentVersion, maxVersion)
 			return nil
 		})
 		g.Go(func() error {
@@ -56,7 +56,7 @@ func TestLockModeAdvisorySession(t *testing.T) {
 			res2 = len(results)
 			currentVersion, err := provider2.GetDBVersion(ctx)
 			check.NoError(t, err)
-			check.Number(t, currentVersion, wantVersion)
+			check.Number(t, currentVersion, maxVersion)
 			return nil
 		})
 		check.NoError(t, g.Wait())
@@ -131,7 +131,7 @@ func TestLockModeAdvisorySession(t *testing.T) {
 		check.NoError(t, err)
 		currentVersion, err := provider1.GetDBVersion(context.Background())
 		check.NoError(t, err)
-		check.Number(t, currentVersion, wantVersion)
+		check.Number(t, currentVersion, maxVersion)
 	}
 
 	t.Run("down_to", func(t *testing.T) {
@@ -174,7 +174,7 @@ func TestLockModeAdvisorySession(t *testing.T) {
 		check.NoError(t, err)
 		currentVersion, err := provider1.GetDBVersion(context.Background())
 		check.NoError(t, err)
-		check.Number(t, currentVersion, wantVersion)
+		check.Number(t, currentVersion, maxVersion)
 	}
 
 	t.Run("down_by_one", func(t *testing.T) {

--- a/tests/e2e/postgres/locking_test.go
+++ b/tests/e2e/postgres/locking_test.go
@@ -1,0 +1,67 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pressly/goose/v4"
+	"github.com/pressly/goose/v4/internal/check"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestLockModeAdvisorySession(t *testing.T) {
+	t.Parallel()
+
+	// The migrations are written in such a way that they cannot be applied concurrently. This test
+	// ensures that the advisory session lock mode works as expected.
+
+	options := goose.DefaultOptions().
+		SetDir(migrationsDir).
+		SetVerbose(testing.Verbose()).
+		SetLockMode(goose.LockModeAdvisorySession) // <----------------- advisory session lock mode
+
+	te := newTestEnv(t, migrationsDir, &options)
+	provider1 := te.provider
+
+	provider2, err := goose.NewProvider(goose.DialectPostgres, te.db, options)
+	check.NoError(t, err)
+
+	migrations := provider1.ListMigrations()
+	wantVersion := migrations[len(migrations)-1].Version
+
+	var g errgroup.Group
+
+	// Since the lock mode is advisory session, only one of these providers is expected to apply ALL
+	// the migrations. The other provider should apply NO migrations. The test MUST fail if both
+	// providers apply migrations.
+
+	var res1, res2 int
+	g.Go(func() error {
+		ctx := context.Background()
+		results, err := provider1.Up(ctx)
+		check.NoError(t, err)
+		res1 = len(results)
+		currentVersion, err := provider1.GetDBVersion(ctx)
+		check.NoError(t, err)
+		check.Number(t, currentVersion, wantVersion)
+		return nil
+	})
+	g.Go(func() error {
+		ctx := context.Background()
+		results, err := provider2.Up(ctx)
+		check.NoError(t, err)
+		res2 = len(results)
+		currentVersion, err := provider2.GetDBVersion(ctx)
+		check.NoError(t, err)
+		check.Number(t, currentVersion, wantVersion)
+		return nil
+	})
+	check.NoError(t, g.Wait())
+
+	if res1 == 0 && res2 == 0 {
+		t.Fatal("both providers applied no migrations")
+	}
+	if res1 > 0 && res2 > 0 {
+		t.Fatal("both providers applied migrations")
+	}
+}

--- a/tests/e2e/postgres/locking_test.go
+++ b/tests/e2e/postgres/locking_test.go
@@ -2,6 +2,9 @@ package postgres_test
 
 import (
 	"context"
+	"errors"
+	"sort"
+	"sync"
 	"testing"
 
 	"github.com/pressly/goose/v4"
@@ -18,7 +21,7 @@ func TestLockModeAdvisorySession(t *testing.T) {
 	options := goose.DefaultOptions().
 		SetDir(migrationsDir).
 		SetVerbose(testing.Verbose()).
-		SetLockMode(goose.LockModeAdvisorySession) // <----------------- advisory session lock mode
+		SetLockMode(goose.LockModeAdvisorySession) /* ---------------- advisory session lock mode */
 
 	te := newTestEnv(t, migrationsDir, &options)
 	provider1 := te.provider
@@ -29,39 +32,196 @@ func TestLockModeAdvisorySession(t *testing.T) {
 	migrations := provider1.ListMigrations()
 	wantVersion := migrations[len(migrations)-1].Version
 
-	var g errgroup.Group
-
 	// Since the lock mode is advisory session, only one of these providers is expected to apply ALL
 	// the migrations. The other provider should apply NO migrations. The test MUST fail if both
 	// providers apply migrations.
 
-	var res1, res2 int
-	g.Go(func() error {
-		ctx := context.Background()
-		results, err := provider1.Up(ctx)
-		check.NoError(t, err)
-		res1 = len(results)
-		currentVersion, err := provider1.GetDBVersion(ctx)
-		check.NoError(t, err)
-		check.Number(t, currentVersion, wantVersion)
-		return nil
-	})
-	g.Go(func() error {
-		ctx := context.Background()
-		results, err := provider2.Up(ctx)
-		check.NoError(t, err)
-		res2 = len(results)
-		currentVersion, err := provider2.GetDBVersion(ctx)
-		check.NoError(t, err)
-		check.Number(t, currentVersion, wantVersion)
-		return nil
-	})
-	check.NoError(t, g.Wait())
+	t.Run("up", func(t *testing.T) {
+		var g errgroup.Group
+		var res1, res2 int
+		g.Go(func() error {
+			ctx := context.Background()
+			results, err := provider1.Up(ctx)
+			check.NoError(t, err)
+			res1 = len(results)
+			currentVersion, err := provider1.GetDBVersion(ctx)
+			check.NoError(t, err)
+			check.Number(t, currentVersion, wantVersion)
+			return nil
+		})
+		g.Go(func() error {
+			ctx := context.Background()
+			results, err := provider2.Up(ctx)
+			check.NoError(t, err)
+			res2 = len(results)
+			currentVersion, err := provider2.GetDBVersion(ctx)
+			check.NoError(t, err)
+			check.Number(t, currentVersion, wantVersion)
+			return nil
+		})
+		check.NoError(t, g.Wait())
 
-	if res1 == 0 && res2 == 0 {
-		t.Fatal("both providers applied no migrations")
+		if res1 == 0 && res2 == 0 {
+			t.Fatal("both providers applied no migrations")
+		}
+		if res1 > 0 && res2 > 0 {
+			t.Fatal("both providers applied migrations")
+		}
+	})
+
+	// Reset the database and run the same test with the advisory lock mode, but apply migrations
+	// one-by-one.
+	{
+		_, err := provider1.Reset(context.Background())
+		check.NoError(t, err)
+		currentVersion, err := provider1.GetDBVersion(context.Background())
+		check.NoError(t, err)
+		check.Number(t, currentVersion, 0)
 	}
-	if res1 > 0 && res2 > 0 {
-		t.Fatal("both providers applied migrations")
+	t.Run("up_by_one", func(t *testing.T) {
+		var g errgroup.Group
+		var (
+			mu      sync.Mutex
+			applied []int64
+		)
+		g.Go(func() error {
+			for {
+				result, err := provider1.UpByOne(context.Background())
+				if err != nil {
+					if errors.Is(err, goose.ErrNoNextVersion) {
+						return nil
+					}
+					return err
+				}
+				check.NoError(t, err)
+				mu.Lock()
+				applied = append(applied, result.Migration.Version)
+				mu.Unlock()
+			}
+		})
+		g.Go(func() error {
+			for {
+				result, err := provider2.UpByOne(context.Background())
+				if err != nil {
+					if errors.Is(err, goose.ErrNoNextVersion) {
+						return nil
+					}
+					return err
+				}
+				check.NoError(t, err)
+				mu.Lock()
+				applied = append(applied, result.Migration.Version)
+				mu.Unlock()
+			}
+		})
+		check.NoError(t, g.Wait())
+		check.Number(t, len(applied), len(migrations))
+		// sort.Slice(applied, func(i, j int) bool {
+		//  return applied[i] < applied[j]
+		// }) Each migration should have been applied up exactly once.
+		for i := 0; i < len(migrations); i++ {
+			check.Number(t, applied[i], migrations[i].Version)
+		}
+	})
+
+	// Restore the database state by applying all migrations and run the same test with the advisory
+	// lock mode, but apply down migrations in parallel.
+	{
+		_, err := provider1.Up(context.Background())
+		check.NoError(t, err)
+		currentVersion, err := provider1.GetDBVersion(context.Background())
+		check.NoError(t, err)
+		check.Number(t, currentVersion, wantVersion)
 	}
+
+	t.Run("down_to", func(t *testing.T) {
+		var g errgroup.Group
+		var res1, res2 int
+		g.Go(func() error {
+			ctx := context.Background()
+			results, err := provider1.DownTo(ctx, 0)
+			check.NoError(t, err)
+			res1 = len(results)
+			currentVersion, err := provider1.GetDBVersion(ctx)
+			check.NoError(t, err)
+			check.Number(t, currentVersion, 0)
+			return nil
+		})
+		g.Go(func() error {
+			ctx := context.Background()
+			results, err := provider2.DownTo(ctx, 0)
+			check.NoError(t, err)
+			res2 = len(results)
+			currentVersion, err := provider2.GetDBVersion(ctx)
+			check.NoError(t, err)
+			check.Number(t, currentVersion, 0)
+			return nil
+		})
+		check.NoError(t, g.Wait())
+
+		if res1 == 0 && res2 == 0 {
+			t.Fatal("both providers applied no migrations")
+		}
+		if res1 > 0 && res2 > 0 {
+			t.Fatal("both providers applied migrations")
+		}
+	})
+
+	// Restore the database state by applying all migrations and run the same test with the advisory
+	// lock mode, but apply down migrations one-by-one.
+	{
+		_, err := provider1.Up(context.Background())
+		check.NoError(t, err)
+		currentVersion, err := provider1.GetDBVersion(context.Background())
+		check.NoError(t, err)
+		check.Number(t, currentVersion, wantVersion)
+	}
+
+	t.Run("down_by_one", func(t *testing.T) {
+		var g errgroup.Group
+		var (
+			mu      sync.Mutex
+			applied []int64
+		)
+		g.Go(func() error {
+			for {
+				result, err := provider1.Down(context.Background())
+				if err != nil {
+					if errors.Is(err, goose.ErrNoCurrentVersion) {
+						return nil
+					}
+					return err
+				}
+				check.NoError(t, err)
+				mu.Lock()
+				applied = append(applied, result.Migration.Version)
+				mu.Unlock()
+			}
+		})
+		g.Go(func() error {
+			for {
+				result, err := provider2.Down(context.Background())
+				if err != nil {
+					if errors.Is(err, goose.ErrNoCurrentVersion) {
+						return nil
+					}
+					return err
+				}
+				check.NoError(t, err)
+				mu.Lock()
+				applied = append(applied, result.Migration.Version)
+				mu.Unlock()
+			}
+		})
+		check.NoError(t, g.Wait())
+		check.Number(t, len(applied), len(migrations))
+		sort.Slice(applied, func(i, j int) bool {
+			return applied[i] < applied[j]
+		})
+		// Each migration should have been applied down exactly once. Since this is sequential the
+		// applied down migrations should be in reverse order.
+		for i := len(migrations) - 1; i >= 0; i-- {
+			check.Number(t, applied[i], migrations[i].Version)
+		}
+	})
 }

--- a/tests/e2e/postgres/migrations_test.go
+++ b/tests/e2e/postgres/migrations_test.go
@@ -20,8 +20,8 @@ func TestUpDownAll(t *testing.T) {
 		maxIdleConns int
 		useDefaults  bool
 	}{
-		// Single connection ensures goose is able to function correctly when multiple
-		// connections are not available.
+		// Single connection ensures goose is able to function correctly when multiple connections
+		// are not available.
 		{name: "single_conn", maxOpenConns: 1, maxIdleConns: 1},
 		{name: "defaults", useDefaults: true},
 	}

--- a/tests/e2e/postgres/migrations_test.go
+++ b/tests/e2e/postgres/migrations_test.go
@@ -50,7 +50,7 @@ func TestUpDownAll(t *testing.T) {
 				check.Number(t, len(upResult), len(migrations))
 				currentVersion, err := te.provider.GetDBVersion(ctx)
 				check.NoError(t, err)
-				check.Number(t, currentVersion, migrations[len(migrations)-1].Version)
+				check.Number(t, currentVersion, te.provider.GetLastVersion())
 				// Validate the db migration version actually matches what goose claims it is
 				gotVersion, err := getMaxVersionID(te.db, te.opt.TableName)
 				check.NoError(t, err)
@@ -137,6 +137,7 @@ func TestMigrateUpByOneWithRedo(t *testing.T) {
 	te := newTestEnv(t, migrationsDir, nil)
 	migrations := te.provider.ListMigrations()
 	check.NumberNotZero(t, len(migrations))
+	maxVersion := te.provider.GetLastVersion()
 
 	for i := 0; i < len(migrations); i++ {
 		originalUpResult, err := te.provider.UpByOne(ctx)
@@ -154,7 +155,6 @@ func TestMigrateUpByOneWithRedo(t *testing.T) {
 		check.Number(t, currentVersion, migrations[i].Version)
 	}
 	// Once everything is tested the version should match the highest testdata version
-	maxVersion := migrations[len(migrations)-1].Version
 	currentVersion, err := te.provider.GetDBVersion(ctx)
 	check.NoError(t, err)
 	check.Number(t, currentVersion, maxVersion)
@@ -167,6 +167,7 @@ func TestMigrateUpByOne(t *testing.T) {
 	te := newTestEnv(t, migrationsDir, nil)
 	migrations := te.provider.ListMigrations()
 	check.NumberNotZero(t, len(migrations))
+	maxVersion := te.provider.GetLastVersion()
 
 	// Apply all migrations one-by-one.
 	var counter int
@@ -183,7 +184,6 @@ func TestMigrateUpByOne(t *testing.T) {
 		check.Number(t, result.Migration.Version, counter)
 	}
 	// Once everything is tested the version should match the highest testdata version
-	maxVersion := migrations[len(migrations)-1].Version
 	currentVersion, err := te.provider.GetDBVersion(ctx)
 	check.NoError(t, err)
 	check.Number(t, currentVersion, maxVersion)

--- a/version.go
+++ b/version.go
@@ -1,18 +1,25 @@
 package goose
 
-import "context"
+import (
+	"context"
+
+	"go.uber.org/multierr"
+)
 
 // GetDBVersion retrieves the current database version.
-func (p *Provider) GetDBVersion(ctx context.Context) (int64, error) {
-	conn, err := p.db.Conn(ctx)
+func (p *Provider) GetDBVersion(ctx context.Context) (_ int64, retErr error) {
+	conn, cleanup, err := p.initialize(ctx)
 	if err != nil {
 		return 0, err
 	}
-	defer conn.Close()
-
+	defer func() {
+		retErr = multierr.Append(retErr, cleanup())
+	}()
+	// Ensure version table exists.
 	if err := p.ensureVersionTable(ctx, conn); err != nil {
 		return 0, err
 	}
+
 	res, err := p.store.ListMigrationsConn(ctx, conn)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This PR adds a session-level advisory lock with a parallel test.