### PR TITLE
Receive context in migrations

### DIFF
--- a/create.go
+++ b/create.go
@@ -99,20 +99,21 @@ SELECT 'down SQL query';
 var goSQLMigrationTemplate = template.Must(template.New("goose.go-migration").Parse(`package migrations
 
 import (
+	"context"
 	"database/sql"
 	"github.com/pressly/goose/v3"
 )
 
 func init() {
-	goose.AddMigration(up{{.CamelName}}, down{{.CamelName}})
+	goose.AddMigrationContext(up{{.CamelName}}, down{{.CamelName}})
 }
 
-func up{{.CamelName}}(tx *sql.Tx) error {
+func up{{.CamelName}}(ctx context.Context, tx *sql.Tx) error {
 	// This code is executed when the migration is applied.
 	return nil
 }
 
-func down{{.CamelName}}(tx *sql.Tx) error {
+func down{{.CamelName}}(ctx context.Context, tx *sql.Tx) error {
 	// This code is executed when the migration is rolled back.
 	return nil
 }

--- a/create.go
+++ b/create.go
@@ -99,21 +99,20 @@ SELECT 'down SQL query';
 var goSQLMigrationTemplate = template.Must(template.New("goose.go-migration").Parse(`package migrations
 
 import (
-	"context"
 	"database/sql"
 	"github.com/pressly/goose/v3"
 )
 
 func init() {
-	goose.AddMigrationContext(up{{.CamelName}}, down{{.CamelName}})
+	goose.AddMigration(up{{.CamelName}}, down{{.CamelName}})
 }
 
-func up{{.CamelName}}(ctx context.Context, tx *sql.Tx) error {
+func up{{.CamelName}}(tx *sql.Tx) error {
 	// This code is executed when the migration is applied.
 	return nil
 }
 
-func down{{.CamelName}}(ctx context.Context, tx *sql.Tx) error {
+func down{{.CamelName}}(tx *sql.Tx) error {
 	// This code is executed when the migration is rolled back.
 	return nil
 }

--- a/goose.go
+++ b/goose.go
@@ -1,6 +1,7 @@
 package goose
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/fs"
@@ -39,22 +40,34 @@ func SetBaseFS(fsys fs.FS) {
 
 // Run runs a goose command.
 func Run(command string, db *sql.DB, dir string, args ...string) error {
-	return run(command, db, dir, args)
+	ctx := context.Background()
+	return RunContext(ctx, command, db, dir, args...)
 }
 
-// Run runs a goose command with options.
+// RunContext runs a goose command.
+func RunContext(ctx context.Context, command string, db *sql.DB, dir string, args ...string) error {
+	return run(ctx, command, db, dir, args)
+}
+
+// RunWithOptions runs a goose command with options.
 func RunWithOptions(command string, db *sql.DB, dir string, args []string, options ...OptionsFunc) error {
-	return run(command, db, dir, args, options...)
+	ctx := context.Background()
+	return RunWithOptionsContext(ctx, command, db, dir, args, options...)
 }
 
-func run(command string, db *sql.DB, dir string, args []string, options ...OptionsFunc) error {
+// RunWithOptionsContext runs a goose command with options.
+func RunWithOptionsContext(ctx context.Context, command string, db *sql.DB, dir string, args []string, options ...OptionsFunc) error {
+	return run(ctx, command, db, dir, args, options...)
+}
+
+func run(ctx context.Context, command string, db *sql.DB, dir string, args []string, options ...OptionsFunc) error {
 	switch command {
 	case "up":
-		if err := Up(db, dir, options...); err != nil {
+		if err := UpContext(ctx, db, dir, options...); err != nil {
 			return err
 		}
 	case "up-by-one":
-		if err := UpByOne(db, dir, options...); err != nil {
+		if err := UpByOneContext(ctx, db, dir, options...); err != nil {
 			return err
 		}
 	case "up-to":
@@ -66,7 +79,7 @@ func run(command string, db *sql.DB, dir string, args []string, options ...Optio
 		if err != nil {
 			return fmt.Errorf("version must be a number (got '%s')", args[0])
 		}
-		if err := UpTo(db, dir, version, options...); err != nil {
+		if err := UpToContext(ctx, db, dir, version, options...); err != nil {
 			return err
 		}
 	case "create":
@@ -82,7 +95,7 @@ func run(command string, db *sql.DB, dir string, args []string, options ...Optio
 			return err
 		}
 	case "down":
-		if err := Down(db, dir, options...); err != nil {
+		if err := DownContext(ctx, db, dir, options...); err != nil {
 			return err
 		}
 	case "down-to":
@@ -94,7 +107,7 @@ func run(command string, db *sql.DB, dir string, args []string, options ...Optio
 		if err != nil {
 			return fmt.Errorf("version must be a number (got '%s')", args[0])
 		}
-		if err := DownTo(db, dir, version, options...); err != nil {
+		if err := DownToContext(ctx, db, dir, version, options...); err != nil {
 			return err
 		}
 	case "fix":
@@ -102,19 +115,19 @@ func run(command string, db *sql.DB, dir string, args []string, options ...Optio
 			return err
 		}
 	case "redo":
-		if err := Redo(db, dir, options...); err != nil {
+		if err := RedoContext(ctx, db, dir, options...); err != nil {
 			return err
 		}
 	case "reset":
-		if err := Reset(db, dir, options...); err != nil {
+		if err := ResetContext(ctx, db, dir, options...); err != nil {
 			return err
 		}
 	case "status":
-		if err := Status(db, dir, options...); err != nil {
+		if err := StatusContext(ctx, db, dir, options...); err != nil {
 			return err
 		}
 	case "version":
-		if err := Version(db, dir, options...); err != nil {
+		if err := VersionContext(ctx, db, dir, options...); err != nil {
 			return err
 		}
 	default:

--- a/migrate.go
+++ b/migrate.go
@@ -128,17 +128,35 @@ func (ms Migrations) String() string {
 // GoMigration is a Go migration func that is run within a transaction.
 type GoMigration func(tx *sql.Tx) error
 
+// GoMigrationContext is a Go migration func that is run within a transaction and receives a context.
+type GoMigrationContext func(ctx context.Context, tx *sql.Tx) error
+
 // GoMigrationNoTx is a Go migration func that is run outside a transaction.
 type GoMigrationNoTx func(db *sql.DB) error
+
+// GoMigrationNoTxContext is a Go migration func that is run outside a transaction and receives a context.
+type GoMigrationNoTxContext func(ctx context.Context, db *sql.DB) error
 
 // AddMigration adds Go migrations.
 func AddMigration(up, down GoMigration) {
 	_, filename, _, _ := runtime.Caller(1)
-	AddNamedMigration(filename, up, down)
+	// intentionally don't call to AddMigrationContext so each of these functions can calculate the filename correctly
+	AddNamedMigrationContext(filename, withContext(up), withContext(down))
+}
+
+// AddMigrationContext adds Go migrations.
+func AddMigrationContext(up, down GoMigrationContext) {
+	_, filename, _, _ := runtime.Caller(1)
+	AddNamedMigrationContext(filename, up, down)
 }
 
 // AddNamedMigration adds named Go migrations.
 func AddNamedMigration(filename string, up, down GoMigration) {
+	AddNamedMigrationContext(filename, withContext(up), withContext(down))
+}
+
+// AddNamedMigrationContext adds named Go migrations.
+func AddNamedMigrationContext(filename string, up, down GoMigrationContext) {
 	if err := register(filename, true, up, down, nil, nil); err != nil {
 		panic(err)
 	}
@@ -146,12 +164,22 @@ func AddNamedMigration(filename string, up, down GoMigration) {
 
 // AddMigrationNoTx adds Go migrations that will be run outside transaction.
 func AddMigrationNoTx(up, down GoMigrationNoTx) {
-	_, filename, _, _ := runtime.Caller(1)
-	AddNamedMigrationNoTx(filename, up, down)
+	AddMigrationNoTxContext(withContext(up), withContext(down))
+}
+
+// AddMigrationNoTxContext adds Go migrations that will be run outside transaction.
+func AddMigrationNoTxContext(up, down GoMigrationNoTxContext) {
+	_, filename, _, _ := runtime.Caller(2)
+	AddNamedMigrationNoTxContext(filename, up, down)
 }
 
 // AddNamedMigrationNoTx adds named Go migrations that will be run outside transaction.
 func AddNamedMigrationNoTx(filename string, up, down GoMigrationNoTx) {
+	AddNamedMigrationNoTxContext(filename, withContext(up), withContext(down))
+}
+
+// AddNamedMigrationNoTxContext adds named Go migrations that will be run outside transaction.
+func AddNamedMigrationNoTxContext(filename string, up, down GoMigrationNoTxContext) {
 	if err := register(filename, false, nil, nil, up, down); err != nil {
 		panic(err)
 	}
@@ -160,8 +188,8 @@ func AddNamedMigrationNoTx(filename string, up, down GoMigrationNoTx) {
 func register(
 	filename string,
 	useTx bool,
-	up, down GoMigration,
-	upNoTx, downNoTx GoMigrationNoTx,
+	up, down GoMigrationContext,
+	upNoTx, downNoTx GoMigrationNoTxContext,
 ) error {
 	// Sanity check caller did not mix tx and non-tx based functions.
 	if (up != nil || down != nil) && (upNoTx != nil || downNoTx != nil) {
@@ -177,16 +205,23 @@ func register(
 	}
 	// Add to global as a registered migration.
 	registeredGoMigrations[v] = &Migration{
-		Version:    v,
-		Next:       -1,
-		Previous:   -1,
-		Registered: true,
-		Source:     filename,
-		UseTx:      useTx,
-		UpFn:       up,
-		DownFn:     down,
-		UpFnNoTx:   upNoTx,
-		DownFnNoTx: downNoTx,
+		Version:           v,
+		Next:              -1,
+		Previous:          -1,
+		Registered:        true,
+		Source:            filename,
+		UseTx:             useTx,
+		UpFnContext:       up,
+		DownFnContext:     down,
+		UpFnNoTxContext:   upNoTx,
+		DownFnNoTxContext: downNoTx,
+		// These are deprecated and will be removed in the future.
+		// For backwards compatibility we still save the non-context versions in the struct in case someone is using them.
+		// Goose does not use these internally anymore and instead uses the context versions.
+		UpFn:       withoutContext(up),
+		DownFn:     withoutContext(down),
+		UpFnNoTx:   withoutContext(upNoTx),
+		DownFnNoTx: withoutContext(downNoTx),
 	}
 	return nil
 }
@@ -367,4 +402,27 @@ func GetDBVersionContext(ctx context.Context, db *sql.DB) (int64, error) {
 	}
 
 	return version, nil
+}
+
+// withContext changes the signature of a function that receives one argument to receive a context and the argument.
+func withContext[T any](fn func(T) error) func(context.Context, T) error {
+	if fn == nil {
+		return nil
+	}
+
+	return func(ctx context.Context, t T) error {
+		return fn(t)
+	}
+}
+
+// withoutContext changes the signature of a function that receives a context and one argument to receive only the argument.
+// When called the passed context is always context.Background().
+func withoutContext[T any](fn func(context.Context, T) error) func(T) error {
+	if fn == nil {
+		return nil
+	}
+
+	return func(t T) error {
+		return fn(context.Background(), t)
+	}
 }

--- a/migration_sql.go
+++ b/migration_sql.go
@@ -29,7 +29,7 @@ func runSQLMigration(
 
 		verboseInfo("Begin transaction")
 
-		tx, err := db.Begin()
+		tx, err := db.BeginTx(ctx, nil)
 		if err != nil {
 			return fmt.Errorf("failed to begin transaction: %w", err)
 		}

--- a/redo.go
+++ b/redo.go
@@ -1,11 +1,18 @@
 package goose
 
 import (
+	"context"
 	"database/sql"
 )
 
 // Redo rolls back the most recently applied migration, then runs it again.
 func Redo(db *sql.DB, dir string, opts ...OptionsFunc) error {
+	ctx := context.Background()
+	return RedoContext(ctx, db, dir, opts...)
+}
+
+// RedoContext rolls back the most recently applied migration, then runs it again.
+func RedoContext(ctx context.Context, db *sql.DB, dir string, opts ...OptionsFunc) error {
 	option := &options{}
 	for _, f := range opts {
 		f(option)
@@ -23,7 +30,7 @@ func Redo(db *sql.DB, dir string, opts ...OptionsFunc) error {
 		}
 		currentVersion = migrations[len(migrations)-1].Version
 	} else {
-		if currentVersion, err = GetDBVersion(db); err != nil {
+		if currentVersion, err = GetDBVersionContext(ctx, db); err != nil {
 			return err
 		}
 	}
@@ -34,10 +41,10 @@ func Redo(db *sql.DB, dir string, opts ...OptionsFunc) error {
 	}
 	current.noVersioning = option.noVersioning
 
-	if err := current.Down(db); err != nil {
+	if err := current.DownContext(ctx, db); err != nil {
 		return err
 	}
-	if err := current.Up(db); err != nil {
+	if err := current.UpContext(ctx, db); err != nil {
 		return err
 	}
 	return nil

--- a/reset.go
+++ b/reset.go
@@ -10,6 +10,11 @@ import (
 // Reset rolls back all migrations
 func Reset(db *sql.DB, dir string, opts ...OptionsFunc) error {
 	ctx := context.Background()
+	return ResetContext(ctx, db, dir, opts...)
+}
+
+// ResetContext rolls back all migrations
+func ResetContext(ctx context.Context, db *sql.DB, dir string, opts ...OptionsFunc) error {
 	option := &options{}
 	for _, f := range opts {
 		f(option)
@@ -19,7 +24,7 @@ func Reset(db *sql.DB, dir string, opts ...OptionsFunc) error {
 		return fmt.Errorf("failed to collect migrations: %w", err)
 	}
 	if option.noVersioning {
-		return DownTo(db, dir, minVersion, opts...)
+		return DownToContext(ctx, db, dir, minVersion, opts...)
 	}
 
 	statuses, err := dbMigrationsStatus(ctx, db)
@@ -32,7 +37,7 @@ func Reset(db *sql.DB, dir string, opts ...OptionsFunc) error {
 		if !statuses[migration.Version] {
 			continue
 		}
-		if err = migration.Down(db); err != nil {
+		if err = migration.DownContext(ctx, db); err != nil {
 			return fmt.Errorf("failed to db-down: %w", err)
 		}
 	}

--- a/status.go
+++ b/status.go
@@ -12,6 +12,11 @@ import (
 // Status prints the status of all migrations.
 func Status(db *sql.DB, dir string, opts ...OptionsFunc) error {
 	ctx := context.Background()
+	return StatusContext(ctx, db, dir, opts...)
+}
+
+// StatusContext prints the status of all migrations.
+func StatusContext(ctx context.Context, db *sql.DB, dir string, opts ...OptionsFunc) error {
 	option := &options{}
 	for _, f := range opts {
 		f(option)
@@ -30,7 +35,7 @@ func Status(db *sql.DB, dir string, opts ...OptionsFunc) error {
 	}
 
 	// must ensure that the version table exists if we're running on a pristine DB
-	if _, err := EnsureDBVersion(db); err != nil {
+	if _, err := EnsureDBVersionContext(ctx, db); err != nil {
 		return fmt.Errorf("failed to ensure DB version: %w", err)
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,12 +1,19 @@
 package goose
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 )
 
 // Version prints the current version of the database.
 func Version(db *sql.DB, dir string, opts ...OptionsFunc) error {
+	ctx := context.Background()
+	return VersionContext(ctx, db, dir, opts...)
+}
+
+// VersionContext prints the current version of the database.
+func VersionContext(ctx context.Context, db *sql.DB, dir string, opts ...OptionsFunc) error {
 	option := &options{}
 	for _, f := range opts {
 		f(option)
@@ -24,7 +31,7 @@ func Version(db *sql.DB, dir string, opts ...OptionsFunc) error {
 		return nil
 	}
 
-	current, err := GetDBVersion(db)
+	current, err := GetDBVersionContext(ctx, db)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is a follow-up to PR #517.
It's currently based on top of `piiano:feat/allow-setting-context` so when #517 will get merged I'll rebase it.

This PR allows defining migrations that receive context.
Old migrations that don't receive `context.Context` will still continue to work for backward compatibility.
The generation of new Go migrations changed to generate migrations that receive context.