### PR TITLE
Verbose logging of statement outputs.

### DIFF
--- a/internal/sqlparser/parser.go
+++ b/internal/sqlparser/parser.go
@@ -256,12 +256,18 @@ func ParseSQLMigration(r io.Reader, direction Direction, debug bool) (stmts []st
 				stateMachine.print("store simple Down query")
 			}
 		case gooseStatementEndUp:
-			stmts = append(stmts, cleanupStatement(buf.String()))
+			parts := strings.Split(buf.String(), ";")
+			for _, part := range parts[:len(parts)-1] {
+				stmts = append(stmts, cleanupStatement(part))
+			}
 			buf.Reset()
 			stateMachine.print("store Up statement")
 			stateMachine.set(gooseUp)
 		case gooseStatementEndDown:
-			stmts = append(stmts, cleanupStatement(buf.String()))
+			parts := strings.Split(buf.String(), ";")
+			for _, part := range parts[:len(parts)-1] {
+				stmts = append(stmts, cleanupStatement(part))
+			}
 			buf.Reset()
 			stateMachine.print("store Down statement")
 			stateMachine.set(gooseDown)


### PR DESCRIPTION
Using the `-verbose` flag, this change outputs the returned value of migration statements.

One use case is logging the changed rows using a `RETURNING` SQL keyword. For example:

```sql
update users set is_admin = true where department = 'engineering' returning id, email;
```

Verbose logging would contain something like:

```
...
2024/04/05 08:07:30 Returned row: [9 jane@test.com]
2024/04/05 08:07:30 Returned row: [6 sari@test.com]
2024/04/05 08:07:30 Returned row: [7 raoul@test.com]
...
```

This could be useful as a record in your CI logs, for example.

TODO:

- [ ] Unit tests
- [ ] Support for Go migrations