### PR TITLE
Implemention GetLatestVersion for all natively supported dialects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Add `CheckPending` method to `goose.Provider` to check if there are pending migrations, returns
   the current (max db) version and the latest (max file) version. (#756)
+- Clarify `GetLatestVersion` method MUST return `ErrVersionNotFound` if no latest migration is
+  found. Previously it was returning a -1 and nil error, which was inconsistent with the rest of the
+  API surface.
+
+- Add `GetLatestVersion` implementations to all existing dialects. This is an optimization to avoid
+  loading all migrations when only the latest version is needed. This uses the `max` function in SQL
+  to get the latest version_id irrespective of the order of applied migrations.
+  - Refactor existing portions of the code to use the new `GetLatestVersion` method.
 
 ## [v3.20.0]
 

--- a/database/dialect.go
+++ b/database/dialect.go
@@ -110,7 +110,15 @@ func (s *store) GetMigration(
 }
 
 func (s *store) GetLatestVersion(ctx context.Context, db DBTxConn) (int64, error) {
-	return -1, errors.New("not implemented")
+	q := s.querier.GetLatestVersion(s.tablename)
+	var version sql.NullInt64
+	if err := db.QueryRowContext(ctx, q).Scan(&version); err != nil {
+		return -1, fmt.Errorf("failed to get latest version: %w", err)
+	}
+	if !version.Valid {
+		return -1, nil
+	}
+	return version.Int64, nil
 }
 
 func (s *store) ListMigrations(

--- a/database/dialect.go
+++ b/database/dialect.go
@@ -116,7 +116,7 @@ func (s *store) GetLatestVersion(ctx context.Context, db DBTxConn) (int64, error
 		return -1, fmt.Errorf("failed to get latest version: %w", err)
 	}
 	if !version.Valid {
-		return -1, nil
+		return -1, fmt.Errorf("latest %w", ErrVersionNotFound)
 	}
 	return version.Int64, nil
 }

--- a/database/store.go
+++ b/database/store.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	// ErrVersionNotFound must be returned by [GetMigration] when a migration version is not found.
+	// ErrVersionNotFound must be returned by [GetMigration] or [GetLatestVersion] when a migration
+	// does not exist.
 	ErrVersionNotFound = errors.New("version not found")
 
 	// ErrNotImplemented must be returned by methods that are not implemented.
@@ -37,7 +38,7 @@ type Store interface {
 	// version is not found, this method must return [ErrVersionNotFound].
 	GetMigration(ctx context.Context, db DBTxConn, version int64) (*GetMigrationResult, error)
 	// GetLatestVersion retrieves the last applied migration version. If no migrations exist, this
-	// method must return -1 and no error.
+	// method must return [ErrVersionNotFound].
 	GetLatestVersion(ctx context.Context, db DBTxConn) (int64, error)
 	// ListMigrations retrieves all migrations sorted in descending order by id or timestamp. If
 	// there are no migrations, return empty slice with no error. Typically this method will return

--- a/database/store.go
+++ b/database/store.go
@@ -9,6 +9,9 @@ import (
 var (
 	// ErrVersionNotFound must be returned by [GetMigration] when a migration version is not found.
 	ErrVersionNotFound = errors.New("version not found")
+
+	// ErrNotImplemented must be returned by methods that are not implemented.
+	ErrNotImplemented = errors.New("not implemented")
 )
 
 // Store is an interface that defines methods for tracking and managing migrations. It is used by

--- a/database/store_test.go
+++ b/database/store_test.go
@@ -96,9 +96,8 @@ func testStore(
 		alreadyExists(t, err)
 	}
 	// Get the latest version. There should be none.
-	version, err := store.GetLatestVersion(ctx, db)
-	check.NoError(t, err)
-	check.Number(t, version, -1)
+	_, err = store.GetLatestVersion(ctx, db)
+	check.IsError(t, err, database.ErrVersionNotFound)
 
 	// List migrations. There should be none.
 	err = runConn(ctx, db, func(conn *sql.Conn) error {
@@ -198,9 +197,8 @@ func testStore(
 	// 3. *sql.DB
 	err = store.Delete(ctx, db, 0)
 	check.NoError(t, err)
-	latest, err := store.GetLatestVersion(ctx, db)
-	check.NoError(t, err)
-	check.Number(t, latest, -1)
+	_, err = store.GetLatestVersion(ctx, db)
+	check.IsError(t, err, database.ErrVersionNotFound)
 
 	// List migrations. There should be none.
 	err = runConn(ctx, db, func(conn *sql.Conn) error {

--- a/internal/dialect/dialectquery/clickhouse.go
+++ b/internal/dialect/dialectquery/clickhouse.go
@@ -37,3 +37,8 @@ func (c *Clickhouse) ListMigrations(tableName string) string {
 	q := `SELECT version_id, is_applied FROM %s ORDER BY version_id DESC`
 	return fmt.Sprintf(q, tableName)
 }
+
+func (c *Clickhouse) GetLatestVersion(tableName string) string {
+	q := `SELECT max(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}

--- a/internal/dialect/dialectquery/dialectquery.go
+++ b/internal/dialect/dialectquery/dialectquery.go
@@ -1,28 +1,27 @@
 package dialectquery
 
-// Querier is the interface that wraps the basic methods to create a dialect
-// specific query.
+// Querier is the interface that wraps the basic methods to create a dialect specific query.
 type Querier interface {
 	// CreateTable returns the SQL query string to create the db version table.
 	CreateTable(tableName string) string
 
-	// InsertVersion returns the SQL query string to insert a new version into
-	// the db version table.
+	// InsertVersion returns the SQL query string to insert a new version into the db version table.
 	InsertVersion(tableName string) string
 
-	// DeleteVersion returns the SQL query string to delete a version from
-	// the db version table.
+	// DeleteVersion returns the SQL query string to delete a version from the db version table.
 	DeleteVersion(tableName string) string
 
-	// GetMigrationByVersion returns the SQL query string to get a single
-	// migration by version.
+	// GetMigrationByVersion returns the SQL query string to get a single migration by version.
 	//
 	// The query should return the timestamp and is_applied columns.
 	GetMigrationByVersion(tableName string) string
 
-	// ListMigrations returns the SQL query string to list all migrations in
-	// descending order by id.
+	// ListMigrations returns the SQL query string to list all migrations in descending order by id.
 	//
 	// The query should return the version_id and is_applied columns.
 	ListMigrations(tableName string) string
+
+	// GetLatestVersion returns the SQL query string to get the last version_id from the db version
+	// table.
+	GetLatestVersion(tableName string) string
 }

--- a/internal/dialect/dialectquery/dialectquery.go
+++ b/internal/dialect/dialectquery/dialectquery.go
@@ -22,6 +22,6 @@ type Querier interface {
 	ListMigrations(tableName string) string
 
 	// GetLatestVersion returns the SQL query string to get the last version_id from the db version
-	// table.
+	// table. Returns a nullable int64 value.
 	GetLatestVersion(tableName string) string
 }

--- a/internal/dialect/dialectquery/mysql.go
+++ b/internal/dialect/dialectquery/mysql.go
@@ -36,3 +36,8 @@ func (m *Mysql) ListMigrations(tableName string) string {
 	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
+
+func (m *Mysql) GetLatestVersion(tableName string) string {
+	q := `SELECT MAX(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}

--- a/internal/dialect/dialectquery/postgres.go
+++ b/internal/dialect/dialectquery/postgres.go
@@ -36,3 +36,8 @@ func (p *Postgres) ListMigrations(tableName string) string {
 	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
+
+func (p *Postgres) GetLatestVersion(tableName string) string {
+	q := `SELECT max(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}

--- a/internal/dialect/dialectquery/redshift.go
+++ b/internal/dialect/dialectquery/redshift.go
@@ -36,3 +36,8 @@ func (r *Redshift) ListMigrations(tableName string) string {
 	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
+
+func (r *Redshift) GetLatestVersion(tableName string) string {
+	q := `SELECT max(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}

--- a/internal/dialect/dialectquery/sqlite3.go
+++ b/internal/dialect/dialectquery/sqlite3.go
@@ -35,3 +35,8 @@ func (s *Sqlite3) ListMigrations(tableName string) string {
 	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
+
+func (s *Sqlite3) GetLatestVersion(tableName string) string {
+	q := `SELECT MAX(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}

--- a/internal/dialect/dialectquery/sqlserver.go
+++ b/internal/dialect/dialectquery/sqlserver.go
@@ -35,3 +35,8 @@ func (s *Sqlserver) ListMigrations(tableName string) string {
 	q := `SELECT version_id, is_applied FROM %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
+
+func (s *Sqlserver) GetLatestVersion(tableName string) string {
+	q := `SELECT MAX(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}

--- a/internal/dialect/dialectquery/tidb.go
+++ b/internal/dialect/dialectquery/tidb.go
@@ -36,3 +36,8 @@ func (t *Tidb) ListMigrations(tableName string) string {
 	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
+
+func (t *Tidb) GetLatestVersion(tableName string) string {
+	q := `SELECT MAX(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}

--- a/internal/dialect/dialectquery/vertica.go
+++ b/internal/dialect/dialectquery/vertica.go
@@ -36,3 +36,8 @@ func (v *Vertica) ListMigrations(tableName string) string {
 	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
+
+func (v *Vertica) GetLatestVersion(tableName string) string {
+	q := `SELECT MAX(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}

--- a/internal/dialect/dialectquery/ydb.go
+++ b/internal/dialect/dialectquery/ydb.go
@@ -46,3 +46,8 @@ func (c *Ydb) ListMigrations(tableName string) string {
 	FROM %s ORDER BY __discard_column_tstamp DESC`
 	return fmt.Sprintf(q, tableName)
 }
+
+func (c *Ydb) GetLatestVersion(tableName string) string {
+	q := `SELECT MAX(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}

--- a/provider.go
+++ b/provider.go
@@ -499,28 +499,6 @@ func (p *Provider) checkPending(ctx context.Context) (current, target int64, ret
 		if errors.Is(err, database.ErrVersionNotFound) {
 			return -1, target, errMissingZeroVersion
 		}
-		// TODO(mf): this was legacy behavior and should be removed on the next cleanup, all
-		// dialects should implement GetLatestVersion.
-		//
-		// if errors.Is(err, database.ErrNotImplemented) {
-		//  res, err := p.store.ListMigrations(ctx, conn)
-		//  if err != nil {
-		//      return -1, -1, err
-		//  }
-		//  dbVersions := make([]int64, 0, len(res))
-		//  for _, m := range res {
-		//      dbVersions = append(dbVersions, m.Version)
-		//  }
-		//  sort.Slice(dbVersions, func(i, j int) bool {
-		//      return dbVersions[i] < dbVersions[j]
-		//  })
-		//  if len(dbVersions) == 0 {
-		//      return -1, -1, errMissingZeroVersion
-		//  } else {
-		//      current = dbVersions[len(dbVersions)-1]
-		//  }
-		//  return current, target, nil
-		// }
 		return -1, target, err
 	}
 	return current, target, nil
@@ -627,22 +605,6 @@ func (p *Provider) getDBMaxVersion(ctx context.Context, conn *sql.Conn) (_ int64
 		if errors.Is(err, database.ErrVersionNotFound) {
 			return 0, errMissingZeroVersion
 		}
-		// TODO(mf): this was legacy behavior and should be removed on the next cleanup, all
-		// dialects should implement GetLatestVersion.
-		//
-		// if errors.Is(err, database.ErrNotImplemented) {
-		//  // Fallback to listing all migrations and returning the highest version.
-		//  res, err := p.store.ListMigrations(ctx, conn)
-		//  if err != nil {
-		//      return 0, err
-		//  }
-		//  if len(res) == 0 {
-		//      return 0, errMissingZeroVersion
-		//  }
-		//  // Sort in descending order.
-		//  sort.Slice(res, func(i, j int) bool { return res[i].Version > res[j].Version })
-		//  return res[0].Version, nil
-		// }
 		return -1, err
 	}
 	return latest, nil

--- a/provider.go
+++ b/provider.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/fs"
 	"math"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -167,6 +166,10 @@ func (p *Provider) HasPending(ctx context.Context) (bool, error) {
 //
 // Note, this method will not use a SessionLocker if one is configured. This allows callers to check
 // for pending migrations without blocking or being blocked by other operations.
+//
+// If out-of-order migrations are enabled this method is not suitable for checking pending
+// migrations because it ONLY returns the highest version in the database. Instead, use the
+// [HasPending] method.
 func (p *Provider) CheckPending(ctx context.Context) (current, target int64, err error) {
 	return p.checkPending(ctx)
 }
@@ -483,30 +486,44 @@ func (p *Provider) checkPending(ctx context.Context) (current, target int64, ret
 		retErr = multierr.Append(retErr, cleanup())
 	}()
 
+	target = p.migrations[len(p.migrations)-1].Version
+
 	// If versioning is disabled, we always have pending migrations and the target version is the
 	// last migration.
 	if p.cfg.disableVersioning {
-		return -1, p.migrations[len(p.migrations)-1].Version, nil
+		return -1, target, nil
 	}
-	// optimize(mf): we should only fetch the max version from the database, no need to fetch all
-	// migrations only to get the max version when we're not using out-of-order migrations.
-	res, err := p.store.ListMigrations(ctx, conn)
+
+	current, err = p.store.GetLatestVersion(ctx, conn)
 	if err != nil {
-		return -1, -1, err
+		// TODO(mf): this was legacy behavior and should be removed on the next cleanup, all
+		// dialects should implement GetLatestVersion.
+		//
+		// if errors.Is(err, database.ErrNotImplemented) {
+		//  res, err := p.store.ListMigrations(ctx, conn)
+		//  if err != nil {
+		//      return -1, -1, err
+		//  }
+		//  dbVersions := make([]int64, 0, len(res))
+		//  for _, m := range res {
+		//      dbVersions = append(dbVersions, m.Version)
+		//  }
+		//  sort.Slice(dbVersions, func(i, j int) bool {
+		//      return dbVersions[i] < dbVersions[j]
+		//  })
+		//  if len(dbVersions) == 0 {
+		//      return -1, -1, errMissingZeroVersion
+		//  } else {
+		//      current = dbVersions[len(dbVersions)-1]
+		//  }
+		//  return current, target, nil
+		// }
+		return -1, target, err
 	}
-	dbVersions := make([]int64, 0, len(res))
-	for _, m := range res {
-		dbVersions = append(dbVersions, m.Version)
+	if current < 0 {
+		return -1, target, errMissingZeroVersion
 	}
-	sort.Slice(dbVersions, func(i, j int) bool {
-		return dbVersions[i] < dbVersions[j]
-	})
-	if len(dbVersions) == 0 {
-		return -1, -1, errMissingZeroVersion
-	} else {
-		current = dbVersions[len(dbVersions)-1]
-	}
-	return current, p.migrations[len(p.migrations)-1].Version, nil
+	return current, target, nil
 }
 
 func (p *Provider) hasPending(ctx context.Context) (_ bool, retErr error) {
@@ -523,7 +540,8 @@ func (p *Provider) hasPending(ctx context.Context) (_ bool, retErr error) {
 		return true, nil
 	}
 	if p.cfg.allowMissing {
-		// List all migrations from the database.
+		// List all migrations from the database. We cannot optimize this because we need to check
+		// that EVERY migration known the provider has been applied.
 		dbMigrations, err := p.store.ListMigrations(ctx, conn)
 		if err != nil {
 			return false, err
@@ -544,16 +562,16 @@ func (p *Provider) hasPending(ctx context.Context) (_ bool, retErr error) {
 		}
 		return false, nil
 	}
-	// If out-of-order migrations are not allowed, we can optimize this by only checking whether the
-	// last migration the provider knows about is applied.
-	last := p.migrations[len(p.migrations)-1]
-	if _, err := p.store.GetMigration(ctx, conn, last.Version); err != nil {
-		if errors.Is(err, database.ErrVersionNotFound) {
-			return true, nil
-		}
+	// If out-of-order migrations are not allowed, we can optimize this by only checking the latest
+	// version in the database against the latest migration version.
+	current, err := p.store.GetLatestVersion(ctx, conn)
+	if err != nil {
 		return false, err
 	}
-	return false, nil
+	if current < 0 {
+		return false, errMissingZeroVersion
+	}
+	return current < p.migrations[len(p.migrations)-1].Version, nil
 }
 
 func (p *Provider) status(ctx context.Context) (_ []*MigrationStatus, retErr error) {
@@ -604,26 +622,28 @@ func (p *Provider) getDBMaxVersion(ctx context.Context, conn *sql.Conn) (_ int64
 		}()
 	}
 
-	version, err := p.store.GetLatestVersion(ctx, conn)
-	if err != nil && !errors.Is(err, database.ErrNotImplemented) {
+	latest, err := p.store.GetLatestVersion(ctx, conn)
+	if err != nil {
+		// TODO(mf): this was legacy behavior and should be removed on the next cleanup, all
+		// dialects should implement GetLatestVersion.
+		//
+		// if errors.Is(err, database.ErrNotImplemented) {
+		//  // Fallback to listing all migrations and returning the highest version.
+		//  res, err := p.store.ListMigrations(ctx, conn)
+		//  if err != nil {
+		//      return 0, err
+		//  }
+		//  if len(res) == 0 {
+		//      return 0, errMissingZeroVersion
+		//  }
+		//  // Sort in descending order.
+		//  sort.Slice(res, func(i, j int) bool { return res[i].Version > res[j].Version })
+		//  return res[0].Version, nil
+		// }
 		return -1, err
 	}
-	if err == nil {
-		if version >= 0 {
-			return version, nil
-		} else {
-			return 0, errMissingZeroVersion
-		}
+	if latest < 0 {
+		return -1, errMissingZeroVersion
 	}
-	// Fallback to listing all migrations and returning the highest version.
-	res, err := p.store.ListMigrations(ctx, conn)
-	if err != nil {
-		return 0, err
-	}
-	if len(res) == 0 {
-		return 0, errMissingZeroVersion
-	}
-	// Sort in descending order.
-	sort.Slice(res, func(i, j int) bool { return res[i].Version > res[j].Version })
-	return res[0].Version, nil
+	return latest, nil
 }


### PR DESCRIPTION
This PR implements:

```go
// GetLatestVersion retrieves the last applied migration version. If no migrations exist, this
// method must return -1 and no error.
GetLatestVersion(ctx context.Context, db DBTxConn) (int64, error)
```

, for all natively supported dialects. They all support a `max` function over the `version_id`, meaning we don't need to fetch all versions, sort, grab the latest and discard.