### PR TITLE
chore: add changelog and goose version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@
 - Fix empty version in log output
 - Add new `context.Context`-aware functions and methods
 
-[Unreleased]: https://github.com/bufbuild/buf/compare/v3.11.2...HEAD
+[Unreleased]: https://github.com/pressly/goose/compare/v3.11.2...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [Unreleased]
+
+- Fix `up` and `up -allowing-missing` behavior
+- Fix empty version in log output
+- Add new `context.Context`-aware functions and methods
+
+[Unreleased]: https://github.com/bufbuild/buf/compare/v3.11.2...HEAD

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ docker-cleanup:
 
 docker-start-postgres:
 	docker run --rm -d \
-		-e POSTGRES_USER=${GOOSE_POSTGRES_DB_USER} \
-		-e POSTGRES_PASSWORD=${GOOSE_POSTGRES_PASSWORD} \
-		-e POSTGRES_DB=${GOOSE_POSTGRES_DBNAME} \
-		-p ${GOOSE_POSTGRES_PORT}:5432 \
+		-e POSTGRES_USER=${POSTGRES_DB_USER} \
+		-e POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
+		-e POSTGRES_DB=${POSTGRES_DBNAME} \
+		-p ${POSTGRES_PORT}:5432 \
 		-l goose_test \
 		postgres:14-alpine -c log_statement=all

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -37,7 +37,7 @@ var (
 	noColor      = flags.Bool("no-color", false, "disable color output (NO_COLOR env variable supported)")
 )
 var (
-	gooseVersion = ""
+	gooseVersion = "v3.12.0-dev"
 )
 
 func main() {
@@ -48,10 +48,11 @@ func main() {
 	}
 
 	if *version {
-		if buildInfo, ok := debug.ReadBuildInfo(); ok && buildInfo != nil && gooseVersion == "" {
+		buildInfo, ok := debug.ReadBuildInfo()
+		if ok && buildInfo != nil && buildInfo.Main.Version != "(devel)" {
 			gooseVersion = buildInfo.Main.Version
 		}
-		fmt.Printf("goose version:%s\n", gooseVersion)
+		fmt.Printf("goose version: %s\n", gooseVersion)
 		return
 	}
 	if *verbose {


### PR DESCRIPTION
This PR is an experiment to better track unreleased work so when it's time to release we have all the correct bits.

To do so, there is a CHANGELOG.md file at the root, and there's also an "unreleased" version in `main.go`, e.g., the latest released version is `v3.11.2` and so the current version is `v3.12.0-dev`.

Once it's time to release, we update the changelog and bump the version, commit, and tag that commit. Once that's done, we "go back to development" and reset both the changelog and version.

Resetting version means bumping the minor and adding the `-dev` suffix.

This does add a bit more friction, but ultimately it's a pattern I've seen adopted elsewhere. It's an experiment, if it doesn't work out we'll scrap the idea.

Most of this can be automated with goreleaser and pre- / post- hooks.