### PR TITLE
Fix install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,11 +14,25 @@ if [ "$arch" = "aarch64" ]; then
 	arch="arm64"
 fi
 
+# Set default version to v3.11.2
+default_version="v3.11.2"
+next_version="v3.13.0"
+
+# Always display the warning message
+echo "Warning: For versions v3.13.0 or later, please consider using 'go install' instead."
+
 if [ $# -eq 0 ]; then
-	goose_uri="https://github.com/pressly/goose/releases/latest/download/goose_${os}_${arch}"
+	version="${default_version}"
 else
-	goose_uri="https://github.com/pressly/goose/releases/download/${1}/goose_${os}_${arch}"
+	version="${1}"
+	# Check if the specified version is greater than or equal to v3.13.0
+	if [ "$(printf '%s\n' "${version}" "${next_version}" | sort -V | tail -n1)" = "${version}" ]; then
+		echo "Error: Specified version is v3.13.0 or later. Please specify a version earlier than v3.13.0."
+		exit 1
+	fi
 fi
+
+goose_uri="https://github.com/pressly/goose/releases/download/${version}/goose_${os}_${arch}"
 
 goose_install="${GOOSE_INSTALL:-/usr/local}"
 bin_dir="${goose_install}/bin"


### PR DESCRIPTION
install.sh script stopped working with the release of v3.13.0, so I have fixed it.

- Display a warning to use 'go install' if you want to install versions v3.13.0 or later.

```
Warning: For versions v3.13.0 or later, please consider using 'go install' instead.
```

- By default, v3.11.2 is installed.
- Versions prior to v3.11.2 can be installed by specifying the version with install.sh
- If versions v3.13.0 or later are specified, an error will occur