### PR TITLE
Create an alias for Dialect from database.Dialect

### DIFF
--- a/database/store_test.go
+++ b/database/store_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/database"
 	"github.com/pressly/goose/v3/internal/check"
 	"github.com/pressly/goose/v3/internal/testdb"
@@ -23,7 +24,7 @@ func TestDialectStore(t *testing.T) {
 	t.Parallel()
 	t.Run("invalid", func(t *testing.T) {
 		// Test empty table name.
-		_, err := database.NewStore(database.DialectSQLite3, "")
+		_, err := database.NewStore(goose.DialectSQLite3, "")
 		check.HasError(t, err)
 		// Test unknown dialect.
 		_, err = database.NewStore("unknown-dialect", "foo")
@@ -40,7 +41,7 @@ func TestDialectStore(t *testing.T) {
 		db, cleanup, err := testdb.NewPostgres()
 		check.NoError(t, err)
 		t.Cleanup(cleanup)
-		testStore(context.Background(), t, database.DialectPostgres, db, func(t *testing.T, err error) {
+		testStore(context.Background(), t, goose.DialectPostgres, db, func(t *testing.T, err error) {
 			var pgErr *pgconn.PgError
 			ok := errors.As(err, &pgErr)
 			check.Bool(t, ok, true)
@@ -51,7 +52,7 @@ func TestDialectStore(t *testing.T) {
 	t.Run("sqlite3", func(t *testing.T) {
 		db, err := sql.Open("sqlite", ":memory:")
 		check.NoError(t, err)
-		testStore(context.Background(), t, database.DialectSQLite3, db, func(t *testing.T, err error) {
+		testStore(context.Background(), t, goose.DialectSQLite3, db, func(t *testing.T, err error) {
 			var sqliteErr *sqlite.Error
 			ok := errors.As(err, &sqliteErr)
 			check.Bool(t, ok, true)
@@ -63,7 +64,7 @@ func TestDialectStore(t *testing.T) {
 		dir := t.TempDir()
 		db, err := sql.Open("sqlite", filepath.Join(dir, "sql_embed.db"))
 		check.NoError(t, err)
-		store, err := database.NewStore(database.DialectSQLite3, "foo")
+		store, err := database.NewStore(goose.DialectSQLite3, "foo")
 		check.NoError(t, err)
 		err = store.CreateVersionTable(context.Background(), db)
 		check.NoError(t, err)
@@ -90,7 +91,7 @@ func TestDialectStore(t *testing.T) {
 func testStore(
 	ctx context.Context,
 	t *testing.T,
-	d database.Dialect,
+	d goose.Dialect,
 	db *sql.DB,
 	alreadyExists func(t *testing.T, err error),
 ) {

--- a/database/store_test.go
+++ b/database/store_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/database"
 	"github.com/pressly/goose/v3/internal/check"
 	"github.com/pressly/goose/v3/internal/testdb"
@@ -24,7 +23,7 @@ func TestDialectStore(t *testing.T) {
 	t.Parallel()
 	t.Run("invalid", func(t *testing.T) {
 		// Test empty table name.
-		_, err := database.NewStore(goose.DialectSQLite3, "")
+		_, err := database.NewStore(database.DialectSQLite3, "")
 		check.HasError(t, err)
 		// Test unknown dialect.
 		_, err = database.NewStore("unknown-dialect", "foo")
@@ -41,7 +40,7 @@ func TestDialectStore(t *testing.T) {
 		db, cleanup, err := testdb.NewPostgres()
 		check.NoError(t, err)
 		t.Cleanup(cleanup)
-		testStore(context.Background(), t, goose.DialectPostgres, db, func(t *testing.T, err error) {
+		testStore(context.Background(), t, database.DialectPostgres, db, func(t *testing.T, err error) {
 			var pgErr *pgconn.PgError
 			ok := errors.As(err, &pgErr)
 			check.Bool(t, ok, true)
@@ -52,7 +51,7 @@ func TestDialectStore(t *testing.T) {
 	t.Run("sqlite3", func(t *testing.T) {
 		db, err := sql.Open("sqlite", ":memory:")
 		check.NoError(t, err)
-		testStore(context.Background(), t, goose.DialectSQLite3, db, func(t *testing.T, err error) {
+		testStore(context.Background(), t, database.DialectSQLite3, db, func(t *testing.T, err error) {
 			var sqliteErr *sqlite.Error
 			ok := errors.As(err, &sqliteErr)
 			check.Bool(t, ok, true)
@@ -64,7 +63,7 @@ func TestDialectStore(t *testing.T) {
 		dir := t.TempDir()
 		db, err := sql.Open("sqlite", filepath.Join(dir, "sql_embed.db"))
 		check.NoError(t, err)
-		store, err := database.NewStore(goose.DialectSQLite3, "foo")
+		store, err := database.NewStore(database.DialectSQLite3, "foo")
 		check.NoError(t, err)
 		err = store.CreateVersionTable(context.Background(), db)
 		check.NoError(t, err)
@@ -91,7 +90,7 @@ func TestDialectStore(t *testing.T) {
 func testStore(
 	ctx context.Context,
 	t *testing.T,
-	d goose.Dialect,
+	d database.Dialect,
 	db *sql.DB,
 	alreadyExists func(t *testing.T, err error),
 ) {

--- a/dialect.go
+++ b/dialect.go
@@ -3,21 +3,23 @@ package goose
 import (
 	"fmt"
 
+	"github.com/pressly/goose/v3/database"
 	"github.com/pressly/goose/v3/internal/dialect"
 )
 
-// Dialect is the type of database dialect.
-type Dialect string
+// Dialect is the type of database dialect. It is an alias for [database.Dialect].
+type Dialect = database.Dialect
 
 const (
-	DialectClickHouse Dialect = "clickhouse"
-	DialectMSSQL      Dialect = "mssql"
-	DialectMySQL      Dialect = "mysql"
-	DialectPostgres   Dialect = "postgres"
-	DialectRedshift   Dialect = "redshift"
-	DialectSQLite3    Dialect = "sqlite3"
-	DialectTiDB       Dialect = "tidb"
-	DialectVertica    Dialect = "vertica"
+	DialectClickHouse Dialect = database.DialectClickHouse
+	DialectMSSQL      Dialect = database.DialectMSSQL
+	DialectMySQL      Dialect = database.DialectMySQL
+	DialectPostgres   Dialect = database.DialectPostgres
+	DialectRedshift   Dialect = database.DialectRedshift
+	DialectSQLite3    Dialect = database.DialectSQLite3
+	DialectTiDB       Dialect = database.DialectTiDB
+	DialectVertica    Dialect = database.DialectVertica
+	DialectYdB        Dialect = database.DialectYdB
 )
 
 func init() {

--- a/migration.go
+++ b/migration.go
@@ -37,6 +37,11 @@ func NewGoMigration(version int64, up, down *GoFunc) *Migration {
 			if f.RunTx == nil && f.RunDB != nil {
 				f.Mode = TransactionDisabled
 			}
+			// Always default to TransactionEnabled if both functions are nil. This is the most
+			// common use case.
+			if f.RunDB == nil && f.RunTx == nil {
+				f.Mode = TransactionEnabled
+			}
 		}
 		return f
 	}

--- a/provider.go
+++ b/provider.go
@@ -51,7 +51,7 @@ type Provider struct {
 // Unless otherwise specified, all methods on Provider are safe for concurrent use.
 //
 // Experimental: This API is experimental and may change in the future.
-func NewProvider(dialect database.Dialect, db *sql.DB, fsys fs.FS, opts ...ProviderOption) (*Provider, error) {
+func NewProvider(dialect Dialect, db *sql.DB, fsys fs.FS, opts ...ProviderOption) (*Provider, error) {
 	if db == nil {
 		return nil, errors.New("db must not be nil")
 	}

--- a/provider_options_test.go
+++ b/provider_options_test.go
@@ -30,18 +30,18 @@ func TestNewProvider(t *testing.T) {
 		_, err = goose.NewProvider("unknown-dialect", db, fsys)
 		check.HasError(t, err)
 		// Nil db not allowed
-		_, err = goose.NewProvider(database.DialectSQLite3, nil, fsys)
+		_, err = goose.NewProvider(goose.DialectSQLite3, nil, fsys)
 		check.HasError(t, err)
 		// Nil store not allowed
-		_, err = goose.NewProvider(database.DialectSQLite3, db, nil, goose.WithStore(nil))
+		_, err = goose.NewProvider(goose.DialectSQLite3, db, nil, goose.WithStore(nil))
 		check.HasError(t, err)
 		// Cannot set both dialect and store
-		store, err := database.NewStore(database.DialectSQLite3, "custom_table")
+		store, err := database.NewStore(goose.DialectSQLite3, "custom_table")
 		check.NoError(t, err)
-		_, err = goose.NewProvider(database.DialectSQLite3, db, nil, goose.WithStore(store))
+		_, err = goose.NewProvider(goose.DialectSQLite3, db, nil, goose.WithStore(store))
 		check.HasError(t, err)
 		// Multiple stores not allowed
-		_, err = goose.NewProvider(database.DialectSQLite3, db, nil,
+		_, err = goose.NewProvider(goose.DialectSQLite3, db, nil,
 			goose.WithStore(store),
 			goose.WithStore(store),
 		)
@@ -49,15 +49,15 @@ func TestNewProvider(t *testing.T) {
 	})
 	t.Run("valid", func(t *testing.T) {
 		// Valid dialect, db, and fsys allowed
-		_, err = goose.NewProvider(database.DialectSQLite3, db, fsys)
+		_, err = goose.NewProvider(goose.DialectSQLite3, db, fsys)
 		check.NoError(t, err)
 		// Valid dialect, db, fsys, and verbose allowed
-		_, err = goose.NewProvider(database.DialectSQLite3, db, fsys,
+		_, err = goose.NewProvider(goose.DialectSQLite3, db, fsys,
 			goose.WithVerbose(testing.Verbose()),
 		)
 		check.NoError(t, err)
 		// Custom store allowed
-		store, err := database.NewStore(database.DialectSQLite3, "custom_table")
+		store, err := database.NewStore(goose.DialectSQLite3, "custom_table")
 		check.NoError(t, err)
 		_, err = goose.NewProvider("", db, nil, goose.WithStore(store))
 		check.HasError(t, err)

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -17,7 +17,6 @@ import (
 	"testing/fstest"
 
 	"github.com/pressly/goose/v3"
-	"github.com/pressly/goose/v3/database"
 	"github.com/pressly/goose/v3/internal/check"
 	"github.com/pressly/goose/v3/internal/testdb"
 	"github.com/pressly/goose/v3/lock"
@@ -321,7 +320,7 @@ INSERT INTO owners (owner_name) VALUES ('seed-user-2');
 INSERT INTO owners (owner_name) VALUES ('seed-user-3');
 `),
 		}
-		p, err := goose.NewProvider(database.DialectSQLite3, db, mapFS)
+		p, err := goose.NewProvider(goose.DialectSQLite3, db, mapFS)
 		check.NoError(t, err)
 		_, err = p.Up(ctx)
 		check.HasError(t, err)
@@ -486,7 +485,7 @@ func TestNoVersioning(t *testing.T) {
 		// These are owners created by migration files.
 		wantOwnerCount = 4
 	)
-	p, err := goose.NewProvider(database.DialectSQLite3, db, fsys,
+	p, err := goose.NewProvider(goose.DialectSQLite3, db, fsys,
 		goose.WithVerbose(testing.Verbose()),
 		goose.WithDisableVersioning(false), // This is the default.
 	)
@@ -499,7 +498,7 @@ func TestNoVersioning(t *testing.T) {
 	check.Number(t, baseVersion, 3)
 	t.Run("seed-up-down-to-zero", func(t *testing.T) {
 		fsys := os.DirFS(filepath.Join("testdata", "no-versioning", "seed"))
-		p, err := goose.NewProvider(database.DialectSQLite3, db, fsys,
+		p, err := goose.NewProvider(goose.DialectSQLite3, db, fsys,
 			goose.WithVerbose(testing.Verbose()),
 			goose.WithDisableVersioning(true), // Provider with no versioning.
 		)
@@ -552,7 +551,7 @@ func TestAllowMissing(t *testing.T) {
 
 	t.Run("missing_now_allowed", func(t *testing.T) {
 		db := newDB(t)
-		p, err := goose.NewProvider(database.DialectSQLite3, db, newFsys(),
+		p, err := goose.NewProvider(goose.DialectSQLite3, db, newFsys(),
 			goose.WithAllowOutofOrder(false),
 		)
 		check.NoError(t, err)
@@ -607,7 +606,7 @@ func TestAllowMissing(t *testing.T) {
 
 	t.Run("missing_allowed", func(t *testing.T) {
 		db := newDB(t)
-		p, err := goose.NewProvider(database.DialectSQLite3, db, newFsys(),
+		p, err := goose.NewProvider(goose.DialectSQLite3, db, newFsys(),
 			goose.WithAllowOutofOrder(true),
 		)
 		check.NoError(t, err)
@@ -723,7 +722,7 @@ func TestGoOnly(t *testing.T) {
 				&goose.GoFunc{RunTx: newTxFn("DELETE FROM users")},
 			),
 		}
-		p, err := goose.NewProvider(database.DialectSQLite3, db, nil,
+		p, err := goose.NewProvider(goose.DialectSQLite3, db, nil,
 			goose.WithGoMigrations(register...),
 		)
 		check.NoError(t, err)
@@ -779,7 +778,7 @@ func TestGoOnly(t *testing.T) {
 				&goose.GoFunc{RunDB: newDBFn("DELETE FROM users")},
 			),
 		}
-		p, err := goose.NewProvider(database.DialectSQLite3, db, nil,
+		p, err := goose.NewProvider(goose.DialectSQLite3, db, nil,
 			goose.WithGoMigrations(register...),
 		)
 		check.NoError(t, err)
@@ -836,7 +835,7 @@ func TestLockModeAdvisorySession(t *testing.T) {
 		)
 		check.NoError(t, err)
 		p, err := goose.NewProvider(
-			database.DialectPostgres,
+			goose.DialectPostgres,
 			db,
 			os.DirFS("testdata/migrations"),
 			goose.WithSessionLocker(sessionLocker), // Use advisory session lock mode.
@@ -1093,7 +1092,7 @@ func newProviderWithDB(t *testing.T, opts ...goose.ProviderOption) (*goose.Provi
 		opts,
 		goose.WithVerbose(testing.Verbose()),
 	)
-	p, err := goose.NewProvider(database.DialectSQLite3, db, newFsys(), opts...)
+	p, err := goose.NewProvider(goose.DialectSQLite3, db, newFsys(), opts...)
 	check.NoError(t, err)
 	return p, db
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -9,7 +9,6 @@ import (
 	"testing/fstest"
 
 	"github.com/pressly/goose/v3"
-	"github.com/pressly/goose/v3/database"
 	"github.com/pressly/goose/v3/internal/check"
 	_ "modernc.org/sqlite"
 )
@@ -19,7 +18,7 @@ func TestProvider(t *testing.T) {
 	db, err := sql.Open("sqlite", filepath.Join(dir, "sql_embed.db"))
 	check.NoError(t, err)
 	t.Run("empty", func(t *testing.T) {
-		_, err := goose.NewProvider(database.DialectSQLite3, db, fstest.MapFS{})
+		_, err := goose.NewProvider(goose.DialectSQLite3, db, fstest.MapFS{})
 		check.HasError(t, err)
 		check.Bool(t, errors.Is(err, goose.ErrNoMigrations), true)
 	})
@@ -30,7 +29,7 @@ func TestProvider(t *testing.T) {
 	}
 	fsys, err := fs.Sub(mapFS, "migrations")
 	check.NoError(t, err)
-	p, err := goose.NewProvider(database.DialectSQLite3, db, fsys)
+	p, err := goose.NewProvider(goose.DialectSQLite3, db, fsys)
 	check.NoError(t, err)
 	sources := p.ListSources()
 	check.Equal(t, len(sources), 2)


### PR DESCRIPTION
This PR creates an alias for the `Dialect` to `database.Dialect`

In the NewProvider signature we use Dialect defined in `package goose`, so that callers can do:

```go
provider, err := goose.NewProvider(goose.DialectSQLite3, db, fsys)
```

Which hides `package database` entirely and makes it _much_ simpler to get started. And for those that bring their own Store implementation they'll end up setting the dialect to an empty `""` string anyways.

tl;dr - for the average user it reduces the overhead of dealing with `package database` entirely