### PR TITLE
Update the go-migrations examples

### DIFF
--- a/examples/go-migrations/00002_rename_root.go
+++ b/examples/go-migrations/00002_rename_root.go
@@ -1,27 +1,22 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/pressly/goose/v3"
 )
 
 func init() {
-	goose.AddMigration(Up00002, Down00002)
+	goose.AddMigrationContext(Up00002, Down00002)
 }
 
-func Up00002(tx *sql.Tx) error {
-	_, err := tx.Exec("UPDATE users SET username='admin' WHERE username='root';")
-	if err != nil {
-		return err
-	}
-	return nil
+func Up00002(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, "UPDATE users SET username='admin' WHERE username='root';")
+	return err
 }
 
-func Down00002(tx *sql.Tx) error {
-	_, err := tx.Exec("UPDATE users SET username='root' WHERE username='admin';")
-	if err != nil {
-		return err
-	}
-	return nil
+func Down00002(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, "UPDATE users SET username='root' WHERE username='admin';")
+	return err
 }

--- a/examples/go-migrations/00003_add_user_no_tx.go
+++ b/examples/go-migrations/00003_add_user_no_tx.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 
@@ -8,17 +9,17 @@ import (
 )
 
 func init() {
-	goose.AddMigrationNoTx(Up00003, Down00003)
+	goose.AddMigrationNoTxContext(Up00003, Down00003)
 }
 
-func Up00003(db *sql.DB) error {
+func Up00003(ctx context.Context, db *sql.DB) error {
 	id, err := getUserID(db, "jamesbond")
 	if err != nil {
 		return err
 	}
 	if id == 0 {
 		query := "INSERT INTO users (username, name, surname) VALUES ($1, $2, $3)"
-		if _, err := db.Exec(query, "jamesbond", "James", "Bond"); err != nil {
+		if _, err := db.ExecContext(ctx, query, "jamesbond", "James", "Bond"); err != nil {
 			return err
 		}
 	}
@@ -34,9 +35,9 @@ func getUserID(db *sql.DB, username string) (int, error) {
 	return id, nil
 }
 
-func Down00003(db *sql.DB) error {
+func Down00003(ctx context.Context, db *sql.DB) error {
 	query := "DELETE FROM users WHERE username = $1"
-	if _, err := db.Exec(query, "jamesbond"); err != nil {
+	if _, err := db.ExecContext(ctx, query, "jamesbond"); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Update the go-migrations examples, replace deprecated AddMigration with AddMigrationContext and AddMigrationNoTxContext