### PR TITLE
feat: Gracefully recover Go migrations that panic

### DIFF
--- a/provider_run.go
+++ b/provider_run.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -427,7 +428,7 @@ func runMigration(ctx context.Context, db database.DBTxConn, m *Migration, direc
 func runGo(ctx context.Context, db database.DBTxConn, m *Migration, direction bool) (retErr error) {
 	defer func() {
 		if r := recover(); r != nil {
-			retErr = fmt.Errorf("panic: %v", r)
+			retErr = fmt.Errorf("panic: %v\n%s", r, debug.Stack())
 		}
 	}()
 

--- a/provider_run.go
+++ b/provider_run.go
@@ -424,7 +424,13 @@ func runMigration(ctx context.Context, db database.DBTxConn, m *Migration, direc
 
 // runGo is a helper function that runs the given Go functions in the given direction. It must only
 // be called after the migration has been initialized.
-func runGo(ctx context.Context, db database.DBTxConn, m *Migration, direction bool) error {
+func runGo(ctx context.Context, db database.DBTxConn, m *Migration, direction bool) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = fmt.Errorf("panic: %v", r)
+		}
+	}()
+
 	switch db := db.(type) {
 	case *sql.Conn:
 		return fmt.Errorf("go migrations are not supported with *sql.Conn")


### PR DESCRIPTION
Fix #642.

A nice quality of life improvement, add a `recover` when running Go migrations with the `Provider`.