### PR TITLE
Add 'sqlserver' to dialects as an alias of mssql

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -22,7 +22,7 @@ func SetDialect(s string) error {
 		d = dialect.Mysql
 	case "sqlite3", "sqlite":
 		d = dialect.Sqlite3
-	case "mssql", "azuresql":
+	case "mssql", "azuresql", "sqlserver":
 		d = dialect.Sqlserver
 	case "redshift":
 		d = dialect.Redshift


### PR DESCRIPTION
The official driver name for mssql is now sqlserver, so may cause confusion by goose not supporting sqlserver instead

This can become a problem where a user calls `goose.OpenDBWithDriver()` with driver name `sqlserver`, as it currently returns a `unknown dialect` error (which is the exact problem I had!)

This is similar to #487 but for sqlserver