### PR TITLE
fix: Improve provider apply() errors

### DIFF
--- a/provider_errors.go
+++ b/provider_errors.go
@@ -6,9 +6,9 @@ import (
 )
 
 var (
-	// ErrVersionNotFound is returned when a specific migration version is not located.
-	// This can occur if a corresponding .sql file or a Go migration function for the
-	// specified version is missing.
+	// ErrVersionNotFound is returned when a specific migration version is not located. This can
+	// occur if a corresponding .sql file or a Go migration function for the specified version is
+	// missing.
 	ErrVersionNotFound = errors.New("version not found")
 
 	// ErrNoMigrations is returned by [NewProvider] when no migrations are found.

--- a/provider_errors.go
+++ b/provider_errors.go
@@ -7,8 +7,7 @@ import (
 
 var (
 	// ErrVersionNotFound is returned when a specific migration version is not located. This can
-	// occur if a corresponding .sql file or a Go migration function for the specified version is
-	// missing.
+	// occur if a .sql file or a Go migration function for the specified version is missing.
 	ErrVersionNotFound = errors.New("version not found")
 
 	// ErrNoMigrations is returned by [NewProvider] when no migrations are found.

--- a/provider_errors.go
+++ b/provider_errors.go
@@ -6,14 +6,21 @@ import (
 )
 
 var (
-	// ErrVersionNotFound when a migration version is not found.
+	// ErrVersionNotFound is returned when a specific migration version is not located.
+	// This can occur if a corresponding .sql file or a Go migration function for the
+	// specified version is missing.
 	ErrVersionNotFound = errors.New("version not found")
-
-	// ErrAlreadyApplied when a migration has already been applied.
-	ErrAlreadyApplied = errors.New("already applied")
 
 	// ErrNoMigrations is returned by [NewProvider] when no migrations are found.
 	ErrNoMigrations = errors.New("no migrations found")
+
+	// ErrAlreadyApplied indicates that the migration cannot be applied because it has already been
+	// executed. This error is returned by [Provider.Apply].
+	ErrAlreadyApplied = errors.New("migration already applied")
+
+	// ErrNotApplied indicates that the rollback cannot be performed because the migration has not
+	// yet been applied. This error is returned by [Provider.Apply].
+	ErrNotApplied = errors.New("migration not applied")
 
 	// errInvalidVersion is returned when a migration version is invalid.
 	errInvalidVersion = errors.New("version must be greater than 0")

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -765,6 +765,20 @@ func TestCustomStoreTableExists(t *testing.T) {
 	check.NoError(t, err)
 }
 
+func TestProviderApply(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p, err := goose.NewProvider(goose.DialectSQLite3, newDB(t), newFsys())
+	check.NoError(t, err)
+	_, err = p.ApplyVersion(ctx, 1, true)
+	check.NoError(t, err)
+	// This version has a corresponding down migration, but has never been applied.
+	_, err = p.ApplyVersion(ctx, 2, false)
+	check.HasError(t, err)
+	check.Bool(t, errors.Is(err, goose.ErrNotApplied), true)
+}
+
 type customStoreSQLite3 struct {
 	database.Store
 }

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -262,7 +262,7 @@ func TestProviderRun(t *testing.T) {
 		_, err = p.ApplyVersion(ctx, 1, true)
 		check.HasError(t, err)
 		check.Bool(t, errors.Is(err, goose.ErrAlreadyApplied), true)
-		check.Contains(t, err.Error(), "version 1: already applied")
+		check.Contains(t, err.Error(), "version 1: migration already applied")
 	})
 	t.Run("status", func(t *testing.T) {
 		ctx := context.Background()

--- a/provider_types.go
+++ b/provider_types.go
@@ -1,6 +1,10 @@
 package goose
 
-import "time"
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+)
 
 // MigrationType is the type of migration.
 type MigrationType string
@@ -30,6 +34,19 @@ type MigrationResult struct {
 	Empty bool
 	// Error is only set if the migration failed.
 	Error error
+}
+
+func (m *MigrationResult) String() string {
+	state := "OK"
+	if m.Empty {
+		state = "EMPTY"
+	}
+	return fmt.Sprintf("%-6s %-4s %s (%s)",
+		state,
+		m.Direction,
+		filepath.Base(m.Source.Path),
+		truncateDuration(m.Duration),
+	)
 }
 
 // State represents the state of a migration.


### PR DESCRIPTION
This PR adds a new error `ErrNotApplied`, that is returned from `*provider.Apply()` when trying to rollback a migration that has not been previously applied.

This makes it consistent with the up direction, which also returns an error (`ErrAlreadyApplied`) when trying to apply a migration that has previously been applied.

This set of comments aims to capture this behaviour:

```go
//  1. direction is up
//    a. migration is applied, this is an error (ErrAlreadyApplied)
//    b. migration is not applied, apply it
//  2. direction is down
//    a. migration is applied, rollback
//    b. migration is not applied, this is an error (ErrNotApplied)
```