### PR TITLE
chore: fix .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,10 +27,7 @@ release:
   disable: false
 
 archives:
-  - replacements:
-      386: i386
-      amd64: x86_64
-    name_template: "{{ tolower .Binary }}_{{ tolower .Os }}_{{ tolower .Arch }}"
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "386" }}i386{{ else }}{{ .Arch }}{{ end }}'
     format: binary
 
 checksum:


### PR DESCRIPTION
- https://github.com/pressly/goose/issues/546

https://goreleaser.com/deprecations/#archivesreplacements

archives.replacements was removed from goreleaser v1.19.0.

https://github.com/pressly/goose/actions/runs/5417089392/jobs/9847661601

```
Run goreleaser/goreleaser-action@v3
Downloading https://github.com/goreleaser/goreleaser/releases/download/v1.19.1/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/059a3cc2-2697-4fe0-8c66-4ff58c7affbc -f /home/runner/work/_temp/8d49dc03-a27c-4e8e-bda2-2bc1fdb51934
GoReleaser latest installed successfully
v3.13.0 tag found for commit '26295ee'
/opt/hostedtoolcache/goreleaser-action/1.19.1/x64/goreleaser release --rm-dist
Flag --rm-dist has been deprecated, please use --clean instead
  • starting release...
  • loading config file                              file=.goreleaser.yml
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 30: field replacements not found in type config.Archive
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.19.1/x64/goreleaser' failed with exit code 1
```

## Test

I confirmed this issue can be reproduced in my laptop and will be fixed by this pull request.

```console
$ goreleaser --version
  ____       ____      _
 / ___| ___ |  _ \ ___| | ___  __ _ ___  ___ _ __
| |  _ / _ \| |_) / _ \ |/ _ \/ _` / __|/ _ \ '__|
| |_| | (_) |  _ <  __/ |  __/ (_| \__ \  __/ |
 \____|\___/|_| \_\___|_|\___|\__,_|___/\___|_|
goreleaser: Deliver Go Binaries as fast and easily as possible
https://goreleaser.com

GitVersion:    1.19.1
GitCommit:     6b46a1a6aa51e45bd281d55b6e5a2315ee82f643
GitTreeState:  false
BuildDate:     2023-06-29T12:55:30Z
BuiltBy:       goreleaser
GoVersion:     go1.20.5
Compiler:      gc
ModuleSum:     h1:MVAFo62jkj6/JflxruefIwfFTqNTeNtkT12Hab1o2Lk=
Platform:      darwin/arm64
```

### AS IS

goreleaser failed.

```console
$ goreleaser --clean --snapshot release
  • starting release...
  • loading config file                              file=.goreleaser.yml
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 30: field replacements not found in type config.Archive
```

### TO BE

goreleaser succeeded.

```console
$ goreleaser --clean --snapshot release
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=4e04e08c7b1145e40e0e4529f8026ec4b4e61191 latest tag=v3.13.0
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=3.13.1-next
  • checking distribution directory
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/goose_windows_amd64_v1/goose.exe
    • building                                       binary=dist/goose_darwin_arm64/goose
    • building                                       binary=dist/goose_linux_amd64_v1/goose
    • building                                       binary=dist/goose_darwin_amd64_v1/goose
    • building                                       binary=dist/goose_windows_arm64/goose.exe
    • building                                       binary=dist/goose_linux_arm64/goose
    • took: 2s
  • archives
    • skip archiving                                 binary=goose name=goose_darwin_arm64
    • skip archiving                                 binary=goose name=goose_linux_arm64
    • skip archiving                                 binary=goose.exe name=goose_windows_arm64.exe
    • skip archiving                                 binary=goose name=goose_linux_x86_64
    • skip archiving                                 binary=goose name=goose_darwin_x86_64
    • skip archiving                                 binary=goose.exe name=goose_windows_x86_64.exe
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 2s
  • thanks for using goreleaser!
```

~~Unfortunately, I can't confirm if the asset name is correct due to the restriction of goreleaser.~~

https://goreleaser.com/customization/archive/

> The name_template option will not reflect the filenames under the dist folder if format is binary. The template will be applied only where the binaries are uploaded (e.g. GitHub releases).

I confirmed the asset names are correct.

- https://github.com/pressly/goose/pull/549#issuecomment-1615503241