### PR TITLE
dev: add debug commands to CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ DB_CLICKHOUSE_PORT ?= 9001
 DB_YDB_PORT ?= 2136
 DB_TURSO_PORT ?= 8080
 
+list-build-tags:
+	@echo "Available build tags:"
+	@echo "  $$(rg -o --trim 'no_[a-zA-Z0-9_]+' ./cmd/goose --no-line-number --no-filename | sort | uniq | tr '\n' ' ')"
+
 .PHONY: dist
 dist:
 	@mkdir -p ./bin

--- a/cmd/goose/driver_turso.go
+++ b/cmd/goose/driver_turso.go
@@ -1,3 +1,6 @@
+//go:build !no_libsql
+// +build !no_libsql
+
 package main
 
 import (

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -119,8 +119,6 @@ func main() {
 		switch remain[0] {
 		case "drivers":
 			printDrivers()
-		case "build-tags":
-			printBuildTags()
 		}
 		return
 	}
@@ -180,21 +178,6 @@ func main() {
 	); err != nil {
 		log.Fatalf("goose run: %v", err)
 	}
-}
-
-func printBuildTags() {
-	buildTags := []string{
-		"no_clickhouse",
-		"no_libsql",
-		"no_mssql",
-		"no_mysql",
-		"no_postgres",
-		"no_sqlite3 ",
-		"no_vertica",
-		"no_ydb",
-	}
-	fmt.Println("Available build tags:")
-	fmt.Printf("  %s\n", strings.Join(buildTags, " "))
 }
 
 func printDrivers() {


### PR DESCRIPTION
This PR adds build tag constraints to the recently added libsql driver #658 

I also added a CLI command `beta drivers`. This command prints out the drivers registered by the binary. This is useful for debugging issues when folks are using build constraints, see the example below.

The top-level beta command may be a good place for us to iterate on commands and/or new features before they are considered "stable". Not all commands are intended to be stable.

Lastly, there's a `make list-build-tags` to quickly list all available builds tags.

### All drivers

```
$ go build -o goose ./cmd/goose

$ goose beta drivers
Available drivers:
  clickhouse
  libsql
  mssql
  mymysql
  mysql
  pgx, pgx/v5
  sqlite
  sqlserver
  vertica
  ydb, ydb/v3
```

### Built w/ postgres driver only

```
$ make list-build-tags
Available build tags:
  no_clickhouse no_libsql no_mssql no_mysql no_postgres no_sqlite3 no_vertica no_ydb

$ go build -tags='no_clickhouse no_libsql no_mssql no_mysql no_sqlite3 no_vertica no_ydb' -o goose ./cmd/goose

$ goose beta drivers
Available drivers:
  pgx, pgx/v5
```