### PR TITLE
fix selecting dialect

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -130,15 +130,6 @@ func main() {
 	}
 
 	driver, dbstring, command := args[0], args[1], args[2]
-	// To avoid breaking existing consumers. An implementation detail
-	// that consumers should not care which underlying driver is used.
-	switch driver {
-	case "sqlite3":
-		//  Internally uses the CGo-free port of SQLite: modernc.org/sqlite
-		driver = "sqlite"
-	case "postgres", "redshift":
-		driver = "pgx"
-	}
 	db, err := goose.OpenDBWithDriver(driver, normalizeDBString(driver, dbstring, *certfile, *sslcert, *sslkey))
 	if err != nil {
 		log.Fatalf("-dbstring=%q: %v\n", dbstring, err)

--- a/db.go
+++ b/db.go
@@ -12,6 +12,8 @@ func OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
 		return nil, err
 	}
 
+	// To avoid breaking existing consumers. An implementation detail
+	// that consumers should not care which underlying driver is used.
 	switch driver {
 	case "mssql":
 		driver = "sqlserver"
@@ -19,6 +21,11 @@ func OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
 		driver = "mysql"
 	case "turso":
 		driver = "libsql"
+	case "sqlite3":
+		//  Internally uses the CGo-free port of SQLite: modernc.org/sqlite
+		driver = "sqlite"
+	case "postgres", "redshift":
+		driver = "pgx"
 	}
 
 	switch driver {


### PR DESCRIPTION
Changed the driver to `pgx` before dialect selection, preventing the correct `redshift` dialect from being applied. This resulted in errors due to the usage of the unsupported Serial type in Redshift, as shown by "2024/02/02 04:56:32 goose run: ERROR: Column 'goose_db_version.id' has unsupported type 'serial'. (SQLSTATE 0A000)."