### PR TITLE
fix(sqlparser): avoid trimming on last semicolon

### DIFF
--- a/internal/sqlparser/parser.go
+++ b/internal/sqlparser/parser.go
@@ -258,14 +258,9 @@ func missingSemicolonError(state parserState, direction Direction, s string) err
 	)
 }
 
-// cleanupStatement attempts to find the last semicolon and trims
-// the remaining chars from the input string. This is useful for cleaning
-// up a statement containing trailing comments or empty lines.
+// cleanupStatement trims whitespace from the given statement.
 func cleanupStatement(input string) string {
-	if n := strings.LastIndex(input, ";"); n > 0 {
-		return input[:n+1]
-	}
-	return input
+	return strings.TrimSpace(input)
 }
 
 // Checks the line to see if the line has a statement-ending semicolon

--- a/internal/sqlparser/parser_test.go
+++ b/internal/sqlparser/parser_test.go
@@ -396,6 +396,7 @@ func TestValidUp(t *testing.T) {
 		{Name: "test06", StatementsCount: 5},
 		{Name: "test07", StatementsCount: 1},
 		{Name: "test08", StatementsCount: 6},
+		{Name: "test09", StatementsCount: 1},
 	}
 	for _, tc := range tests {
 		path := filepath.Join("testdata", "valid-up", tc.Name)

--- a/internal/sqlparser/testdata/valid-up/test03/01.golden.sql
+++ b/internal/sqlparser/testdata/valid-up/test03/01.golden.sql
@@ -29,4 +29,5 @@ BEGIN
     
     EXECUTE a_output; 
 END; 
-' LANGUAGE 'plpgsql';
+' LANGUAGE 'plpgsql'; -- This comment WILL BE preserved.
+-- And so will this one.

--- a/internal/sqlparser/testdata/valid-up/test03/input.sql
+++ b/internal/sqlparser/testdata/valid-up/test03/input.sql
@@ -31,8 +31,8 @@ BEGIN
     
     EXECUTE a_output; 
 END; 
-' LANGUAGE 'plpgsql'; -- This comment will NOT be preserved.
--- And neither will this one.
+' LANGUAGE 'plpgsql'; -- This comment WILL BE preserved.
+-- And so will this one.
 -- +goose StatementEnd
 
 -- +goose Down

--- a/internal/sqlparser/testdata/valid-up/test06/04.golden.sql
+++ b/internal/sqlparser/testdata/valid-up/test06/04.golden.sql
@@ -10,3 +10,6 @@ BEGIN
   RETURN 1;
 END;
 $$ LANGUAGE plpgsql;
+
+-- 3 this comment WILL BE preserved
+  -- 4 this comment WILL BE preserved

--- a/internal/sqlparser/testdata/valid-up/test06/input.sql
+++ b/internal/sqlparser/testdata/valid-up/test06/input.sql
@@ -43,8 +43,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- 3 this comment will NOT be preserved
-  -- 4 this comment will NOT be preserved
+-- 3 this comment WILL BE preserved
+  -- 4 this comment WILL BE preserved
 
 
 -- +goose StatementEnd

--- a/internal/sqlparser/testdata/valid-up/test09/01.golden.sql
+++ b/internal/sqlparser/testdata/valid-up/test09/01.golden.sql
@@ -1,0 +1,2 @@
+create table t ( id int );
+update rows set value = now() -- missing semicolon. valid statement because wrapped in goose annotation, but will fail when executed.

--- a/internal/sqlparser/testdata/valid-up/test09/input.sql
+++ b/internal/sqlparser/testdata/valid-up/test09/input.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+-- +goose StatementBegin
+create table t ( id int );
+update rows set value = now() -- missing semicolon. valid statement because wrapped in goose annotation, but will fail when executed.
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TABLE IF EXISTS t;


### PR DESCRIPTION
The `cleanupStatement` function removed everything beyond the last semicolon, such as comments and whitespace. Which was primarily implemented for `StatementBegin` / `StatementEnd` to cleanup the statement.

However, this also means removing non-terminating statements as mentioned in #580 

So, this PR relaxes the cleanup to only remove whitespace. This does mean adding trailing comments will get preserved as part of the final parsed statement, but that's better than missing a statement. Databases will ignore the comments anyways.