### PR TITLE
Add new `-engine` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 # Local testing
 .envrc
 *.FAIL
+
+# binary
+goose

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ See the docs for more [installation instructions](https://pressly.github.io/goos
 ```
 Usage: goose [OPTIONS] DRIVER DBSTRING COMMAND
 
+or
+
+Set environment key
+GOOSE_DRIVER=DRIVER
+GOOSE_DBSTRING=DBSTRING
+
+Usage: goose [OPTIONS] COMMAND
+
 Drivers:
     postgres
     mysql
@@ -71,7 +79,7 @@ Examples:
     goose sqlite3 ./foo.db create fetch_user_data go
     goose sqlite3 ./foo.db up
 
-    goose postgres "user=postgres password=postgres dbname=postgres sslmode=disable" status
+    goose postgres "user=postgres dbname=postgres sslmode=disable" status
     goose mysql "user:password@/dbname?parseTime=true" status
     goose redshift "postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" status
     goose tidb "user:password@/dbname?parseTime=true" status
@@ -79,27 +87,37 @@ Examples:
     goose clickhouse "tcp://127.0.0.1:9000" status
     goose vertica "vertica://user:password@localhost:5433/dbname?connection_load_balance=1" status
 
+    GOOSE_DRIVER=sqlite3 GOOSE_DBSTRING=./foo.db goose status
+    GOOSE_DRIVER=sqlite3 GOOSE_DBSTRING=./foo.db goose create init sql
+    GOOSE_DRIVER=postgres GOOSE_DBSTRING="user=postgres dbname=postgres sslmode=disable" goose status
+    GOOSE_DRIVER=mysql GOOSE_DBSTRING="user:password@/dbname" goose status
+    GOOSE_DRIVER=redshift GOOSE_DBSTRING="postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" goose status
+
 Options:
 
   -allow-missing
-    	applies missing (out-of-order) migrations
+        applies missing (out-of-order) migrations
   -certfile string
-    	file path to root CA's certificates in pem format (only supported on mysql)
+        file path to root CA's certificates in pem format (only support on mysql)
   -dir string
-    	directory with migration files (default ".")
-  -h	print help
+        directory with migration files (default ".")
+  -engine string
+        migrations table engine (only support on clickhouse)
+  -h    print help
+  -no-color
+        disable color output (NO_COLOR env variable supported)
   -no-versioning
-    	apply migration commands with no versioning, in file order, from directory pointed to
-  -s	use sequential numbering for new migrations
+        apply migration commands with no versioning, in file order, from directory pointed to
+  -s    use sequential numbering for new migrations
   -ssl-cert string
-    	file path to SSL certificates in pem format (only supported on mysql)
+        file path to SSL certificates in pem format (only support on mysql)
   -ssl-key string
-    	file path to SSL key in pem format (only supported on mysql)
+        file path to SSL key in pem format (only support on mysql)
   -table string
-    	migrations table name (default "goose_db_version")
-  -v	enable verbose mode
+        migrations table name (default "goose_db_version")
+  -v    enable verbose mode
   -version
-    	print version
+        print version
 
 Commands:
     up                   Migrate the DB to the most recent version available

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -25,6 +25,7 @@ var (
 	flags        = flag.NewFlagSet("goose", flag.ExitOnError)
 	dir          = flags.String("dir", cfg.DefaultMigrationDir, "directory with migration files")
 	table        = flags.String("table", "goose_db_version", "migrations table name")
+	engine       = flags.String("engine", "", "migrations table engine (only support on clickhouse)")
 	verbose      = flags.Bool("v", false, "enable verbose mode")
 	help         = flags.Bool("h", false, "print help")
 	version      = flags.Bool("version", false, "print version")
@@ -61,6 +62,7 @@ func main() {
 		goose.SetSequential(true)
 	}
 	goose.SetTableName(*table)
+	goose.SetTableEngine(*engine)
 
 	args := flags.Args()
 

--- a/internal/dialect/dialectquery/clickhouse.go
+++ b/internal/dialect/dialectquery/clickhouse.go
@@ -6,16 +6,20 @@ type Clickhouse struct{}
 
 var _ Querier = (*Clickhouse)(nil)
 
-func (c *Clickhouse) CreateTable(tableName string) string {
+func (c *Clickhouse) CreateTable(tableName string, tableEngine string) string {
+	if tableEngine == "" {
+		tableEngine = "MergeTree()"
+	}
+
 	q := `CREATE TABLE IF NOT EXISTS %s (
 		version_id Int64,
 		is_applied UInt8,
 		date Date default now(),
 		tstamp DateTime default now()
 	  )
-	  ENGINE = MergeTree()
+	  ENGINE = %s
 		ORDER BY (date)`
-	return fmt.Sprintf(q, tableName)
+	return fmt.Sprintf(q, tableName, tableEngine)
 }
 
 func (c *Clickhouse) InsertVersion(tableName string) string {

--- a/internal/dialect/dialectquery/dialectquery.go
+++ b/internal/dialect/dialectquery/dialectquery.go
@@ -4,7 +4,7 @@ package dialectquery
 // specific query.
 type Querier interface {
 	// CreateTable returns the SQL query string to create the db version table.
-	CreateTable(tableName string) string
+	CreateTable(tableName string, tableEngine string) string
 
 	// InsertVersion returns the SQL query string to insert a new version into
 	// the db version table.

--- a/internal/dialect/dialectquery/mysql.go
+++ b/internal/dialect/dialectquery/mysql.go
@@ -6,7 +6,7 @@ type Mysql struct{}
 
 var _ Querier = (*Mysql)(nil)
 
-func (m *Mysql) CreateTable(tableName string) string {
+func (m *Mysql) CreateTable(tableName string, tableEngine string) string {
 	q := `CREATE TABLE %s (
 		id serial NOT NULL,
 		version_id bigint NOT NULL,

--- a/internal/dialect/dialectquery/postgres.go
+++ b/internal/dialect/dialectquery/postgres.go
@@ -6,7 +6,7 @@ type Postgres struct{}
 
 var _ Querier = (*Postgres)(nil)
 
-func (p *Postgres) CreateTable(tableName string) string {
+func (p *Postgres) CreateTable(tableName string, tableEngine string) string {
 	q := `CREATE TABLE %s (
 		id serial NOT NULL,
 		version_id bigint NOT NULL,

--- a/internal/dialect/dialectquery/redshift.go
+++ b/internal/dialect/dialectquery/redshift.go
@@ -6,7 +6,7 @@ type Redshift struct{}
 
 var _ Querier = (*Redshift)(nil)
 
-func (r *Redshift) CreateTable(tableName string) string {
+func (r *Redshift) CreateTable(tableName string, tableEngine string) string {
 	q := `CREATE TABLE %s (
 		id integer NOT NULL identity(1, 1),
 		version_id bigint NOT NULL,

--- a/internal/dialect/dialectquery/sqlite3.go
+++ b/internal/dialect/dialectquery/sqlite3.go
@@ -6,7 +6,7 @@ type Sqlite3 struct{}
 
 var _ Querier = (*Sqlite3)(nil)
 
-func (s *Sqlite3) CreateTable(tableName string) string {
+func (s *Sqlite3) CreateTable(tableName string, tableEngine string) string {
 	q := `CREATE TABLE %s (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		version_id INTEGER NOT NULL,

--- a/internal/dialect/dialectquery/sqlserver.go
+++ b/internal/dialect/dialectquery/sqlserver.go
@@ -6,7 +6,7 @@ type Sqlserver struct{}
 
 var _ Querier = (*Sqlserver)(nil)
 
-func (s *Sqlserver) CreateTable(tableName string) string {
+func (s *Sqlserver) CreateTable(tableName string, tableEngine string) string {
 	q := `CREATE TABLE %s (
 		id INT NOT NULL IDENTITY(1,1) PRIMARY KEY,
 		version_id BIGINT NOT NULL,

--- a/internal/dialect/dialectquery/tidb.go
+++ b/internal/dialect/dialectquery/tidb.go
@@ -6,7 +6,7 @@ type Tidb struct{}
 
 var _ Querier = (*Tidb)(nil)
 
-func (t *Tidb) CreateTable(tableName string) string {
+func (t *Tidb) CreateTable(tableName string, tableEngine string) string {
 	q := `CREATE TABLE %s (
 		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE,
 		version_id bigint NOT NULL,

--- a/internal/dialect/dialectquery/vertica.go
+++ b/internal/dialect/dialectquery/vertica.go
@@ -6,7 +6,7 @@ type Vertica struct{}
 
 var _ Querier = (*Vertica)(nil)
 
-func (v *Vertica) CreateTable(tableName string) string {
+func (v *Vertica) CreateTable(tableName string, tableEngine string) string {
 	q := `CREATE TABLE %s (
 		id identity(1,1) NOT NULL,
 		version_id bigint NOT NULL,

--- a/internal/dialect/store.go
+++ b/internal/dialect/store.go
@@ -21,7 +21,7 @@ import (
 type Store interface {
 	// CreateVersionTable creates the version table within a transaction.
 	// This table is used to store goose migrations.
-	CreateVersionTable(ctx context.Context, tx *sql.Tx, tableName string) error
+	CreateVersionTable(ctx context.Context, tx *sql.Tx, tableName string, tableEngine string) error
 
 	// InsertVersion inserts a version id into the version table within a transaction.
 	InsertVersion(ctx context.Context, tx *sql.Tx, tableName string, version int64) error
@@ -87,8 +87,8 @@ type store struct {
 
 var _ Store = (*store)(nil)
 
-func (s *store) CreateVersionTable(ctx context.Context, tx *sql.Tx, tableName string) error {
-	q := s.querier.CreateTable(tableName)
+func (s *store) CreateVersionTable(ctx context.Context, tx *sql.Tx, tableName string, tableEngine string) error {
+	q := s.querier.CreateTable(tableName, tableEngine)
 	_, err := tx.ExecContext(ctx, q)
 	return err
 }

--- a/migrate.go
+++ b/migrate.go
@@ -336,7 +336,7 @@ func createVersionTable(ctx context.Context, db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	if err := store.CreateVersionTable(ctx, txn, TableName()); err != nil {
+	if err := store.CreateVersionTable(ctx, txn, TableName(), TableEngine()); err != nil {
 		_ = txn.Rollback()
 		return err
 	}

--- a/version.go
+++ b/version.go
@@ -43,3 +43,16 @@ func TableName() string {
 func SetTableName(n string) {
 	tableName = n
 }
+
+// If empty, the default engine will be used (depends of the dialect)
+var tableEngine = ""
+
+// TableEngine returns goose db version table engine
+func TableEngine() string {
+	return tableEngine
+}
+
+// SetTableEngine set goose db version table engine
+func SetTableEngine(n string) {
+	tableEngine = n
+}


### PR DESCRIPTION
I use goose on a ClickHouse cluster.
Unfortunately, the migrations table is created with the `MergeTree` engine which is perfect for a single node instance, but causes issue on a replicated clusted which should use the `ReplicatedMergeTree` engine.

This PR adds a new `-engine` option to override the engine. The default value of the option is empty, as it depends of the dialect.

Note: I implemented the feature only for ClickHouse, but I guess it could be useful for other databases like MySQL