### PR TITLE
fix `ListMigrations` query for YDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     SELECT * FROM regions WHERE name = '${REGION}';
     ```
 
+- Fixed query for list migrations in YDB (#684)
+
 ## [v3.17.0] - 2023-12-15
 
 - Standardised the MIT license (#647)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sethvargo/go-retry v0.2.4
 	github.com/tursodatabase/libsql-client-go v0.0.0-20231216154754-8383a53d618f
 	github.com/vertica/vertica-sql-go v1.3.3
-	github.com/ydb-platform/ydb-go-sdk/v3 v3.55.0
+	github.com/ydb-platform/ydb-go-sdk/v3 v3.55.1
 	github.com/ziutek/mymysql v1.5.4
 	go.uber.org/multierr v1.11.0
 	golang.org/x/sync v0.6.0
@@ -70,7 +70,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	github.com/ydb-platform/ydb-go-genproto v0.0.0-20231215113745-46f6d30f974a // indirect
+	github.com/ydb-platform/ydb-go-genproto v0.0.0-20240126124512-dbb0e1720dbf // indirect
 	go.opentelemetry.io/otel v1.20.0 // indirect
 	go.opentelemetry.io/otel/trace v1.20.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,12 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/ydb-platform/ydb-go-genproto v0.0.0-20231215113745-46f6d30f974a h1:9wx+kCrCQCdwmDe1AFW5yAHdzlo+RV7lcy6y7Zq661s=
 github.com/ydb-platform/ydb-go-genproto v0.0.0-20231215113745-46f6d30f974a/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20240126124512-dbb0e1720dbf h1:ckwNHVo4bv2tqNkgx3W3HANh3ta1j6TR5qw08J1A7Tw=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20240126124512-dbb0e1720dbf/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.55.0 h1:KqnJX8vE4+33FXgsbigjsIOhFfJYppFsupZcw4NjBks=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.55.0/go.mod h1:1UiKA9dSZM4gbFEBw2nT/7bHgWIGaCU1i8DFj0LP460=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.55.1 h1:Ebo6J5AMXgJ3A438ECYotA0aK7ETqjQx9WoZvVxzKBE=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.55.1/go.mod h1:udNPW8eupyH/EZocecFmaSNJacKKYjzQa7cVgX5U2nc=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/dialect/dialectquery/ydb.go
+++ b/internal/dialect/dialectquery/ydb.go
@@ -41,10 +41,6 @@ func (c *Ydb) GetMigrationByVersion(tableName string) string {
 }
 
 func (c *Ydb) ListMigrations(tableName string) string {
-	// "--!syntax_pg" enables query processing with PostgreSQL-compatible syntax.
-	// YQL by design strictly forbids the execution of SELECT statements without columns from ORDER BY clause.
-	// In PostgreSQL-compatible mode, SELECT statements can be processed without columns from ORDER BY clause.
-	q := `--!syntax_pg
-	SELECT version_id, is_applied FROM %s ORDER BY tstamp DESC`
+	q := `SELECT version_id, is_applied FROM %s ORDER BY version_id DESC`
 	return fmt.Sprintf(q, tableName)
 }

--- a/internal/dialect/dialectquery/ydb.go
+++ b/internal/dialect/dialectquery/ydb.go
@@ -41,6 +41,8 @@ func (c *Ydb) GetMigrationByVersion(tableName string) string {
 }
 
 func (c *Ydb) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied FROM %s ORDER BY version_id DESC`
+	q := `
+	SELECT version_id, is_applied, tstamp AS __discard_column_tstamp 
+	FROM %s ORDER BY __discard_column_tstamp DESC`
 	return fmt.Sprintf(q, tableName)
 }


### PR DESCRIPTION
Fix for #684

Some postgresql compatibility was broken. Thats why a query with `--!syntax_pg` not worked on `trunk` version of YDB
Rewrite of query for ListMigrations can helps for YDB since 23.3 and to trunk version