### PR TITLE
Fixing `up` and `up -allow-missing` behaviour

### DIFF
--- a/tests/e2e/allow_missing_test.go
+++ b/tests/e2e/allow_missing_test.go
@@ -315,7 +315,7 @@ func TestMigrateAllowMissingDown(t *testing.T) {
 	}
 }
 
-func TestUpWithAndWithoutAllowMissing(t *testing.T) {
+func TestWithWithoutAllowMissing(t *testing.T) {
 	// Test for https://github.com/pressly/goose/issues/521
 
 	// Apply 1,2,4,3 then run up without allow missing. If the next requested migration is
@@ -335,6 +335,20 @@ func TestUpWithAndWithoutAllowMissing(t *testing.T) {
 	check.NoError(t, err)
 	err = goose.UpTo(db, migrationsDir, 4, goose.WithAllowMissing())
 	check.NoError(t, err)
+
+	// Rollback migration 3 because it is the last applied migration.
+	// But, we want to change this behaviour to apply rollback migration 4.
+	// See these issues for more details:
+	// https://github.com/pressly/goose/issues/523
+	// https://github.com/pressly/goose/issues/402
+	//
+	// Adding this test to ensure the behaviour is updated and captured in a test.
+	err = goose.Down(db, migrationsDir)
+	check.NoError(t, err)
+
+	version, err := goose.GetDBVersion(db)
+	check.NoError(t, err)
+	check.Number(t, version, 4)
 }
 
 // setupTestDB is helper to setup a DB and apply migrations

--- a/up.go
+++ b/up.go
@@ -3,7 +3,6 @@ package goose
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -64,6 +63,12 @@ func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 	if err != nil {
 		return err
 	}
+	currentVersion := dbMigrations[len(dbMigrations)-1].Version
+	// lookupAppliedInDB is a map of all applied migrations in the database.
+	lookupAppliedInDB := make(map[int64]bool)
+	for _, m := range dbMigrations {
+		lookupAppliedInDB[m.Version] = true
+	}
 
 	missingMigrations := findMissingMigrations(dbMigrations, foundMigrations)
 
@@ -79,37 +84,26 @@ func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 		return fmt.Errorf("error: found %d missing migrations:\n\t%s",
 			len(missingMigrations), strings.Join(collected, "\n\t"))
 	}
+	migrationsToApply := missingMigrations
 
-	if option.allowMissing {
-		return upWithMissing(
-			db,
-			missingMigrations,
-			foundMigrations,
-			dbMigrations,
-			option,
-		)
+	for _, m := range foundMigrations {
+		if lookupAppliedInDB[m.Version] {
+			continue
+		}
+		if m.Version > currentVersion && m.Version <= version {
+			migrationsToApply = append(migrationsToApply, m)
+		}
 	}
 
 	var current int64
-	for {
-		var err error
-		current, err = GetDBVersion(db)
-		if err != nil {
-			return err
-		}
-		next, err := foundMigrations.Next(current)
-		if err != nil {
-			if errors.Is(err, ErrNoNextVersion) {
-				break
-			}
-			return fmt.Errorf("failed to find next migration: %v", err)
-		}
-		if err := next.Up(db); err != nil {
+	for _, m := range migrationsToApply {
+		if err := m.Up(db); err != nil {
 			return err
 		}
 		if option.applyUpByOne {
 			return nil
 		}
+		current = m.Version
 	}
 	// At this point there are no more migrations to apply. But we need to maintain
 	// the following behaviour:
@@ -137,77 +131,6 @@ func upToNoVersioning(db *sql.DB, migrations Migrations, version int64) error {
 		finalVersion = current.Version
 	}
 	log.Printf("goose: up to current file version: %d\n", finalVersion)
-	return nil
-}
-
-func upWithMissing(
-	db *sql.DB,
-	missingMigrations Migrations,
-	foundMigrations Migrations,
-	dbMigrations Migrations,
-	option *options,
-) error {
-	lookupApplied := make(map[int64]bool)
-	for _, found := range dbMigrations {
-		lookupApplied[found.Version] = true
-	}
-
-	// Apply all missing migrations first.
-	for _, missing := range missingMigrations {
-		if err := missing.Up(db); err != nil {
-			return err
-		}
-		// Apply one migration and return early.
-		if option.applyUpByOne {
-			return nil
-		}
-		// TODO(mf): do we need this check? It's a bit redundant, but we may
-		// want to keep it as a safe-guard. Maybe we should instead have
-		// the underlying query (if possible) return the current version as
-		// part of the same transaction.
-		current, err := GetDBVersion(db)
-		if err != nil {
-			return err
-		}
-		if current == missing.Version {
-			lookupApplied[missing.Version] = true
-			continue
-		}
-		return fmt.Errorf("error: missing migration:%d does not match current db version:%d",
-			current, missing.Version)
-	}
-
-	// We can no longer rely on the database version_id to be sequential because
-	// missing (out-of-order) migrations get applied before newer migrations.
-
-	for _, found := range foundMigrations {
-		// TODO(mf): instead of relying on this lookup, consider hitting
-		// the database directly?
-		// Alternatively, we can skip a bunch migrations and start the cursor
-		// at a version that represents 100% applied migrations. But this is
-		// risky, and we should aim to keep this logic simple.
-		if lookupApplied[found.Version] {
-			continue
-		}
-		if err := found.Up(db); err != nil {
-			return err
-		}
-		if option.applyUpByOne {
-			return nil
-		}
-	}
-	current, err := GetDBVersion(db)
-	if err != nil {
-		return err
-	}
-	// At this point there are no more migrations to apply. But we need to maintain
-	// the following behaviour:
-	// UpByOne returns an error to signifying there are no more migrations.
-	// Up and UpTo return nil
-	log.Printf("goose: no migrations to run. current version: %d\n", current)
-	if option.applyUpByOne {
-		return ErrNoNextVersion
-	}
 	return nil
 }
 

--- a/up.go
+++ b/up.go
@@ -63,7 +63,7 @@ func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 	if err != nil {
 		return err
 	}
-	currentVersion := dbMigrations[len(dbMigrations)-1].Version
+	dbMaxVersion := dbMigrations[len(dbMigrations)-1].Version
 	// lookupAppliedInDB is a map of all applied migrations in the database.
 	lookupAppliedInDB := make(map[int64]bool)
 	for _, m := range dbMigrations {
@@ -96,7 +96,7 @@ func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 		if lookupAppliedInDB[m.Version] {
 			continue
 		}
-		if m.Version > currentVersion && m.Version <= version {
+		if m.Version > dbMaxVersion && m.Version <= version {
 			migrationsToApply = append(migrationsToApply, m)
 		}
 	}

--- a/up_test.go
+++ b/up_test.go
@@ -10,7 +10,7 @@ func TestFindMissingMigrations(t *testing.T) {
 		{Version: 3},
 		{Version: 4},
 		{Version: 5},
-		{Version: 7},
+		{Version: 7}, // <-- database max version_id
 	}
 	new := Migrations{
 		{Version: 1},
@@ -22,7 +22,7 @@ func TestFindMissingMigrations(t *testing.T) {
 		{Version: 7}, // <-- database max version_id
 		{Version: 8}, // new migration
 	}
-	got := findMissingMigrations(known, new)
+	got := findMissingMigrations(known, new, 7)
 	if len(got) != 2 {
 		t.Fatalf("invalid migration count: got:%d want:%d", len(got), 2)
 	}


### PR DESCRIPTION
Fix #521 and partially address #523.

Use the migration version instead of the applied version.