### PR TITLE
fix: return error when no migration files are found

### DIFF
--- a/create.go
+++ b/create.go
@@ -31,24 +31,19 @@ func CreateWithTemplate(db *sql.DB, dir string, tmpl *template.Template, name, m
 	if sequential {
 		// always use DirFS here because it's modifying operation
 		migrations, err := collectMigrationsFS(osFS{}, dir, minVersion, maxVersion)
-		if err != nil {
-			if errors.Is(err, ErrNoMigrationsFound) {
-				version = fmt.Sprintf(seqVersionTemplate, int64(1))
-			} else {
-				return err
-			}
-		} else {
-			vMigrations, err := migrations.versioned()
-			if err != nil {
-				return err
-			}
+		if err != nil && !errors.Is(err, ErrNoMigrationsFound) {
+			return err
+		}
 
-			if last, err := vMigrations.Last(); err == nil {
-				version = fmt.Sprintf(seqVersionTemplate, last.Version+1)
-			}
-			if err != nil {
-				return err
-			}
+		vMigrations, err := migrations.versioned()
+		if err != nil {
+			return err
+		}
+
+		if last, err := vMigrations.Last(); err == nil {
+			version = fmt.Sprintf(seqVersionTemplate, last.Version+1)
+		} else {
+			version = fmt.Sprintf(seqVersionTemplate, int64(1))
 		}
 	}
 

--- a/create.go
+++ b/create.go
@@ -31,7 +31,7 @@ func CreateWithTemplate(db *sql.DB, dir string, tmpl *template.Template, name, m
 	if sequential {
 		// always use DirFS here because it's modifying operation
 		migrations, err := collectMigrationsFS(osFS{}, dir, minVersion, maxVersion)
-		if err != nil && !errors.Is(err, ErrNoMigrationsFound) {
+		if err != nil && !errors.Is(err, ErrNoMigrationFiles) {
 			return err
 		}
 

--- a/goose_test.go
+++ b/goose_test.go
@@ -158,6 +158,19 @@ func TestIssue293(t *testing.T) {
 	}
 }
 
+func TestIssue336(t *testing.T) {
+	t.Parallel()
+	// error when no migrations are found
+	// https://github.com/pressly/goose/issues/336
+
+	tempDir := t.TempDir()
+	params := []string{"--dir=" + tempDir, "sqlite3", filepath.Join(tempDir, "sql.db"), "up"}
+
+	_, err := runGoose(params...)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), "no migrations found")
+}
+
 func TestLiteBinary(t *testing.T) {
 	t.Parallel()
 

--- a/goose_test.go
+++ b/goose_test.go
@@ -168,7 +168,7 @@ func TestIssue336(t *testing.T) {
 
 	_, err := runGoose(params...)
 	check.HasError(t, err)
-	check.Contains(t, err.Error(), "no migrations found")
+	check.Contains(t, err.Error(), "no migration files found")
 }
 
 func TestLiteBinary(t *testing.T) {

--- a/goose_test.go
+++ b/goose_test.go
@@ -245,7 +245,7 @@ func TestEmbeddedMigrations(t *testing.T) {
 	t.Cleanup(func() { SetBaseFS(nil) })
 
 	t.Run("Migration cycle", func(t *testing.T) {
-		if err := Up(db, ""); err != nil {
+		if err := Up(db, "."); err != nil {
 			t.Errorf("Failed to run 'up' migrations: %s", err)
 		}
 
@@ -258,7 +258,7 @@ func TestEmbeddedMigrations(t *testing.T) {
 			t.Errorf("Expected version 3 after 'up', got %d", ver)
 		}
 
-		if err := Reset(db, ""); err != nil {
+		if err := Reset(db, "."); err != nil {
 			t.Errorf("Failed to run 'down' migrations: %s", err)
 		}
 

--- a/migrate.go
+++ b/migrate.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	// ErrNoMigrationsFound when no migrations have been found.
-	ErrNoMigrationsFound = errors.New("no migrations found")
+	// ErrNoMigrationFiles when no migration files have been found.
+	ErrNoMigrationFiles = errors.New("no migration files found")
 	// ErrNoCurrentVersion when a current migration version is not found.
 	ErrNoCurrentVersion = errors.New("no current version found")
 	// ErrNoNextVersion when the next migration version is not found.
@@ -258,7 +258,7 @@ func collectMigrationsFS(fsys fs.FS, dirpath string, current, target int64) (Mig
 	}
 
 	if len(migrations) == 0 {
-		return nil, ErrNoMigrationsFound
+		return nil, ErrNoMigrationFiles
 	}
 
 	migrations = sortAndConnectMigrations(migrations)


### PR DESCRIPTION
👋 Had a go at fixing #344 and #336. In fact I think #344 has already been fixed since this line will fail if the directory does not exist https://github.com/pressly/goose/blob/7dcddde25a60909edc82028faa68815e6708ced0/migrate.go#L195

However, other errors may slip though such as `open : invalid name`.

I ran the changes on the example in #344. Before we had
```
$ go run .
2023/06/20 17:15:19 goose: no migrations to run. current version: 0
```
and after these changes
```
$ go run .
2023/06/20 17:15:26 could not run migrations: no migrations found
```
