### PR TITLE
feat: read pointed file of environment variables using `github.com/joho/godotenv`

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -17,6 +17,7 @@ import (
 	"text/tabwriter"
 	"text/template"
 
+	"github.com/joho/godotenv"
 	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/internal/cfg"
 	"github.com/pressly/goose/v3/internal/migrationstats"
@@ -37,6 +38,7 @@ var (
 	noVersioning = flags.Bool("no-versioning", false, "apply migration commands with no versioning, in file order, from directory pointed to")
 	noColor      = flags.Bool("no-color", false, "disable color output (NO_COLOR env variable supported)")
 	timeout      = flags.Duration("timeout", 0, "maximum allowed duration for queries to run; e.g., 1h13m")
+	envFile      = flags.String("env-file", ".env", "file path to a file of environment variables")
 )
 
 var version string
@@ -77,6 +79,9 @@ func main() {
 		flags.Usage()
 		os.Exit(1)
 	}
+
+	// read the `.env` or whichever file is pointed, skipping any error
+	godotenv.Load(*envFile)
 
 	// The -dir option has not been set, check whether the env variable is set
 	// before defaulting to ".".

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -81,7 +81,10 @@ func main() {
 	}
 
 	// read the `.env` or whichever file is pointed, skipping any error
-	godotenv.Load(*envFile)
+	_ = godotenv.Load(*envFile)
+
+	// load the cfg from the environment variables
+	cfg.Load()
 
 	// The -dir option has not been set, check whether the env variable is set
 	// before defaulting to ".".

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/compress v1.17.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFr
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -3,16 +3,26 @@ package cfg
 import "os"
 
 var (
-	GOOSEDRIVER       = envOr("GOOSE_DRIVER", "")
-	GOOSEDBSTRING     = envOr("GOOSE_DBSTRING", "")
-	GOOSEMIGRATIONDIR = envOr("GOOSE_MIGRATION_DIR", DefaultMigrationDir)
+	GOOSEDRIVER       = ""
+	GOOSEDBSTRING     = ""
+	GOOSEMIGRATIONDIR = DefaultMigrationDir
 	// https://no-color.org/
-	GOOSENOCOLOR = envOr("NO_COLOR", "false")
+	GOOSENOCOLOR = "false"
 )
 
 var (
 	DefaultMigrationDir = "."
 )
+
+// Load reads the config values from environment,
+// allowing them to be loaded first from file pointed by `-env-file` argument
+func Load() {
+	GOOSEDRIVER = envOr("GOOSE_DRIVER", GOOSEDRIVER)
+	GOOSEDBSTRING = envOr("GOOSE_DBSTRING", GOOSEDBSTRING)
+	GOOSEMIGRATIONDIR = envOr("GOOSE_MIGRATION_DIR", GOOSEMIGRATIONDIR)
+	// https://no-color.org/
+	GOOSENOCOLOR = envOr("NO_COLOR", GOOSENOCOLOR)
+}
 
 // An EnvVar is an environment variable Name=Value.
 type EnvVar struct {


### PR DESCRIPTION
refs https://github.com/pressly/goose/issues/347#issuecomment-1475334446

Defaulting to `.env` in the current directory.

Skipping any error, including non-existing file or errors while parsing
the file as no better options for now.