### PR TITLE
build: use `groups` in dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,9 +13,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    groups:
+      gomod:
+        patterns:
+          - "*"
     assignees:
       - "mfridman"
     ignore:
-      # For deps, ignore all patch updates
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,12 @@ jobs:
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on your needs.
       # ${{ github.ref_name }} or $GITHUB_REF_NAME or ${{env.GITHUB_REF_NAME}} currently.
-      - run: ./scripts/release-notes.sh ${{github.ref_name}} > ./release_notes.txt
-      - uses: goreleaser/goreleaser-action@v4
+      - name: Generate release notes
+        continue-on-error: true
+        run: ./scripts/release-notes.sh ${{github.ref_name}} > ./release_notes.txt
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        if: '!cancelled()'
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,6 @@ jobs:
         run: ./scripts/release-notes.sh ${{github.ref_name}} > ./release_notes.txt
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
-        if: '!cancelled()'
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser


### PR DESCRIPTION
Use grouped dependabot updates for go modules, recently released feature for dependabot:

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

Small tweak to `.github/workflows/release.yaml` to continue with goreleaser even if the release notes script fails.