### PR TITLE
Fix current version in empty up state

### DIFF
--- a/goose_test.go
+++ b/goose_test.go
@@ -94,7 +94,6 @@ func TestIssue532(t *testing.T) {
 
 	tempDir := t.TempDir()
 	dirFlag := "--dir=" + migrationsDir
-	params := []string{dirFlag, "sqlite3", filepath.Join(tempDir, "sql.db")}
 
 	tt := []struct {
 		command   string
@@ -103,9 +102,10 @@ func TestIssue532(t *testing.T) {
 	}{
 		{"up", true, ""},
 		{"up", false, "goose: no migrations to run. current version: 3"},
+		{"version", false, "goose: version 3"},
 	}
 	for _, tc := range tt {
-		params = append(params, tc.command)
+		params := []string{dirFlag, "sqlite3", filepath.Join(tempDir, "sql.db"), tc.command}
 		got, err := runGoose(params...)
 		check.NoError(t, err)
 		if tc.skipCheck {

--- a/goose_test.go
+++ b/goose_test.go
@@ -96,19 +96,18 @@ func TestIssue532(t *testing.T) {
 	dirFlag := "--dir=" + migrationsDir
 
 	tt := []struct {
-		command   string
-		skipCheck bool
-		output    string
+		command string
+		output  string
 	}{
-		{"up", true, ""},
-		{"up", false, "goose: no migrations to run. current version: 3"},
-		{"version", false, "goose: version 3"},
+		{"up", ""},
+		{"up", "goose: no migrations to run. current version: 3"},
+		{"version", "goose: version 3"},
 	}
 	for _, tc := range tt {
 		params := []string{dirFlag, "sqlite3", filepath.Join(tempDir, "sql.db"), tc.command}
 		got, err := runGoose(params...)
 		check.NoError(t, err)
-		if tc.skipCheck {
+		if tc.output == "" {
 			continue
 		}
 		if !strings.Contains(strings.TrimSpace(got), tc.output) {

--- a/up.go
+++ b/up.go
@@ -111,7 +111,7 @@ func UpTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
 		}
 		current = m.Version
 	}
-	if len(migrationsToApply) == 0 && option.applyUpByOne {
+	if len(migrationsToApply) == 0 {
 		current, err = GetDBVersion(db)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fix #532 

For `up` cases when there are no versions to apply (such as when you run `up` multiple times in a row), we need to lookup the current version.