### PR TITLE
feat(experimental): keep Store internal and add Tablename method

### DIFF
--- a/database/dialect.go
+++ b/database/dialect.go
@@ -26,7 +26,7 @@ const (
 // NewStore returns a new [Store] implementation for the given dialect.
 func NewStore(dialect Dialect, tablename string) (Store, error) {
 	if tablename == "" {
-		return nil, errors.New("tablename must not be empty")
+		return nil, errors.New("table name must not be empty")
 	}
 	if dialect == "" {
 		return nil, errors.New("dialect must not be empty")

--- a/database/dialect.go
+++ b/database/dialect.go
@@ -66,6 +66,12 @@ type store struct {
 
 var _ Store = (*store)(nil)
 
+func (s *store) private() {}
+
+func (s *store) Tablename() string {
+	return s.tablename
+}
+
 func (s *store) CreateVersionTable(ctx context.Context, db DBTxConn) error {
 	q := s.querier.CreateTable(s.tablename)
 	if _, err := db.ExecContext(ctx, q); err != nil {

--- a/database/dialect.go
+++ b/database/dialect.go
@@ -23,7 +23,7 @@ const (
 	DialectYdB        Dialect = "ydb"
 )
 
-// NewStore returns a new [Store] backed by the given dialect.
+// NewStore returns a new [Store] implementation for the given dialect.
 func NewStore(dialect Dialect, tablename string) (Store, error) {
 	if tablename == "" {
 		return nil, errors.New("tablename must not be empty")

--- a/database/dialect.go
+++ b/database/dialect.go
@@ -21,10 +21,6 @@ const (
 	DialectTiDB       Dialect = "tidb"
 	DialectVertica    Dialect = "vertica"
 	DialectYdB        Dialect = "ydb"
-
-	// DialectCustom is a special dialect that allows users to provide their own [Store]
-	// implementation when constructing a [goose.Provider].
-	DialectCustom Dialect = "custom"
 )
 
 // NewStore returns a new [Store] backed by the given dialect.
@@ -34,9 +30,6 @@ func NewStore(dialect Dialect, tablename string) (Store, error) {
 	}
 	if dialect == "" {
 		return nil, errors.New("dialect must not be empty")
-	}
-	if dialect == DialectCustom {
-		return nil, errors.New("dialect must not be custom")
 	}
 	lookup := map[Dialect]dialectquery.Querier{
 		DialectClickHouse: &dialectquery.Clickhouse{},

--- a/database/dialect.go
+++ b/database/dialect.go
@@ -73,14 +73,15 @@ func (s *store) CreateVersionTable(ctx context.Context, db DBTxConn) error {
 	return nil
 }
 
-func (s *store) InsertOrDelete(ctx context.Context, db DBTxConn, direction bool, version int64) error {
-	if direction {
-		q := s.querier.InsertVersion(s.tablename)
-		if _, err := db.ExecContext(ctx, q, version, true); err != nil {
-			return fmt.Errorf("failed to insert version %d: %w", version, err)
-		}
-		return nil
+func (s *store) Insert(ctx context.Context, db DBTxConn, req InsertRequest) error {
+	q := s.querier.InsertVersion(s.tablename)
+	if _, err := db.ExecContext(ctx, q, req.Version, true); err != nil {
+		return fmt.Errorf("failed to insert version %d: %w", req.Version, err)
 	}
+	return nil
+}
+
+func (s *store) Delete(ctx context.Context, db DBTxConn, version int64) error {
 	q := s.querier.DeleteVersion(s.tablename)
 	if _, err := db.ExecContext(ctx, q, version); err != nil {
 		return fmt.Errorf("failed to delete version %d: %w", version, err)

--- a/database/store.go
+++ b/database/store.go
@@ -18,9 +18,11 @@ type Store interface {
 	// migrations.
 	CreateVersionTable(ctx context.Context, db DBTxConn) error
 
-	// InsertOrDelete inserts or deletes a version id from the version table. If direction is true,
-	// insert the version id. If direction is false, delete the version id.
-	InsertOrDelete(ctx context.Context, db DBTxConn, direction bool, version int64) error
+	// Insert inserts a version id into the version table.
+	Insert(ctx context.Context, db DBTxConn, req InsertRequest) error
+
+	// Delete deletes a version id from the version table.
+	Delete(ctx context.Context, db DBTxConn, version int64) error
 
 	// GetMigration retrieves a single migration by version id. This method may return the raw sql
 	// error if the query fails so the caller can assert for errors such as [sql.ErrNoRows].
@@ -32,6 +34,15 @@ type Store interface {
 
 	// TODO(mf): remove this method once the Provider is public and a custom Store can be used.
 	private()
+}
+
+type InsertRequest struct {
+	Version int64
+
+	// TODO(mf): in the future, we maybe want to expand this struct so implementors can store
+	// additional information. See the following issues for more information:
+	//  - https://github.com/pressly/goose/issues/422
+	//  - https://github.com/pressly/goose/issues/288
 }
 
 type GetMigrationResult struct {

--- a/database/store.go
+++ b/database/store.go
@@ -11,6 +11,9 @@ import (
 // Each database dialect requires a specific implementation of this interface. A dialect represents
 // a set of SQL statements specific to a particular database system.
 type Store interface {
+	// Tablename is the version table used to record applied migrations. Must not be empty.
+	Tablename() string
+
 	// CreateVersionTable creates the version table. This table is used to record applied
 	// migrations.
 	CreateVersionTable(ctx context.Context, db DBTxConn) error
@@ -26,6 +29,9 @@ type Store interface {
 	// ListMigrations retrieves all migrations sorted in descending order by id or timestamp. If
 	// there are no migrations, return empty slice with no error.
 	ListMigrations(ctx context.Context, db DBTxConn) ([]*ListMigrationsResult, error)
+
+	// TODO(mf): remove this method once the Provider is public and a custom Store can be used.
+	private()
 }
 
 type GetMigrationResult struct {

--- a/database/store_test.go
+++ b/database/store_test.go
@@ -31,8 +31,6 @@ func TestDialectStore(t *testing.T) {
 		// Test empty dialect.
 		_, err = database.NewStore("", "foo")
 		check.HasError(t, err)
-		_, err = database.NewStore(database.DialectCustom, "foo")
-		check.HasError(t, err)
 	})
 	t.Run("postgres", func(t *testing.T) {
 		if testing.Short() {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -52,6 +52,11 @@ func NewProvider(dialect database.Dialect, db *sql.DB, fsys fs.FS, opts ...Provi
 	if err != nil {
 		return nil, err
 	}
+	// TODO(mf): in the future we enable users to bring their own Store implementation so we should
+	// ensure at least the tablename is set.
+	if store.Tablename() == "" {
+		return nil, errors.New("invalid store implementation: table name must not be empty")
+	}
 	// Collect migrations from the filesystem and merge with registered migrations.
 	//
 	// Note, neither of these functions parse SQL migrations by default. SQL migrations are parsed

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -44,11 +44,11 @@ func NewProvider(dialect database.Dialect, db *sql.DB, fsys fs.FS, opts ...Provi
 			return nil, err
 		}
 	}
-	if dialect != "" && cfg.store != nil {
-		return nil, errors.New("cannot set both dialect and store")
-	}
 	if dialect == "" && cfg.store == nil {
 		return nil, errors.New("dialect must not be empty")
+	}
+	if dialect != "" && cfg.store != nil {
+		return nil, errors.New("cannot set both dialect and store")
 	}
 	var store database.Store
 	if dialect != "" {
@@ -60,9 +60,6 @@ func NewProvider(dialect database.Dialect, db *sql.DB, fsys fs.FS, opts ...Provi
 	} else {
 		store = cfg.store
 	}
-
-	// TODO(mf): in the future we enable users to bring their own Store implementation so we should
-	// ensure at least the tablename is set.
 	if store.Tablename() == "" {
 		return nil, errors.New("invalid store implementation: table name must not be empty")
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,7 +16,9 @@ import (
 //
 // The caller is responsible for matching the database dialect with the database/sql driver. For
 // example, if the database dialect is "postgres", the database/sql driver could be
-// github.com/lib/pq or github.com/jackc/pgx.
+// github.com/lib/pq or github.com/jackc/pgx. Each dialect has a corresponding [database.Dialect]
+// constant backed by a default [database.Store] implementation. For more advanced use cases, such
+// as using a custom table name or supplying a custom store implementation, see [WithStore].
 //
 // fsys is the filesystem used to read the migration files, but may be nil. Most users will want to
 // use [os.DirFS], os.DirFS("path/to/migrations"), to read migrations from the local filesystem.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -44,14 +44,23 @@ func NewProvider(dialect database.Dialect, db *sql.DB, fsys fs.FS, opts ...Provi
 			return nil, err
 		}
 	}
-	// Set defaults after applying user-supplied options so option funcs can check for empty values.
-	if cfg.tableName == "" {
-		cfg.tableName = DefaultTablename
+	if dialect != "" && cfg.store != nil {
+		return nil, errors.New("cannot set both dialect and store")
 	}
-	store, err := database.NewStore(dialect, cfg.tableName)
-	if err != nil {
-		return nil, err
+	if dialect == "" && cfg.store == nil {
+		return nil, errors.New("dialect must not be empty")
 	}
+	var store database.Store
+	if dialect != "" {
+		var err error
+		store, err = database.NewStore(dialect, DefaultTablename)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		store = cfg.store
+	}
+
 	// TODO(mf): in the future we enable users to bring their own Store implementation so we should
 	// ensure at least the tablename is set.
 	if store.Tablename() == "" {

--- a/internal/provider/provider_options_test.go
+++ b/internal/provider/provider_options_test.go
@@ -34,28 +34,10 @@ func TestNewProvider(t *testing.T) {
 		// Nil fsys not allowed
 		_, err = provider.NewProvider("sqlite3", db, nil)
 		check.HasError(t, err)
-		// Duplicate table name not allowed
-		_, err = provider.NewProvider("sqlite3", db, fsys,
-			provider.WithTableName("foo"),
-			provider.WithTableName("bar"),
-		)
-		check.HasError(t, err)
-		check.Equal(t, `table already set to "foo"`, err.Error())
-		// Empty table name not allowed
-		_, err = provider.NewProvider("sqlite3", db, fsys,
-			provider.WithTableName(""),
-		)
-		check.HasError(t, err)
-		check.Equal(t, "table must not be empty", err.Error())
 	})
 	t.Run("valid", func(t *testing.T) {
 		// Valid dialect, db, and fsys allowed
 		_, err = provider.NewProvider("sqlite3", db, fsys)
-		check.NoError(t, err)
-		// Valid dialect, db, fsys, and table name allowed
-		_, err = provider.NewProvider("sqlite3", db, fsys,
-			provider.WithTableName("foo"),
-		)
 		check.NoError(t, err)
 		// Valid dialect, db, fsys, and verbose allowed
 		_, err = provider.NewProvider("sqlite3", db, fsys,

--- a/internal/provider/provider_options_test.go
+++ b/internal/provider/provider_options_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/pressly/goose/v3/database"
 	"github.com/pressly/goose/v3/internal/check"
 	"github.com/pressly/goose/v3/internal/provider"
 	_ "modernc.org/sqlite"
@@ -29,20 +30,39 @@ func TestNewProvider(t *testing.T) {
 		_, err = provider.NewProvider("unknown-dialect", db, fsys)
 		check.HasError(t, err)
 		// Nil db not allowed
-		_, err = provider.NewProvider("sqlite3", nil, fsys)
+		_, err = provider.NewProvider(database.DialectSQLite3, nil, fsys)
 		check.HasError(t, err)
 		// Nil fsys not allowed
-		_, err = provider.NewProvider("sqlite3", db, nil)
+		_, err = provider.NewProvider(database.DialectSQLite3, db, nil)
+		check.HasError(t, err)
+		// Nil store not allowed
+		_, err = provider.NewProvider(database.DialectSQLite3, db, nil, provider.WithStore(nil))
+		check.HasError(t, err)
+		// Cannot set both dialect and store
+		store, err := database.NewStore(database.DialectSQLite3, "custom_table")
+		check.NoError(t, err)
+		_, err = provider.NewProvider(database.DialectSQLite3, db, nil, provider.WithStore(store))
+		check.HasError(t, err)
+		// Multiple stores not allowed
+		_, err = provider.NewProvider(database.DialectSQLite3, db, nil,
+			provider.WithStore(store),
+			provider.WithStore(store),
+		)
 		check.HasError(t, err)
 	})
 	t.Run("valid", func(t *testing.T) {
 		// Valid dialect, db, and fsys allowed
-		_, err = provider.NewProvider("sqlite3", db, fsys)
+		_, err = provider.NewProvider(database.DialectSQLite3, db, fsys)
 		check.NoError(t, err)
 		// Valid dialect, db, fsys, and verbose allowed
-		_, err = provider.NewProvider("sqlite3", db, fsys,
+		_, err = provider.NewProvider(database.DialectSQLite3, db, fsys,
 			provider.WithVerbose(testing.Verbose()),
 		)
 		check.NoError(t, err)
+		// Custom store allowed
+		store, err := database.NewStore(database.DialectSQLite3, "custom_table")
+		check.NoError(t, err)
+		_, err = provider.NewProvider("", db, nil, provider.WithStore(store))
+		check.HasError(t, err)
 	})
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -20,7 +20,7 @@ func TestProvider(t *testing.T) {
 	db, err := sql.Open("sqlite", filepath.Join(dir, "sql_embed.db"))
 	check.NoError(t, err)
 	t.Run("empty", func(t *testing.T) {
-		_, err := provider.NewProvider("sqlite3", db, fstest.MapFS{})
+		_, err := provider.NewProvider(database.DialectSQLite3, db, fstest.MapFS{})
 		check.HasError(t, err)
 		check.Bool(t, errors.Is(err, provider.ErrNoMigrations), true)
 	})
@@ -31,7 +31,7 @@ func TestProvider(t *testing.T) {
 	}
 	fsys, err := fs.Sub(mapFS, "migrations")
 	check.NoError(t, err)
-	p, err := provider.NewProvider("sqlite3", db, fsys)
+	p, err := provider.NewProvider(database.DialectSQLite3, db, fsys)
 	check.NoError(t, err)
 	sources := p.ListSources()
 	check.Equal(t, len(sources), 2)

--- a/internal/provider/run.go
+++ b/internal/provider/run.go
@@ -248,7 +248,10 @@ func (p *Provider) runIndividually(
 			if p.cfg.noVersioning {
 				return nil
 			}
-			return p.store.InsertOrDelete(ctx, tx, direction, m.Source.Version)
+			if direction {
+				return p.store.Insert(ctx, tx, database.InsertRequest{Version: m.Source.Version})
+			}
+			return p.store.Delete(ctx, tx, m.Source.Version)
 		})
 	}
 	// Run the migration outside of a transaction.
@@ -268,7 +271,10 @@ func (p *Provider) runIndividually(
 	if p.cfg.noVersioning {
 		return nil
 	}
-	return p.store.InsertOrDelete(ctx, conn, direction, m.Source.Version)
+	if direction {
+		return p.store.Insert(ctx, conn, database.InsertRequest{Version: m.Source.Version})
+	}
+	return p.store.Delete(ctx, conn, m.Source.Version)
 }
 
 // beginTx begins a transaction and runs the given function. If the function returns an error, the
@@ -367,7 +373,7 @@ func (p *Provider) ensureVersionTable(ctx context.Context, conn *sql.Conn) (retE
 		if p.cfg.noVersioning {
 			return nil
 		}
-		return p.store.InsertOrDelete(ctx, tx, true, 0)
+		return p.store.Insert(ctx, tx, database.InsertRequest{Version: 0})
 	})
 }
 

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -5,20 +5,6 @@ import (
 	"time"
 )
 
-// Dialect is the type of database dialect.
-type Dialect string
-
-const (
-	DialectClickHouse Dialect = "clickhouse"
-	DialectMSSQL      Dialect = "mssql"
-	DialectMySQL      Dialect = "mysql"
-	DialectPostgres   Dialect = "postgres"
-	DialectRedshift   Dialect = "redshift"
-	DialectSQLite3    Dialect = "sqlite3"
-	DialectTiDB       Dialect = "tidb"
-	DialectVertica    Dialect = "vertica"
-)
-
 // MigrationType is the type of migration.
 type MigrationType int
 


### PR DESCRIPTION
This PR updates the Store interface,

1. Keep it internal only (for now, as we settle on the final API). Still an interesting discussion here: https://github.com/pressly/goose/pull/608
2. Add a `Tablename() string` method to ensure ALL store implementations at least have it set. I don't think the goose package actually needs it, but if we're decoupling the store from the provider, we should have a single check for this in the provider constructor.
3. Break `InsertOrDelete` into `Insert` / `Delete` and have insert take a `InsertRequest`. This way we can future-proof the ability to pass additional information to Store implementations without breaking the contract.

This would potentially allow us to expand the goose table in a backwards-compatible way, #422 #288

In addition, 

- Add `WithStore` option to support custom implementations.