### PR TITLE
build: improve CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run unit tests
@@ -38,3 +42,7 @@ jobs:
           go vet ./...
           go build ./...
           make test-packages
+      - name: Gorelease dry-run
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.go-version == '1.22'
+        run: |
+          goreleaser build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run e2e tests

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,6 +5,11 @@ on:
       - master
       - main
   pull_request:
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golangci:
     name: lint


### PR DESCRIPTION
This PR does 2 things:

1. Add concurrency to limit a single job per workflow/ref (cancel in progress ones), this eliminates the need to have workers do unnecessary work.
2. Add a goreleaser check to ensure a build is successful for every merge on master, that way we have confidence that a subsequent tag won't fail.