### PR TITLE
chore(readme): update install code fences

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,23 @@ Goose supports [embedding SQL migrations](#embedded-sql-migrations), which means
 
 # Install
 
-    $ go install github.com/pressly/goose/v3/cmd/goose@latest
+```shell
+go install github.com/pressly/goose/v3/cmd/goose@latest
+```
 
 This will install the `goose` binary to your `$GOPATH/bin` directory.
 
 For a lite version of the binary without DB connection dependent commands, use the exclusive build tags:
 
-    $ go build -tags='no_postgres no_mysql no_sqlite3' -o goose ./cmd/goose
+```shell
+go build -tags='no_postgres no_mysql no_sqlite3' -o goose ./cmd/goose
+```
 
 For macOS users `goose` is available as a [Homebrew Formulae](https://formulae.brew.sh/formula/goose#default):
 
-    $ brew install goose
+```shell
+brew install goose
+```
 
 See the docs for more [installation instructions](https://pressly.github.io/goose/installation/).
 


### PR DESCRIPTION
👋🏻 Hey friends, I enjoy using this project, and thought I'd push up a slightly opinionated take on the install scripts in the Readme.

**The story**:

I often go to the readme and press the copy to clipboard button that GitHub renders:

![copy-to-clipboard](https://github.com/pressly/goose/assets/11184711/3a32c803-07ac-4927-b513-1c10b08bee85)

and then paste it into my terminal. However, this adds a preceeding `$`, which causes the command to fail:

```shell
$ $ go install github.com/pressly/goose/v3/cmd/goose@latest
$: command not found
```

**The change**:

The change adds a code fence with the `shell` language, which (at least on my browser and os) looks idential in the GH UI, but when I copy the command to the clipboard, I can use it without modification.

To see what it looks like, here's the link to the install section in my fork: https://github.com/greyscaled/goose#install

and a side-by-side (original left, my fork right):

![side-by-side](https://github.com/pressly/goose/assets/11184711/98ba98c1-eade-456e-8c4f-0f6a4d645d86)


LMK what you think, thanks!