### PR TITLE
Add GOOSE_MIGRATION_DIR environment variable to the usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ or
 Set environment key
 GOOSE_DRIVER=DRIVER
 GOOSE_DBSTRING=DBSTRING
+GOOSE_MIGRATION_DIR=MIGRATION_DIR
 
 Usage: goose [OPTIONS] COMMAND
 
@@ -110,7 +111,7 @@ Options:
   -certfile string
         file path to root CA's certificates in pem format (only support on mysql)
   -dir string
-        directory with migration files (default ".")
+        directory with migration files (default ".", can be set via the GOOSE_MIGRATION_DIR env variable).
   -h    print help
   -no-color
         disable color output (NO_COLOR env variable supported)

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	flags        = flag.NewFlagSet("goose", flag.ExitOnError)
-	dir          = flags.String("dir", cfg.DefaultMigrationDir, "directory with migration files")
+	dir          = flags.String("dir", cfg.DefaultMigrationDir, "directory with migration files, (GOOSE_MIGRATION_DIR env variable supported)")
 	table        = flags.String("table", "goose_db_version", "migrations table name")
 	verbose      = flags.Bool("v", false, "enable verbose mode")
 	help         = flags.Bool("h", false, "print help")


### PR DESCRIPTION
Had to look through the code to find out if I could set it.

Thought it would be nice to add to the usage instructions as it's nice to be able to type goose up (or any other commands) without having to specify the directory on the command line.
