### PR TITLE
[/v4]  - Add support for grouped migrations (prefactor)

### DIFF
--- a/down.go
+++ b/down.go
@@ -48,6 +48,10 @@ func (p *Provider) down(ctx context.Context, downByOne bool, version int64) (_ [
 		return nil, err
 	}
 
+	if len(p.migrations) == 0 {
+		return nil, nil
+	}
+
 	if p.opt.NoVersioning {
 		if downByOne && len(p.migrations) == 0 {
 			return nil, ErrNoNextVersion

--- a/internal/dialectadapter/locker.go
+++ b/internal/dialectadapter/locker.go
@@ -33,7 +33,8 @@ type Locker interface {
 
 	// LockSession and UnlockSession are used to lock the database for the duration of a session.
 	//
-	// The session is defined as the duration of a single connection.
+	// The session is defined as the duration of a single connection and both methods must be called
+	// on the same connection.
 	LockSession(ctx context.Context, conn *sql.Conn) error
 	UnlockSession(ctx context.Context, conn *sql.Conn) error
 

--- a/options.go
+++ b/options.go
@@ -38,6 +38,9 @@ type Options struct {
 	ExcludeFilenames []string
 
 	// Unimplemented.
+	//
+	// See run_grouped.go for more details.
+	groupedMigrations bool
 }
 
 func DefaultOptions() Options {
@@ -164,5 +167,26 @@ func (l LockMode) String() string {
 // Default: LockModeNone
 func (o Options) SetLockMode(m LockMode) Options {
 	o.LockMode = m
+	return o
+}
+
+// setGroupedMigrations returns a new Options value with GroupedMigrations set to the given value.
+// GroupedMigrations enables the ability to share a single transaction across multiple migrations.
+//
+// For more information, see: TODO(mf): add link to docs
+//
+// For example, say we have 6 new migrations to apply: 11,12,13,14,15,16. But migration 14 is marked
+// with -- +goose NO TRANSACTION. Then the migrations will be applied in 3 groups:
+//
+//  1. migrations 11,12,13 will be applied in a single transaction and committed
+//  2. migration 14 will be applied outside transaction and committed
+//  3. migrations 15,16 will be applied in a single transaction and committed
+//
+// This feature is useful to avoid leaving the database in a partially migrated state. But, keep in
+// mind there may be performance implications if you have a large number of migrations.
+//
+// Default: false
+func (o Options) setGroupedMigrations(b bool) Options {
+	o.groupedMigrations = b
 	return o
 }

--- a/options.go
+++ b/options.go
@@ -40,7 +40,7 @@ type Options struct {
 	// Unimplemented.
 	//
 	// See run_grouped.go for more details.
-	groupedMigrations bool
+	groupedMigrations bool //nolint:golint,unused
 }
 
 func DefaultOptions() Options {
@@ -176,7 +176,7 @@ func (o Options) SetLockMode(m LockMode) Options {
 // For more information, see: TODO(mf): add link to docs
 //
 // For example, say we have 6 new migrations to apply: 11,12,13,14,15,16. But migration 14 is marked
-// with -- +goose NO TRANSACTION. Then the migrations will be applied in 3 groups:
+// with -- +goose NO TRANSACTION. Then the migrations will be applied sequentially in 3 groups:
 //
 //  1. migrations 11,12,13 will be applied in a single transaction and committed
 //  2. migration 14 will be applied outside transaction and committed
@@ -186,7 +186,7 @@ func (o Options) SetLockMode(m LockMode) Options {
 // mind there may be performance implications if you have a large number of migrations.
 //
 // Default: false
-func (o Options) setGroupedMigrations(b bool) Options {
+func (o Options) setGroupedMigrations(b bool) Options { //nolint:golint,unused
 	o.groupedMigrations = b
 	return o
 }

--- a/run_grouped.go
+++ b/run_grouped.go
@@ -1,0 +1,31 @@
+package goose
+
+/*
+
+Unimplemented. this is a placeholder for a future feature.
+
+See the following issues for more details:
+
+ - https://github.com/pressly/goose/issues/222
+ - https://github.com/pressly/goose/issues/485
+
+*/
+
+func splitMigrationsIntoGroups(migrations []*migration) [][]*migration {
+	groups := make([][]*migration, 0)
+	var prev bool
+	for _, m := range migrations {
+		if len(groups) == 0 {
+			groups = append(groups, []*migration{m})
+			prev = m.useTx()
+			continue
+		}
+		if prev && m.useTx() {
+			groups[len(groups)-1] = append(groups[len(groups)-1], m)
+		} else {
+			groups = append(groups, []*migration{m})
+		}
+		prev = m.useTx()
+	}
+	return groups
+}

--- a/run_grouped_test.go
+++ b/run_grouped_test.go
@@ -1,0 +1,134 @@
+package goose
+
+import (
+	"testing"
+
+	"github.com/pressly/goose/v4/internal/check"
+)
+
+func TestSplitMigrationsIntoGroups(t *testing.T) {
+	tt := []struct {
+		migrations []*migration
+		expected   [][]int64
+	}{
+		{
+			migrations: []*migration{},
+			expected:   nil,
+		},
+		{
+			migrations: []*migration{
+				newSQL(11, true),
+				newGo(12, true),
+				newSQL(13, true),
+				newSQL(14, false),
+				newGo(15, true),
+				newSQL(16, true),
+			},
+			expected: [][]int64{
+				{11, 12, 13},
+				{14},
+				{15, 16},
+			},
+		},
+		{
+			migrations: []*migration{
+				newGo(3, true),
+				newSQL(4, true),
+			},
+			expected: [][]int64{
+				{3, 4},
+			},
+		},
+		{
+			migrations: []*migration{
+				newGo(3, false),
+				newSQL(4, false),
+			},
+			expected: [][]int64{
+				{3},
+				{4},
+			},
+		},
+		{
+			migrations: []*migration{
+				newGo(3, false),
+				newSQL(4, true),
+				newSQL(5, false),
+			},
+			expected: [][]int64{
+				{3},
+				{4},
+				{5},
+			},
+		},
+		{
+			migrations: []*migration{
+				newGo(3, true),
+				newSQL(4, false),
+				newSQL(5, true),
+			},
+			expected: [][]int64{
+				{3},
+				{4},
+				{5},
+			},
+		},
+		{
+			migrations: []*migration{
+				newSQL(3, true),
+				newSQL(4, true),
+				newSQL(5, false),
+				newGo(6, false),
+			},
+			expected: [][]int64{
+				{3, 4},
+				{5},
+				{6},
+			},
+		},
+		{
+			migrations: []*migration{
+				newSQL(3, true),
+				newSQL(4, true),
+				newSQL(5, false),
+				newGo(6, false),
+				newSQL(7, true),
+			},
+			expected: [][]int64{
+				{3, 4},
+				{5},
+				{6},
+				{7},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		groups := splitMigrationsIntoGroups(tc.migrations)
+		check.Number(t, len(groups), len(tc.expected))
+		for i, g := range groups {
+			check.Number(t, len(g), len(tc.expected[i]))
+			for j, m := range g {
+				if m.version != tc.expected[i][j] {
+					t.Errorf("expected %d, got %d", tc.expected[i][j], m.version)
+				}
+			}
+		}
+	}
+}
+
+func newSQL(version int64, useTx bool) *migration {
+	return &migration{
+		migrationType: MigrationTypeSQL,
+		sqlMigration:  &sqlMigration{useTx: useTx},
+		version:       version,
+	}
+}
+
+func newGo(version int64, useTx bool) *migration {
+	return &migration{
+		migrationType: MigrationTypeGo,
+		goMigration:   &goMigration{useTx: useTx},
+		version:       version,
+	}
+}

--- a/up.go
+++ b/up.go
@@ -58,6 +58,10 @@ func (p *Provider) up(ctx context.Context, upByOne bool, version int64) (_ []*Mi
 		return nil, err
 	}
 
+	if len(p.migrations) == 0 {
+		return nil, nil
+	}
+
 	if p.opt.NoVersioning {
 		return p.runMigrations(ctx, conn, p.migrations, sqlparser.DirectionUp, upByOne)
 	}


### PR DESCRIPTION
Added a helper function that takes a list of migrations and groups them by whether they are safe to run in a tx or not.

By grouping the migrations we can best effort apply them within the same transaction. See tests or this https://github.com/pressly/goose/issues/485#issuecomment-1485969912

Description:

```go
// GroupedMigrations enables the ability to share a single transaction across multiple migrations.
//
// For more information, see: TODO(mf): add link to docs
//
// For example, say we have 6 new migrations to apply: 11,12,13,14,15,16. But migration 14 is marked
// with -- +goose NO TRANSACTION. Then the migrations will be applied sequentially in 3 groups:
//
//  1. migrations 11,12,13 will be applied in a single transaction and committed
//  2. migration 14 will be applied outside transaction and committed
//  3. migrations 15,16 will be applied in a single transaction and committed
//
// This feature is useful to avoid leaving the database in a partially migrated state. But, keep in
// mind there may be performance implications if you have a large number of migrations.
//
// Default: false
```