### PR TITLE
Standardise the license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Standardised the MIT license (#647)
+
 ## [v3.16.0] - 2023-11-12
 
 - Added YDB support. (#592)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-The MIT License (MIT)
+MIT License
 
 Original work Copyright (c) 2012 Liam Staskawicz
 Modified work Copyright (c) 2016 Vojtech Vitek

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
+The MIT License (MIT)
+
 Original work Copyright (c) 2012 Liam Staskawicz
 Modified work Copyright (c) 2016 Vojtech Vitek
 Modified work Copyright (c) 2021 Michael Fridman, Vojtech Vitek
-
-MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
I raised issue https://github.com/pressly/goose/issues/647 detailing the problem. 

In summary the declaration of the license seems to be non-standard.  The location of the title does not conform with the definition of the license and its tripping up some 3rd party tools that analyses repo licenses. 

I've changed it to move the title to the top preserving the license below and I've changed it to the longer version of the title because all the golang libs I see use that now.