### PR TITLE
Add provider HasPending method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,14 @@ test-packages:
 test-packages-short:
 	go test -test.short $(GO_TEST_FLAGS) $$(go list ./... | grep -v -e /tests -e /bin -e /cmd -e /examples)
 
+coverage-short:
+	go test ./ -test.short  $(GO_TEST_FLAGS) -cover -coverprofile=coverage.out
+	go tool cover -html=coverage.out
+
+coverage:
+	go test ./ $(GO_TEST_FLAGS) -cover -coverprofile=coverage.out
+	go tool cover -html=coverage.out
+
 #
 # Integration-related targets
 #

--- a/provider.go
+++ b/provider.go
@@ -23,8 +23,9 @@ type Provider struct {
 	// database.
 	mu sync.Mutex
 
-	db    *sql.DB
-	store database.Store
+	db               *sql.DB
+	store            database.Store
+	versionTableOnce sync.Once
 
 	fsys fs.FS
 	cfg  config

--- a/provider.go
+++ b/provider.go
@@ -235,6 +235,13 @@ func (p *Provider) Up(ctx context.Context) ([]*MigrationResult, error) {
 // UpByOne applies the next pending migration. If there is no next migration to apply, this method
 // returns [ErrNoNextVersion].
 func (p *Provider) UpByOne(ctx context.Context) (*MigrationResult, error) {
+	hasPending, err := p.HasPending(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !hasPending {
+		return nil, ErrNoNextVersion
+	}
 	res, err := p.up(ctx, true, math.MaxInt64)
 	if err != nil {
 		return nil, err

--- a/provider.go
+++ b/provider.go
@@ -480,8 +480,8 @@ func (p *Provider) hasPending(ctx context.Context) (_ bool, retErr error) {
 		}
 		return false, nil
 	}
-	// If missing migrations are not allowed, we can optimize this by checking the last migration
-	// version in the database.
+	// If missing migrations are not allowed, we can optimize this by only checking whether the last
+	// migration this provider knows about is applied.
 	last := p.migrations[len(p.migrations)-1]
 	if _, err := p.store.GetMigration(ctx, conn, last.Version); err != nil {
 		if errors.Is(err, database.ErrVersionNotFound) {

--- a/provider.go
+++ b/provider.go
@@ -156,8 +156,8 @@ func (p *Provider) Status(ctx context.Context) ([]*MigrationStatus, error) {
 
 // HasPending returns true if there are pending migrations to apply, otherwise, it returns false.
 //
-// Note, this method does not use a SessionLocker. This allows callers to check for pending
-// migrations without blocking or being blocked by other operations.
+// Note, this method will not use a SessionLocker if one is configured. This allows callers to check
+// for pending migrations without blocking or being blocked by other operations.
 func (p *Provider) HasPending(ctx context.Context) (bool, error) {
 	return p.hasPending(ctx)
 }

--- a/provider_run.go
+++ b/provider_run.go
@@ -51,8 +51,14 @@ func (p *Provider) resolveUpMigrations(
 		if len(collected) > 1 {
 			msg += "s"
 		}
-		return nil, fmt.Errorf("found %d missing (out-of-order) %s lower than current max (%d): [%s]",
-			len(missingMigrations), msg, dbMaxVersion, strings.Join(collected, ","),
+		var versionsMsg string
+		if len(collected) > 1 {
+			versionsMsg = "versions " + strings.Join(collected, ",")
+		} else {
+			versionsMsg = "version " + collected[0]
+		}
+		return nil, fmt.Errorf("found %d missing (out-of-order) %s lower than current max (%d): %s",
+			len(missingMigrations), msg, dbMaxVersion, versionsMsg,
 		)
 	}
 	for _, missingVersion := range missingMigrations {

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -791,7 +791,7 @@ func TestHasPending(t *testing.T) {
 		hasPending, err := p.HasPending(ctx)
 		check.NoError(t, err)
 		check.Bool(t, hasPending, true)
-		// Apply the missing migration.
+		// Apply the missing migrations.
 		_, err = p.Up(ctx)
 		check.NoError(t, err)
 		// All migrations have been applied.

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -786,7 +786,7 @@ func TestHasPending(t *testing.T) {
 		// Some migrations have been applied out of order.
 		_, err = p.ApplyVersion(ctx, 1, true)
 		check.NoError(t, err)
-		p.ApplyVersion(ctx, 3, true)
+		_, err = p.ApplyVersion(ctx, 3, true)
 		check.NoError(t, err)
 		hasPending, err := p.HasPending(ctx)
 		check.NoError(t, err)
@@ -808,7 +808,7 @@ func TestHasPending(t *testing.T) {
 		// Some migrations have been applied.
 		_, err = p.ApplyVersion(ctx, 1, true)
 		check.NoError(t, err)
-		p.ApplyVersion(ctx, 2, true)
+		_, err = p.ApplyVersion(ctx, 2, true)
 		check.NoError(t, err)
 		hasPending, err := p.HasPending(ctx)
 		check.NoError(t, err)


### PR DESCRIPTION
Fix #640 

This PR adds a new provider method to check for pending migrations. 

```go
func (p *Provider) HasPending(context.Context) (bool, error) {}
```

This functionality is especially useful for cases like @roblaszczak described in https://github.com/pressly/goose/pull/507#discussion_r1266498077 (I'll try to summarize this when writing up the documentation for this).

> [!IMPORTANT]  
> This underlying implementation does not respect the `SessionLocker` and can be used to check for pending migrations **without blocking or being blocked by other operations**.

I've also added this before running `.Up()`, `.UpTo`, `.UpByOne` methods, which means those methods don't have to acquire the session lock (if enabled) until it's truly required to begin an operation.

This is quite necessary in k8s-type environments where newer pods have long-running migrations, and older pods being bounced/rebooted/recovering from a crash/etc. are blocked by the `SessionLocker` and the entire application is down waiting on the long-running migration from one of the newer pods to complete.

There's an edge case that needs to be accounted for. Since `HasPending` doesn't use a `SessionLocker`, we need to make the initial table version creation retriable since there can be multiple instances trying to create it in parallel. Worst case instance 1 creates the table and instance 2 fails on its first try, then on the second try it succeeds. Retry 3 times every 1 second.

### Debug notes

```sh
seq 100 | xargs -I{} -P 4 -n 1 sh -c 'go test -timeout 30s -run ^TestPostgresHasPending$ ./internal/testing/integration -race -count=1 >> log.out'
```