### PR TITLE
fix: unterminated up statement is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Fix pre-built binary versioning and make small improvements to the build process.
+- Fix pre-built binary versioning and make small improvements to GoReleaser config.
+- Fix an edge case in the `sqlparser` where the last up statement may be ignored if it's
+  unterminated and followed by a `-- +goose Down` annotation.
 
 ## [v3.13.1] - 2023-07-03
 

--- a/internal/sqlparser/parser.go
+++ b/internal/sqlparser/parser.go
@@ -127,10 +127,11 @@ func ParseSQLMigration(r io.Reader, direction Direction, debug bool) (stmts []st
 			case "+goose Down":
 				switch stateMachine.get() {
 				case gooseUp, gooseStatementEndUp:
-					// If we hit the down annotation, but the buffer is not empty, we have an unfinished SQL query.
-					// This is an error, because we expect the SQL query to be terminated by a semicolon.
+					// If we hit a down annotation, but the buffer is not empty, we have an unfinished SQL query from a
+					// previous up annotation. This is an error, because we expect the SQL query to be terminated by a semicolon
+					// and the buffer to have been reset.
 					if bufferRemaining := strings.TrimSpace(buf.String()); len(bufferRemaining) > 0 {
-						return nil, false, fmt.Errorf("failed to parse migration: state %d, direction: %v: unexpected unfinished SQL query: %q: missing semicolon?", stateMachine.state, direction, bufferRemaining)
+						return nil, false, missingSemicolonError(stateMachine.state, direction, bufferRemaining)
 					}
 					stateMachine.set(gooseDown)
 				default:
@@ -243,10 +244,18 @@ func ParseSQLMigration(r io.Reader, direction Direction, debug bool) (stmts []st
 	}
 
 	if bufferRemaining := strings.TrimSpace(buf.String()); len(bufferRemaining) > 0 {
-		return nil, false, fmt.Errorf("failed to parse migration: state %d, direction: %v: unexpected unfinished SQL query: %q: missing semicolon?", stateMachine.state, direction, bufferRemaining)
+		return nil, false, missingSemicolonError(stateMachine.state, direction, bufferRemaining)
 	}
 
 	return stmts, useTx, nil
+}
+
+func missingSemicolonError(state parserState, direction Direction, s string) error {
+	return fmt.Errorf("failed to parse migration: state %d, direction: %v: unexpected unfinished SQL query: %q: missing semicolon?",
+		state,
+		direction,
+		s,
+	)
 }
 
 // cleanupStatement attempts to find the last semicolon and trims

--- a/internal/sqlparser/parser_test.go
+++ b/internal/sqlparser/parser_test.go
@@ -86,6 +86,22 @@ func TestSplitStatements(t *testing.T) {
 	}
 }
 
+func TestInvalidUp(t *testing.T) {
+	t.Parallel()
+
+	testdataDir := filepath.Join("testdata", "invalid", "up")
+	entries, err := os.ReadDir(testdataDir)
+	check.NoError(t, err)
+	check.NumberNotZero(t, len(entries))
+
+	for _, entry := range entries {
+		by, err := os.ReadFile(filepath.Join(testdataDir, entry.Name()))
+		check.NoError(t, err)
+		_, _, err = ParseSQLMigration(strings.NewReader(string(by)), DirectionUp, false)
+		check.HasError(t, err)
+	}
+}
+
 func TestUseTransactions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/sqlparser/testdata/invalid/up/a.sql
+++ b/internal/sqlparser/testdata/invalid/up/a.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+SELECT * FROM foo;
+SELECT * FROM bar
+-- +goose Down
+SELECT * FROM baz;

--- a/internal/sqlparser/testdata/invalid/up/b.sql
+++ b/internal/sqlparser/testdata/invalid/up/b.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+SELECT * FROM bar
+-- +goose Down
+SELECT * FROM baz;

--- a/internal/sqlparser/testdata/invalid/up/c.sql
+++ b/internal/sqlparser/testdata/invalid/up/c.sql
@@ -1,0 +1,3 @@
+-- +goose Up
+SELECT * FROM bar
+-- +goose Down

--- a/internal/sqlparser/testdata/invalid/up/d.sql
+++ b/internal/sqlparser/testdata/invalid/up/d.sql
@@ -1,0 +1,2 @@
+-- +goose Up
+SELECT * FROM bar


### PR DESCRIPTION
Fix an edge case in the sqlparser where the last unterminated up statement, before a `-- +goose Down`, is ignored.

Add a test to ensure we return an error for this condition.