### PR TITLE
Add StoreController to allowing extending interface

### DIFF
--- a/database/controller.go
+++ b/database/controller.go
@@ -1,0 +1,73 @@
+package database
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrNotSupported is returned when an optional method is not supported by the Store implementation.
+var ErrNotSupported = errors.New("not supported")
+
+// A StoreController is used by the goose package to interact with a database. This type is a
+// wrapper around the Store interface, but can be extended to include additional (optional) methods
+// that are not part of the core Store interface.
+type StoreController struct {
+	store Store
+}
+
+var _ Store = (*StoreController)(nil)
+
+// NewStoreController returns a new StoreController that wraps the given Store.
+//
+// If the Store implements the following optional methods, the StoreController will call them as
+// appropriate:
+//
+//   - TableExists(context.Context, DBTxConn) (bool, error)
+//
+// If the Store does not implement a method, it will either return a [ErrNotSupported] error or fall
+// back to the default behavior.
+func NewStoreController(store Store) *StoreController {
+	return &StoreController{store: store}
+}
+
+// TableExists is an optional method that checks if the version table exists in the database. It is
+// recommended to implement this method if the database supports it, as it can be used to optimize
+// certain operations.
+func (c *StoreController) TableExists(ctx context.Context, db DBTxConn) (bool, error) {
+	if t, ok := c.store.(interface {
+		TableExists(context.Context, DBTxConn, string) (bool, error)
+	}); ok {
+		return t.TableExists(ctx, db, c.Tablename())
+	}
+	return false, ErrNotSupported
+}
+
+// Default methods
+
+func (c *StoreController) Tablename() string {
+	return c.store.Tablename()
+}
+
+func (c *StoreController) CreateVersionTable(ctx context.Context, db DBTxConn) error {
+	return c.store.CreateVersionTable(ctx, db)
+}
+
+func (c *StoreController) Insert(ctx context.Context, db DBTxConn, req InsertRequest) error {
+	return c.store.Insert(ctx, db, req)
+}
+
+func (c *StoreController) Delete(ctx context.Context, db DBTxConn, version int64) error {
+	return c.store.Delete(ctx, db, version)
+}
+
+func (c *StoreController) GetMigration(ctx context.Context, db DBTxConn, version int64) (*GetMigrationResult, error) {
+	return c.store.GetMigration(ctx, db, version)
+}
+
+func (c *StoreController) GetLatestVersion(ctx context.Context, db DBTxConn) (int64, error) {
+	return c.store.GetLatestVersion(ctx, db)
+}
+
+func (c *StoreController) ListMigrations(ctx context.Context, db DBTxConn) ([]*ListMigrationsResult, error) {
+	return c.store.ListMigrations(ctx, db)
+}

--- a/internal/dialect/dialectquery/dialectquery.go
+++ b/internal/dialect/dialectquery/dialectquery.go
@@ -26,3 +26,45 @@ type Querier interface {
 	// The query should return the version_id and is_applied columns.
 	ListMigrations(tableName string) string
 }
+
+type QueryController struct {
+	querier Querier
+}
+
+// NewQueryController returns a new QueryController that wraps the given Querier.
+func NewQueryController(querier Querier) *QueryController {
+	return &QueryController{querier: querier}
+}
+
+// Optional methods
+
+func (c *QueryController) TableExists(tableName string) string {
+	if t, ok := c.querier.(interface {
+		TableExists(string) string
+	}); ok {
+		return t.TableExists(tableName)
+	}
+	return ""
+}
+
+// Default methods
+
+func (c *QueryController) CreateTable(tableName string) string {
+	return c.querier.CreateTable(tableName)
+}
+
+func (c *QueryController) InsertVersion(tableName string) string {
+	return c.querier.InsertVersion(tableName)
+}
+
+func (c *QueryController) DeleteVersion(tableName string) string {
+	return c.querier.DeleteVersion(tableName)
+}
+
+func (c *QueryController) GetMigrationByVersion(tableName string) string {
+	return c.querier.GetMigrationByVersion(tableName)
+}
+
+func (c *QueryController) ListMigrations(tableName string) string {
+	return c.querier.ListMigrations(tableName)
+}

--- a/internal/dialect/dialectquery/postgres.go
+++ b/internal/dialect/dialectquery/postgres.go
@@ -36,3 +36,7 @@ func (p *Postgres) ListMigrations(tableName string) string {
 	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
+
+func (p *Postgres) TableExists(tableName string) string {
+	return `SELECT EXISTS ( SELECT FROM pg_tables WHERE tablename = $1)`
+}

--- a/provider.go
+++ b/provider.go
@@ -24,7 +24,7 @@ type Provider struct {
 	mu sync.Mutex
 
 	db    *sql.DB
-	store database.Store
+	store *database.StoreController
 
 	fsys fs.FS
 	cfg  config
@@ -143,7 +143,7 @@ func newProvider(
 		db:         db,
 		fsys:       fsys,
 		cfg:        cfg,
-		store:      store,
+		store:      database.NewStoreController(store),
 		migrations: migrations,
 	}, nil
 }


### PR DESCRIPTION
This PR adds a `database.StoreController` type to allow us to extend goose behavior without breaking the core `Store` interface.

We can document any optional methods by having a well-defined type like the `*StoreController`. It becomes much easier to reason about in the code than the type assertions and hidden interfaces. A good example of this in practice is the [ResponseController](https://pkg.go.dev/net/http#ResponseController) added in go recently.

For a practical example see https://github.com/pressly/goose/issues/461. The request here was to support a more graceful operation for checking whether the version table exists or not.

I've gone ahead and implemented the Postgres-specific version of the `TableExists()` method. And the nice thing is we can incrementally update the rest of the dialect implementations piecemeal.

But we always fallback to some less optimized version if `ErrNotSupported` is returned.