### PR TITLE
test: improve goose cli testing

### DIFF
--- a/goose_cli_test.go
+++ b/goose_cli_test.go
@@ -1,10 +1,7 @@
-package goose
+package goose_test
 
 import (
-	"database/sql"
-	"embed"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,7 +41,6 @@ func TestLiteBinary(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		total := countSQLFiles(t, "testdata/migrations")
-
 		commands := []struct {
 			cmd string
 			out string
@@ -159,84 +155,6 @@ func TestLiteBinary(t *testing.T) {
 		}
 		for i, f := range files {
 			check.Equal(t, f.Name(), expected[i])
-		}
-	})
-}
-
-//go:embed examples/sql-migrations/*.sql
-var migrations embed.FS
-
-func TestEmbeddedMigrations(t *testing.T) {
-	// not using t.Parallel here to avoid races
-	db, err := sql.Open("sqlite", "sql_embed.db")
-	if err != nil {
-		t.Fatalf("Database open failed: %s", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Remove("./sql_embed.db"); err != nil {
-			t.Logf("failed to remove %s resources: %v", t.Name(), err)
-		}
-	})
-
-	db.SetMaxOpenConns(1)
-
-	// decouple from existing structure
-	fsys, err := fs.Sub(migrations, "examples/sql-migrations")
-	if err != nil {
-		t.Fatalf("SubFS make failed: %s", err)
-	}
-
-	SetBaseFS(fsys)
-	check.NoError(t, SetDialect("sqlite3"))
-	t.Cleanup(func() { SetBaseFS(nil) })
-
-	t.Run("Migration cycle", func(t *testing.T) {
-		if err := Up(db, "."); err != nil {
-			t.Errorf("Failed to run 'up' migrations: %s", err)
-		}
-
-		ver, err := GetDBVersion(db)
-		if err != nil {
-			t.Fatalf("Failed to get migrations version: %s", err)
-		}
-
-		if ver != 3 {
-			t.Errorf("Expected version 3 after 'up', got %d", ver)
-		}
-
-		if err := Reset(db, "."); err != nil {
-			t.Errorf("Failed to run 'down' migrations: %s", err)
-		}
-
-		ver, err = GetDBVersion(db)
-		if err != nil {
-			t.Fatalf("Failed to get migrations version: %s", err)
-		}
-
-		if ver != 0 {
-			t.Errorf("Expected version 0 after 'reset', got %d", ver)
-		}
-	})
-
-	t.Run("Create uses os fs", func(t *testing.T) {
-		tmpDir := t.TempDir()
-
-		if err := Create(db, tmpDir, "test", "sql"); err != nil {
-			t.Errorf("Failed to create migration: %s", err)
-		}
-
-		paths, _ := filepath.Glob(filepath.Join(tmpDir, "*test.sql"))
-		if len(paths) == 0 {
-			t.Errorf("Failed to find created migration")
-		}
-
-		if err := Fix(tmpDir); err != nil {
-			t.Errorf("Failed to 'fix' migrations: %s", err)
-		}
-
-		_, err = os.Stat(filepath.Join(tmpDir, "00001_test.sql"))
-		if err != nil {
-			t.Errorf("Failed to locate fixed migration: %s", err)
 		}
 	})
 }

--- a/goose_embed_test.go
+++ b/goose_embed_test.go
@@ -1,0 +1,61 @@
+package goose
+
+import (
+	"database/sql"
+	"embed"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pressly/goose/v3/internal/check"
+	_ "modernc.org/sqlite"
+)
+
+//go:embed testdata/migrations/*.sql
+var embedMigrations embed.FS
+
+func TestEmbeddedMigrations(t *testing.T) {
+	dir := t.TempDir()
+	// not using t.Parallel here to avoid races
+	db, err := sql.Open("sqlite", filepath.Join(dir, "sql_embed.db"))
+	check.NoError(t, err)
+
+	db.SetMaxOpenConns(1)
+
+	migrationFiles, err := fs.ReadDir(embedMigrations, "testdata/migrations")
+	check.NoError(t, err)
+	total := len(migrationFiles)
+
+	// decouple from existing structure
+	fsys, err := fs.Sub(embedMigrations, "testdata/migrations")
+	check.NoError(t, err)
+
+	SetBaseFS(fsys)
+	t.Cleanup(func() { SetBaseFS(nil) })
+	check.NoError(t, SetDialect("sqlite3"))
+
+	t.Run("migration_cycle", func(t *testing.T) {
+		err := Up(db, ".")
+		check.NoError(t, err)
+		ver, err := GetDBVersion(db)
+		check.NoError(t, err)
+		check.Number(t, ver, total)
+		err = Reset(db, ".")
+		check.NoError(t, err)
+		ver, err = GetDBVersion(db)
+		check.NoError(t, err)
+		check.Number(t, ver, 0)
+	})
+	t.Run("create_uses_os_fs", func(t *testing.T) {
+		dir := t.TempDir()
+		err := Create(db, dir, "test", "sql")
+		check.NoError(t, err)
+		paths, _ := filepath.Glob(filepath.Join(dir, "*test.sql"))
+		check.NumberNotZero(t, len(paths))
+		err = Fix(dir)
+		check.NoError(t, err)
+		_, err = os.Stat(filepath.Join(dir, "00001_test.sql"))
+		check.NoError(t, err)
+	})
+}

--- a/goose_embed_test.go
+++ b/goose_embed_test.go
@@ -1,4 +1,4 @@
-package goose
+package goose_test
 
 import (
 	"database/sql"
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/internal/check"
 	_ "modernc.org/sqlite"
 )
@@ -31,29 +32,29 @@ func TestEmbeddedMigrations(t *testing.T) {
 	fsys, err := fs.Sub(embedMigrations, "testdata/migrations")
 	check.NoError(t, err)
 
-	SetBaseFS(fsys)
-	t.Cleanup(func() { SetBaseFS(nil) })
-	check.NoError(t, SetDialect("sqlite3"))
+	goose.SetBaseFS(fsys)
+	t.Cleanup(func() { goose.SetBaseFS(nil) })
+	check.NoError(t, goose.SetDialect("sqlite3"))
 
 	t.Run("migration_cycle", func(t *testing.T) {
-		err := Up(db, ".")
+		err := goose.Up(db, ".")
 		check.NoError(t, err)
-		ver, err := GetDBVersion(db)
+		ver, err := goose.GetDBVersion(db)
 		check.NoError(t, err)
 		check.Number(t, ver, total)
-		err = Reset(db, ".")
+		err = goose.Reset(db, ".")
 		check.NoError(t, err)
-		ver, err = GetDBVersion(db)
+		ver, err = goose.GetDBVersion(db)
 		check.NoError(t, err)
 		check.Number(t, ver, 0)
 	})
 	t.Run("create_uses_os_fs", func(t *testing.T) {
 		dir := t.TempDir()
-		err := Create(db, dir, "test", "sql")
+		err := goose.Create(db, dir, "test", "sql")
 		check.NoError(t, err)
 		paths, _ := filepath.Glob(filepath.Join(dir, "*test.sql"))
 		check.NumberNotZero(t, len(paths))
-		err = Fix(dir)
+		err = goose.Fix(dir)
 		check.NoError(t, err)
 		_, err = os.Stat(filepath.Join(dir, "00001_test.sql"))
 		check.NoError(t, err)

--- a/goose_test.go
+++ b/goose_test.go
@@ -30,9 +30,9 @@ func TestFullBinary(t *testing.T) {
 	check.Equal(t, out, "goose version: "+gooseTestBinaryVersion+"\n")
 }
 
-func TestBinary(t *testing.T) {
+func TestLiteBinary(t *testing.T) {
 	t.Parallel()
-	cli := buildGooseCLI(t)
+	cli := buildLiteGooseCLI(t)
 
 	t.Run("binary_version", func(t *testing.T) {
 		t.Parallel()

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -73,7 +73,7 @@ func Bool(t *testing.T, got, want bool) {
 func Contains(t *testing.T, got, want string) {
 	t.Helper()
 	if !strings.Contains(got, want) {
-		t.Errorf("failed to find substring %q in string value %q", got, want)
+		t.Errorf("failed to find substring:\n%s\n\nin string value:\n%s", got, want)
 	}
 }
 

--- a/testdata/migrations/00001_users_table.sql
+++ b/testdata/migrations/00001_users_table.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    username TEXT NOT NULL,
+    email TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- +goose Down
+DROP TABLE users;

--- a/testdata/migrations/00002_posts_table.sql
+++ b/testdata/migrations/00002_posts_table.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+CREATE TABLE posts (
+    id INTEGER PRIMARY KEY,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    author_id INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (author_id) REFERENCES users(id)
+);
+
+-- +goose Down
+DROP TABLE posts;

--- a/testdata/migrations/00003_comments_table.sql
+++ b/testdata/migrations/00003_comments_table.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+CREATE TABLE comments (
+    id INTEGER PRIMARY KEY,
+    post_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (post_id) REFERENCES posts(id),
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+-- +goose Down
+DROP TABLE comments;

--- a/testdata/migrations/00004_insert_data.sql
+++ b/testdata/migrations/00004_insert_data.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+INSERT INTO users (id, username, email)
+VALUES
+    (1, 'john_doe', 'john@example.com'),
+    (2, 'jane_smith', 'jane@example.com'),
+    (3, 'alice_wonderland', 'alice@example.com');
+
+INSERT INTO posts (id, title, content, author_id)
+VALUES
+    (1, 'Introduction to SQL', 'SQL is a powerful language for managing databases...', 1),
+    (2, 'Data Modeling Techniques', 'Choosing the right data model is crucial...', 2),
+    (3, 'Advanced Query Optimization', 'Optimizing queries can greatly improve...', 1);
+
+INSERT INTO comments (id, post_id, user_id, content)
+VALUES
+    (1, 1, 3, 'Great introduction! Looking forward to more.'),
+    (2, 1, 2, 'SQL can be a bit tricky at first, but practice helps.'),
+    (3, 2, 1, 'You covered normalization really well in this post.');
+
+-- +goose Down
+DELETE FROM comments;
+DELETE FROM posts;
+DELETE FROM users;

--- a/testdata/migrations/00005_posts_view.sql
+++ b/testdata/migrations/00005_posts_view.sql
@@ -1,0 +1,15 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+CREATE VIEW posts_view AS
+    SELECT
+        p.id,
+        p.title,
+        p.content,
+        p.created_at,
+        u.username AS author
+    FROM posts p
+    JOIN users u ON p.author_id = u.id;
+
+-- +goose Down
+DROP VIEW posts_view;


### PR DESCRIPTION
This PR improves the `goose_test.go` tests. I noticed we were building the full goose binary in multiple parallel tests and didn't have good output assertions.

- Build a lite version (sqlite3 driver only) once and run multiple parallel tests with a pre-built binary
- Build a full binary with all drivers
- Test linker tags `-X main.version` (avoid regressions such as #585)
- Always use `t.TempDir()` and avoid building binaries and files in the root of the project (no more manual cleanup)
- All tests can now run in parallel with their own state
- Use `_test` packages and shuffle around tests into `goose_cli_test.go` and `goose_embed_test.go`