### PR TITLE
fix: goose validate for context-aware functions

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pressly/goose/v3"
 	"github.com/pressly/goose/v3/internal/cfg"
 	"github.com/pressly/goose/v3/internal/migrationstats"
-	"github.com/pressly/goose/v3/internal/migrationstats/migrationstatsos"
 )
 
 var (
@@ -320,8 +319,10 @@ func printValidate(filename string, verbose bool) error {
 	if err != nil {
 		return err
 	}
-	fileWalker := migrationstatsos.NewFileWalker(filenames...)
-	stats, err := migrationstats.GatherStats(fileWalker, false)
+	stats, err := migrationstats.GatherStats(
+		migrationstats.NewFileWalker(filenames...),
+		false,
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/migrationstats/migration_go.go
+++ b/internal/migrationstats/migration_go.go
@@ -7,11 +7,14 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
+	"strings"
 )
 
 const (
-	registerGoFuncName     = "AddMigration"
-	registerGoFuncNameNoTx = "AddMigrationNoTx"
+	registerGoFuncName            = "AddMigration"
+	registerGoFuncNameNoTx        = "AddMigrationNoTx"
+	registerGoFuncNameContext     = "AddMigrationContext"
+	registerGoFuncNameNoTxContext = "AddMigrationNoTxContext"
 )
 
 type goMigration struct {
@@ -72,10 +75,10 @@ func parseInitFunc(fd *ast.FuncDecl) (*goMigration, error) {
 		funcName := sel.Sel.Name
 		b := false
 		switch funcName {
-		case registerGoFuncName:
+		case registerGoFuncName, registerGoFuncNameContext:
 			b = true
 			gf.useTx = &b
-		case registerGoFuncNameNoTx:
+		case registerGoFuncNameNoTx, registerGoFuncNameNoTxContext:
 			gf.useTx = &b
 		default:
 			continue
@@ -107,11 +110,15 @@ func parseInitFunc(fd *ast.FuncDecl) (*goMigration, error) {
 	}
 	// validation
 	switch gf.name {
-	case registerGoFuncName, registerGoFuncNameNoTx:
+	case registerGoFuncName, registerGoFuncNameNoTx, registerGoFuncNameContext, registerGoFuncNameNoTxContext:
 	default:
-		return nil, fmt.Errorf("goose register function must be one of: %s or %s",
-			registerGoFuncName,
-			registerGoFuncNameNoTx,
+		return nil, fmt.Errorf("goose register function must be one of: %s",
+			strings.Join([]string{
+				registerGoFuncName,
+				registerGoFuncNameNoTx,
+				registerGoFuncNameContext,
+				registerGoFuncNameNoTxContext,
+			}, ", "),
 		)
 	}
 	if gf.useTx == nil {

--- a/internal/migrationstats/migrationstats_test.go
+++ b/internal/migrationstats/migrationstats_test.go
@@ -89,7 +89,7 @@ func TestParsingGoMigrationsError(t *testing.T) {
 
 	_, err = parseGoFile(strings.NewReader(wrongName))
 	check.HasError(t, err)
-	check.Contains(t, err.Error(), "AddMigration or AddMigrationNoTx")
+	check.Contains(t, err.Error(), "AddMigration, AddMigrationNoTx, AddMigrationContext, AddMigrationNoTxContext")
 }
 
 var (

--- a/internal/migrationstats/migrationstats_walker.go
+++ b/internal/migrationstats/migrationstats_walker.go
@@ -1,17 +1,15 @@
-package migrationstatsos
+package migrationstats
 
 import (
 	"io"
 	"os"
 	"path/filepath"
-
-	"github.com/pressly/goose/v3/internal/migrationstats"
 )
 
 // NewFileWalker returns a new FileWalker for the given filenames.
 //
 // Filenames without a .sql or .go extension are ignored.
-func NewFileWalker(filenames ...string) migrationstats.FileWalker {
+func NewFileWalker(filenames ...string) FileWalker {
 	return &fileWalker{
 		filenames: filenames,
 	}
@@ -21,7 +19,7 @@ type fileWalker struct {
 	filenames []string
 }
 
-var _ migrationstats.FileWalker = (*fileWalker)(nil)
+var _ FileWalker = (*fileWalker)(nil)
 
 func (f *fileWalker) Walk(fn func(filename string, r io.Reader) error) error {
 	for _, filename := range f.filenames {


### PR DESCRIPTION
Fix #661 

This PR adds the context-aware functions as valid functions in the `goose validate` command. Namely, 

- AddMigrationContext
- AddMigrationNoTxContext