### PR TITLE
Fix migrations for redshift (not working out of the box right now)

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -125,7 +125,7 @@ func main() {
 	case "sqlite3":
 		//  Internally uses the CGo-free port of SQLite: modernc.org/sqlite
 		driver = "sqlite"
-	case "postgres":
+	case "postgres", "redshift":
 		driver = "pgx"
 	}
 	db, err := goose.OpenDBWithDriver(driver, normalizeDBString(driver, dbstring, *certfile, *sslcert, *sslkey))

--- a/db.go
+++ b/db.go
@@ -15,8 +15,6 @@ func OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
 	switch driver {
 	case "mssql":
 		driver = "sqlserver"
-	case "redshift":
-		driver = "pgx"
 	case "tidb":
 		driver = "mysql"
 	}

--- a/db.go
+++ b/db.go
@@ -16,7 +16,7 @@ func OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
 	case "mssql":
 		driver = "sqlserver"
 	case "redshift":
-		driver = "postgres"
+		driver = "pgx"
 	case "tidb":
 		driver = "mysql"
 	}


### PR DESCRIPTION
redshift migrations configured to use pq driver (https://github.com/lib/pq) which is not imported into project. Because of that error is being thrown.
postgres migrations use pgx driver (https://github.com/jackc/pgx)
2 possible solutions here, either import pq or change redshift driver to pgx. This PR is with change from pq to pgx for redshift 