### PR TITLE
feat: Expose setter for global Go registry

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -1,0 +1,87 @@
+package goose
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	registeredGoMigrations = make(map[int64]*Migration)
+)
+
+// ResetGlobalMigrations resets the global go migrations registry.
+//
+// Not safe for concurrent use.
+func ResetGlobalMigrations() {
+	registeredGoMigrations = make(map[int64]*Migration)
+}
+
+// SetGlobalMigrations registers go migrations globally. It returns an error if a migration with the
+// same version has already been registered.
+//
+// Source may be empty, but if it is set, it must be a path with a numeric component that matches
+// the version. Do not register legacy non-context functions: UpFn, DownFn, UpFnNoTx, DownFnNoTx.
+//
+// Not safe for concurrent use.
+func SetGlobalMigrations(migrations ...Migration) error {
+	for _, m := range migrations {
+		// make a copy of the migration so we can modify it without affecting the original.
+		if err := validGoMigration(&m); err != nil {
+			return fmt.Errorf("invalid go migration: %w", err)
+		}
+		if _, ok := registeredGoMigrations[m.Version]; ok {
+			return fmt.Errorf("go migration with version %d already registered", m.Version)
+		}
+		m.Next, m.Previous = -1, -1 // Do not allow these to be set by the user.
+		registeredGoMigrations[m.Version] = &m
+	}
+	return nil
+}
+
+func validGoMigration(m *Migration) error {
+	if m == nil {
+		return errors.New("must not be nil")
+	}
+	if !m.Registered {
+		return errors.New("must be registered")
+	}
+	if m.Type != TypeGo {
+		return fmt.Errorf("type must be %q", TypeGo)
+	}
+	if m.Version < 1 {
+		return errors.New("version must be greater than zero")
+	}
+	if m.Source != "" {
+		// If the source is set, expect it to be a path with a numeric component that matches the
+		// version. This field is not intended to be used for descriptive purposes.
+		version, err := NumericComponent(m.Source)
+		if err != nil {
+			return err
+		}
+		if version != m.Version {
+			return fmt.Errorf("numeric component [%d] in go migration does not match version in source %q", m.Version, m.Source)
+		}
+	}
+	// It's valid for all of these funcs to be nil. Which means version the go migration but do not
+	// run anything.
+	if m.UpFnContext != nil && m.UpFnNoTxContext != nil {
+		return errors.New("must specify exactly one of UpFnContext or UpFnNoTxContext")
+	}
+	if m.DownFnContext != nil && m.DownFnNoTxContext != nil {
+		return errors.New("must specify exactly one of DownFnContext or DownFnNoTxContext")
+	}
+	// Do not allow legacy functions to be set.
+	if m.UpFn != nil {
+		return errors.New("must not specify UpFn")
+	}
+	if m.DownFn != nil {
+		return errors.New("must not specify DownFn")
+	}
+	if m.UpFnNoTx != nil {
+		return errors.New("must not specify UpFnNoTx")
+	}
+	if m.DownFnNoTx != nil {
+		return errors.New("must not specify DownFnNoTx")
+	}
+	return nil
+}

--- a/globals_test.go
+++ b/globals_test.go
@@ -23,7 +23,7 @@ func TestGlobalRegister(t *testing.T) {
 	)
 	check.NoError(t, err)
 	err = goose.SetGlobalMigrations(
-		goose.Migration{Registered: true, Version: 1, Type: goose.TypeGo},
+		goose.Migration{Registered: true, Version: 1, Type: goose.TypeGo, UpFnContext: fn},
 	)
 	check.NoError(t, err)
 	err = goose.SetGlobalMigrations(
@@ -32,7 +32,14 @@ func TestGlobalRegister(t *testing.T) {
 	check.HasError(t, err)
 	check.Contains(t, err.Error(), "go migration with version 1 already registered")
 	err = goose.SetGlobalMigrations(
-		goose.Migration{Registered: true, Version: 2, Source: "00002_foo.sql", Type: goose.TypeGo},
+		goose.Migration{
+			Registered:        true,
+			Version:           2,
+			Source:            "00002_foo.sql",
+			Type:              goose.TypeGo,
+			UpFnContext:       func(context.Context, *sql.Tx) error { return nil },
+			DownFnNoTxContext: func(context.Context, *sql.DB) error { return nil },
+		},
 	)
 	check.NoError(t, err)
 	// Reset.

--- a/globals_test.go
+++ b/globals_test.go
@@ -1,0 +1,106 @@
+package goose_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+	"github.com/pressly/goose/v3/internal/check"
+)
+
+func TestGlobalRegister(t *testing.T) {
+	// Avoid polluting other tests and do not run in parallel.
+	t.Cleanup(func() {
+		goose.ResetGlobalMigrations()
+	})
+	fnNoTx := func(context.Context, *sql.DB) error { return nil }
+	fn := func(context.Context, *sql.Tx) error { return nil }
+
+	// Success.
+	err := goose.SetGlobalMigrations(
+		[]goose.Migration{}...,
+	)
+	check.NoError(t, err)
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, Type: goose.TypeGo},
+	)
+	check.NoError(t, err)
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, Type: goose.TypeGo},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), "go migration with version 1 already registered")
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 2, Source: "00002_foo.sql", Type: goose.TypeGo},
+	)
+	check.NoError(t, err)
+	// Reset.
+	{
+		goose.ResetGlobalMigrations()
+	}
+	// Failure.
+	err = goose.SetGlobalMigrations(
+		goose.Migration{},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), "invalid go migration: must be registered")
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), `invalid go migration: type must be "go"`)
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, Type: goose.TypeSQL},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), `invalid go migration: type must be "go"`)
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 0, Type: goose.TypeGo},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), "invalid go migration: version must be greater than zero")
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, Source: "2_foo.sql", Type: goose.TypeGo},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), `invalid go migration: numeric component [1] in go migration does not match version in source "2_foo.sql"`)
+	// Legacy functions.
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, UpFn: func(tx *sql.Tx) error { return nil }, Type: goose.TypeGo},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), "invalid go migration: must not specify UpFn")
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, DownFn: func(tx *sql.Tx) error { return nil }, Type: goose.TypeGo},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), "invalid go migration: must not specify DownFn")
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, UpFnNoTx: func(db *sql.DB) error { return nil }, Type: goose.TypeGo},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), "invalid go migration: must not specify UpFnNoTx")
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, DownFnNoTx: func(db *sql.DB) error { return nil }, Type: goose.TypeGo},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), "invalid go migration: must not specify DownFnNoTx")
+	// Context-aware functions.
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, UpFnContext: fn, UpFnNoTxContext: fnNoTx, Type: goose.TypeGo},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), "invalid go migration: must specify exactly one of UpFnContext or UpFnNoTxContext")
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, DownFnContext: fn, DownFnNoTxContext: fnNoTx, Type: goose.TypeGo},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), "invalid go migration: must specify exactly one of DownFnContext or DownFnNoTxContext")
+	// Source and version mismatch.
+	err = goose.SetGlobalMigrations(
+		goose.Migration{Registered: true, Version: 1, Source: "invalid_numeric.sql", Type: goose.TypeGo},
+	)
+	check.HasError(t, err)
+	check.Contains(t, err.Error(), `invalid go migration: failed to parse version from migration file: invalid_numeric.sql`)
+}

--- a/migrate.go
+++ b/migrate.go
@@ -23,8 +23,6 @@ var (
 	ErrNoNextVersion = errors.New("no next version found")
 	// MaxVersion is the maximum allowed version.
 	MaxVersion int64 = math.MaxInt64
-
-	registeredGoMigrations = map[int64]*Migration{}
 )
 
 // Migrations slice.

--- a/types.go
+++ b/types.go
@@ -1,0 +1,17 @@
+package goose
+
+// MigrationType is the type of migration.
+type MigrationType string
+
+const (
+	TypeGo  MigrationType = "go"
+	TypeSQL MigrationType = "sql"
+)
+
+func (t MigrationType) String() string {
+	// This should never happen.
+	if t == "" {
+		return "unknown migration type"
+	}
+	return string(t)
+}


### PR DESCRIPTION
This PR introduces 2 functions to interact with the global go migration registry. Note, not safe for concurrent use!

> [!IMPORTANT]  
> Once #379 fully lands, users are encouraged to register Go migrations directly on the `goose.Provider`, and not globally within the package scope. 

Bonus, unlike the `init()` registration, this setter allows mixing up and down migrations with different transaction levels for the same version. For example, a caller can register an Up function that runs with `*sql.Tx` (transaction) and a Down function that runs with `*sql.DB` (no transaction).

### Example

```go
// Register one or more migrations globally
err = goose.SetGlobalMigrations(
	goose.Migration{
		Registered:        true,
		Version:           2,
		Source:            "00002_foo.sql",
		Type:              goose.TypeGo,
		UpFnContext:       func(context.Context, *sql.Tx) error { return nil },
		DownFnNoTxContext: func(context.Context, *sql.DB) error { return nil },
	},
)

// Reset global registry
goose.ResetGlobalMigrations()
```

Supersedes #351