### PR TITLE
Update HasPending logic to account for out-of-order errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mfridman/interpolate v0.0.2
 	github.com/microsoft/go-mssqldb v1.7.0
 	github.com/sethvargo/go-retry v0.2.4
+	github.com/stretchr/testify v1.8.4
 	github.com/tursodatabase/libsql-client-go v0.0.0-20240411070317-a1138d155304
 	github.com/vertica/vertica-sql-go v1.3.3
 	github.com/ydb-platform/ydb-go-sdk/v3 v3.55.1
@@ -23,6 +24,7 @@ require (
 	github.com/ClickHouse/ch-go v0.58.2 // indirect
 	github.com/andybalholm/brotli v1.0.6 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elastic/go-sysinfo v1.11.2 // indirect
 	github.com/elastic/go-windows v1.0.1 // indirect
@@ -46,6 +48,7 @@ require (
 	github.com/paulmach/orb v0.10.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/segmentio/asm v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tursodatabase/libsql-client-go v0.0.0-20240411070317-a1138d155304 h1:Y6cw8yjWCEJDy5Bll7HjTinkgTQU55AXiKSEe29SpgA=
 github.com/tursodatabase/libsql-client-go v0.0.0-20240411070317-a1138d155304/go.mod h1:2Fu26tjM011BLeR5+jwTfs6DX/fNMEWV/3CBZvggrA4=

--- a/internal/gooseutil/resolve.go
+++ b/internal/gooseutil/resolve.go
@@ -1,0 +1,110 @@
+// Package gooseutil provides utility functions we want to keep internal to the package. It's
+// intended to be a collection of well-tested helper functions.
+package gooseutil
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// UpVersions returns a list of migrations to apply based on the versions in the filesystem and the
+// versions in the database. The target version can be used to specify a target version. In most
+// cases this will be math.MaxInt64.
+//
+// The allowMissing flag can be used to allow missing migrations as part of the list of migrations
+// to apply. Otherwise, an error will be returned if there are missing migrations in the database.
+func UpVersions(
+	fsysVersions []int64,
+	dbVersions []int64,
+	target int64,
+	allowMissing bool,
+) ([]int64, error) {
+	// Sort the list of versions in the filesystem. This should already be sorted, but we do this
+	// just in case.
+	sortAscending(fsysVersions)
+
+	// dbAppliedVersions is a map of all applied migrations in the database.
+	dbAppliedVersions := make(map[int64]bool, len(dbVersions))
+	var dbMaxVersion int64
+	for _, v := range dbVersions {
+		dbAppliedVersions[v] = true
+		if v > dbMaxVersion {
+			dbMaxVersion = v
+		}
+	}
+
+	// Get a list of migrations that are missing from the database. A missing migration is one that
+	// has a version less than the max version in the database.
+	var missing []int64
+	for _, v := range fsysVersions {
+		if !dbAppliedVersions[v] && v < dbMaxVersion {
+			missing = append(missing, v)
+		}
+	}
+
+	// feat(mf): It is very possible someone may want to apply ONLY new migrations and skip missing
+	// migrations entirely. At the moment this is not supported, but leaving this comment because
+	// that's where that logic would be handled.
+	//
+	// For example, if database has 1,4 already applied and 2,3,5 are new, we would apply only 5 and
+	// skip 2,3. Not sure if this is a common use case, but it's possible someone may want to do
+	// this.
+	if len(missing) > 0 && !allowMissing {
+		return nil, newMissingError(missing, dbMaxVersion)
+	}
+
+	var out []int64
+
+	// 1. Add missing migrations to the list of migrations to apply, if any.
+	out = append(out, missing...)
+
+	// 2. Add new migrations to the list of migrations to apply, if any.
+	for _, v := range fsysVersions {
+		if dbAppliedVersions[v] {
+			continue
+		}
+		if v > dbMaxVersion && v <= target {
+			out = append(out, v)
+		}
+	}
+	// 3. Sort the list of migrations to apply.
+	sortAscending(out)
+
+	return out, nil
+}
+
+func newMissingError(
+	missing []int64,
+	dbMaxVersion int64,
+) error {
+	sortAscending(missing)
+
+	collected := make([]string, 0, len(missing))
+	for _, v := range missing {
+		collected = append(collected, strconv.FormatInt(v, 10))
+	}
+
+	msg := "migration"
+	if len(collected) > 1 {
+		msg += "s"
+	}
+
+	var versionsMsg string
+	if len(collected) > 1 {
+		versionsMsg = "versions " + strings.Join(collected, ",")
+	} else {
+		versionsMsg = "version " + collected[0]
+	}
+
+	return fmt.Errorf("found %d missing (out-of-order) %s lower than current database max version (%d): %s",
+		len(missing), msg, dbMaxVersion, versionsMsg,
+	)
+}
+
+func sortAscending(versions []int64) {
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i] < versions[j]
+	})
+}

--- a/internal/gooseutil/resolve.go
+++ b/internal/gooseutil/resolve.go
@@ -36,7 +36,7 @@ func UpVersions(
 	}
 
 	// Get a list of migrations that are missing from the database. A missing migration is one that
-	// has a version less than the max version in the database.
+	// has a version less than the max version in the database and has not been applied.
 	var missing []int64
 	for _, v := range fsysVersions {
 		if !dbAppliedVersions[v] && v < dbMaxVersion {

--- a/internal/gooseutil/resolve_test.go
+++ b/internal/gooseutil/resolve_test.go
@@ -104,6 +104,12 @@ func TestResolveVersions(t *testing.T) {
 				"detected 1 missing (out-of-order) migration lower than database version (6), with target version (4): version 2",
 				err.Error(),
 			)
+			_, err = UpVersions([]int64{1, 2, 3, 4, 5, 6}, []int64{1 /* 2 */, 3, 4 /* 5*/, 6}, 6, false)
+			require.Error(t, err)
+			require.Equal(t,
+				"detected 2 missing (out-of-order) migrations lower than database version (6), with target version (6): versions 2,5",
+				err.Error(),
+			)
 		})
 	})
 
@@ -182,6 +188,11 @@ func TestResolveVersions(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, len(got))
 			require.Equal(t, int64(2), got[0]) // missing
+			got, err = UpVersions([]int64{1, 2, 3, 4, 5, 6}, []int64{1 /* 2 */, 3, 4 /* 5*/, 6}, 6, true)
+			require.NoError(t, err)
+			require.Equal(t, 2, len(got))
+			require.Equal(t, int64(2), got[0]) // missing
+			require.Equal(t, int64(5), got[1]) // missing
 		})
 	})
 

--- a/internal/gooseutil/resolve_test.go
+++ b/internal/gooseutil/resolve_test.go
@@ -187,7 +187,7 @@ func TestResolveVersions(t *testing.T) {
 
 	t.Run("sort_ascending", func(t *testing.T) {
 		got := []int64{5, 3, 4, 2, 1}
-		SortAscending(got)
+		sortAscending(got)
 		require.Equal(t, []int64{1, 2, 3, 4, 5}, got)
 	})
 }

--- a/internal/gooseutil/resolve_test.go
+++ b/internal/gooseutil/resolve_test.go
@@ -8,133 +8,178 @@ import (
 )
 
 func TestResolveVersions(t *testing.T) {
-	got, err := UpVersions(nil, nil, 0, false)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(got))
+	t.Run("not_allow_missing", func(t *testing.T) {
+		// Nothing to apply nil
+		got, err := UpVersions(nil, nil, math.MaxInt64, false)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(got))
+		// Nothing to apply empty
+		got, err = UpVersions([]int64{}, []int64{}, math.MaxInt64, false)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(got))
 
-	// Nothing to apply
-	got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 2, 3}, math.MaxInt64, false)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(got))
-	// Nothing to apply with missing allowed
-	got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 2, 3}, math.MaxInt64, true)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(got))
+		// Nothing new
+		got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 2, 3}, math.MaxInt64, false)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(got))
 
-	// All new
-	got, err = UpVersions([]int64{1, 2, 3}, []int64{}, math.MaxInt64, false)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(got))
-	require.Equal(t, int64(1), got[0])
-	require.Equal(t, int64(2), got[1])
-	require.Equal(t, int64(3), got[2])
+		// All new
+		got, err = UpVersions([]int64{1, 2, 3}, []int64{}, math.MaxInt64, false)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(got))
+		require.Equal(t, int64(1), got[0])
+		require.Equal(t, int64(2), got[1])
+		require.Equal(t, int64(3), got[2])
 
-	// Squashed, all old
-	got, err = UpVersions([]int64{3}, []int64{3}, math.MaxInt64, false)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(got))
+		// Squashed, no new
+		got, err = UpVersions([]int64{3}, []int64{3}, math.MaxInt64, false)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(got))
+		// Squashed, 1 new
+		got, err = UpVersions([]int64{3, 4}, []int64{3}, math.MaxInt64, false)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(got))
+		require.Equal(t, int64(4), got[0])
 
-	// New migrations with missing not allowed
-	got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 2}, math.MaxInt64, false)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(got))
-	require.Equal(t, int64(3), got[0])
-	// New migrations with missing allowed
-	got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 2}, math.MaxInt64, true)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(got))
-	require.Equal(t, int64(3), got[0])
+		// Some new with target
+		got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1, 2}, 4, false)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(got))
+		require.Equal(t, int64(3), got[0])
+		require.Equal(t, int64(4), got[1]) // up to and including target
+		// Some new with zero target
+		got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1, 2}, 0, false)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(got))
 
-	// One missing migration with missing allowed
-	got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 3}, math.MaxInt64, true)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(got))
-	require.Equal(t, int64(2), got[0])
-	// Multiple missing migrations with missing allowed
-	got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{2, 4, 5}, math.MaxInt64, true)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(got))
-	require.Equal(t, int64(1), got[0])
-	require.Equal(t, int64(3), got[1])
-	// Multiple missing migrations and new with missing allowed
-	got, err = UpVersions([]int64{1, 2, 3, 4, 5, 6}, []int64{2, 4, 5}, math.MaxInt64, true)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(got))
-	require.Equal(t, int64(1), got[0])
-	require.Equal(t, int64(3), got[1])
-	require.Equal(t, int64(6), got[2])
+		// Error: one missing migrations with max target
+		_, err = UpVersions([]int64{1, 2, 3, 4}, []int64{1 /* 2*/, 3}, math.MaxInt64, false)
+		require.Error(t, err)
+		require.Equal(t,
+			"found 1 missing (out-of-order) migration lower than current database max version (3): version 2",
+			err.Error(),
+		)
+		// Error: multiple missing migrations with max target
+		_, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{ /* 1 */ 2 /* 3 */, 4, 5}, math.MaxInt64, false)
+		require.Error(t, err)
+		require.Equal(t,
+			"found 2 missing (out-of-order) migrations lower than current database max version (5): versions 1,3",
+			err.Error(),
+		)
 
-	// Missing migrations, no new, with missing not allowed
-	_, err = UpVersions([]int64{1, 2, 3, 4}, []int64{1, 4}, math.MaxInt64, false)
-	require.Error(t, err)
-	require.Equal(t,
-		"found 2 missing (out-of-order) migrations lower than current database max version (4): versions 2,3",
-		err.Error(),
-	)
-	// One missing migration and one new with missing not allowed
-	_, err = UpVersions([]int64{1, 2, 3, 4}, []int64{1, 3}, math.MaxInt64, false)
-	require.Error(t, err)
-	require.Equal(t,
-		"found 1 missing (out-of-order) migration lower than current database max version (3): version 2",
-		err.Error(),
-	)
+		t.Run("target_lower_than_max", func(t *testing.T) {
 
-	// Missing multiple migrations with one new missing not allowed
-	_, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1, 4}, math.MaxInt64, false)
-	require.Error(t, err)
-	require.Equal(t,
-		"found 2 missing (out-of-order) migrations lower than current database max version (4): versions 2,3",
-		err.Error(),
-	)
+			// These tests are a bit of an edge case but an important one worth documenting. There
+			// can be missing migrations above and/or below the target version which itself can be
+			// lower than the max db version. For example, migrations 1,2,3,4 in the filesystem, and
+			// migrations 1,2,4 applied to the database and the user requested target 2. Technically
+			// there are no missing migrations based on the target version since 1,2 have been
+			// applied, but there is 1 missing migration (3) based on the max db version. Should
+			// this return an error, or report no pending migrations?
+			//
+			// We've taken the stance that this SHOULD return an error because if users have have
+			// not opted to allow missing migrations, then they should be made aware of any missing
+			// migrations regardless of the target version. This is a bit of a gotcha, and gets even
+			// more harder to reason about when the target version equals the missing version.
+			//
+			// TL;DR: If a version is lower than the max db version and hasn't been applied, it's a
+			// missing migration!
 
-	// Squashed migrations
-	got, err = UpVersions([]int64{5}, []int64{1, 2, 3, 4, 5}, 3, false)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(got))
-	got, err = UpVersions([]int64{5}, []int64{1, 2, 3, 4, 5}, 3, true)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(got))
+			for _, n := range []int64{1, 2, 3, 4} {
+				_, err = UpVersions([]int64{1, 2, 3, 4}, []int64{1, 2 /* 3 */, 4}, n, false)
+				require.Error(t, err)
+				require.Equal(t,
+					"found 1 missing (out-of-order) migration lower than current database max version (4): version 3",
+					err.Error(),
+				)
+			}
+			_, err = UpVersions([]int64{1, 2, 3, 4, 5, 6}, []int64{1 /* 2 */, 3, 4 /* 5*/, 6}, 4, false)
+			require.Error(t, err)
+			require.Equal(t,
+				"found 2 missing (out-of-order) migrations lower than current database max version (6): versions 2,5",
+				err.Error(),
+			)
+		})
+	})
 
-	// With target version
-	got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1, 2, 3}, 3, false)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(got))
-	got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1, 2, 3}, 3, true)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(got))
+	t.Run("allow_missing", func(t *testing.T) {
+		// Nothing to apply nil
+		got, err := UpVersions(nil, nil, math.MaxInt64, true)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(got))
+		// Nothing to apply empty
+		got, err = UpVersions([]int64{}, []int64{}, math.MaxInt64, true)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(got))
 
-	// With target version
-	got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1}, 4, false)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(got))
-	require.Equal(t, int64(2), got[0])
-	require.Equal(t, int64(3), got[1])
-	require.Equal(t, int64(4), got[2])
+		// Nothing new
+		got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 2, 3}, math.MaxInt64, true)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(got))
 
-	// no input ordering guarantees, but we can check that the output is sorted
-	got, err = UpVersions([]int64{5, 4, 3, 2, 1}, []int64{2, 1, 3}, 3, false)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(got))
-	// same, but with a max target
-	got, err = UpVersions([]int64{5, 4, 3, 2, 1}, []int64{2, 1, 3}, math.MaxInt64, false)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(got))
-	require.Equal(t, int64(4), got[0])
-	require.Equal(t, int64(5), got[1])
-	// same, but with missing allowed
-	got, err = UpVersions([]int64{5, 4, 3, 2, 1}, []int64{1, 3}, math.MaxInt64, true)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(got))
-	require.Equal(t, int64(2), got[0])
-	require.Equal(t, int64(4), got[1])
-	require.Equal(t, int64(5), got[2])
-	// same, but with missing not allowed
-	_, err = UpVersions([]int64{5, 4, 3, 2, 1}, []int64{1, 3}, math.MaxInt64, false)
-	require.Error(t, err)
-	require.Equal(t,
-		"found 1 missing (out-of-order) migration lower than current database max version (3): version 2",
-		err.Error(),
-	)
+		// All new
+		got, err = UpVersions([]int64{1, 2, 3}, []int64{}, math.MaxInt64, true)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(got))
+		require.Equal(t, int64(1), got[0])
+		require.Equal(t, int64(2), got[1])
+		require.Equal(t, int64(3), got[2])
+
+		// Squashed, no new
+		got, err = UpVersions([]int64{3}, []int64{3}, math.MaxInt64, true)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(got))
+		// Squashed, 1 new
+		got, err = UpVersions([]int64{3, 4}, []int64{3}, math.MaxInt64, true)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(got))
+		require.Equal(t, int64(4), got[0])
+
+		// Some new with target
+		got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1, 2}, 4, true)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(got))
+		require.Equal(t, int64(3), got[0])
+		require.Equal(t, int64(4), got[1]) // up to and including target
+		// Some new with zero target
+		got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1, 2}, 0, true)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(got))
+
+		// No error: one missing
+		got, err = UpVersions([]int64{1, 2, 3}, []int64{1 /* 2*/, 3}, math.MaxInt64, true)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(got))
+		require.Equal(t, int64(2), got[0]) // missing
+
+		// No error: multiple missing and new with max target
+		got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{ /* 1 */ 2 /* 3 */, 4}, math.MaxInt64, true)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(got))
+		require.Equal(t, int64(1), got[0]) // missing
+		require.Equal(t, int64(3), got[1]) // missing
+		require.Equal(t, int64(5), got[2])
+
+		t.Run("target_lower_than_max", func(t *testing.T) {
+			got, err := UpVersions([]int64{1, 2, 3, 4}, []int64{1, 2 /* 3 */, 4}, 2, true)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(got))
+			require.Equal(t, int64(3), got[0]) // missing
+
+			got, err = UpVersions([]int64{1, 2, 3, 4, 5, 6}, []int64{1 /* 2 */, 3, 4 /* 5*/, 6}, 4, true)
+			require.NoError(t, err)
+			require.Equal(t, 2, len(got))
+			require.Equal(t, int64(2), got[0]) // missing
+			require.Equal(t, int64(5), got[1]) // missing
+
+			for _, n := range []int64{1, 2, 3, 4} {
+				got, err = UpVersions([]int64{1, 2, 3, 4}, []int64{1, 2 /* 3 */, 4}, n, true)
+				require.NoError(t, err)
+				require.Equal(t, 1, len(got))
+				require.Equal(t, int64(3), got[0]) // missing
+			}
+		})
+	})
 
 	t.Run("sort_ascending", func(t *testing.T) {
 		got := []int64{5, 3, 4, 2, 1}

--- a/internal/gooseutil/resolve_test.go
+++ b/internal/gooseutil/resolve_test.go
@@ -1,0 +1,144 @@
+package gooseutil
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveVersions(t *testing.T) {
+	got, err := UpVersions(nil, nil, 0, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(got))
+
+	// Nothing to apply
+	got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 2, 3}, math.MaxInt64, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(got))
+	// Nothing to apply with missing allowed
+	got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 2, 3}, math.MaxInt64, true)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(got))
+
+	// All new
+	got, err = UpVersions([]int64{1, 2, 3}, []int64{}, math.MaxInt64, false)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(got))
+	require.Equal(t, int64(1), got[0])
+	require.Equal(t, int64(2), got[1])
+	require.Equal(t, int64(3), got[2])
+
+	// Squashed, all old
+	got, err = UpVersions([]int64{3}, []int64{3}, math.MaxInt64, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(got))
+
+	// New migrations with missing not allowed
+	got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 2}, math.MaxInt64, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(got))
+	require.Equal(t, int64(3), got[0])
+	// New migrations with missing allowed
+	got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 2}, math.MaxInt64, true)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(got))
+	require.Equal(t, int64(3), got[0])
+
+	// One missing migration with missing allowed
+	got, err = UpVersions([]int64{1, 2, 3}, []int64{1, 3}, math.MaxInt64, true)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(got))
+	require.Equal(t, int64(2), got[0])
+	// Multiple missing migrations with missing allowed
+	got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{2, 4, 5}, math.MaxInt64, true)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(got))
+	require.Equal(t, int64(1), got[0])
+	require.Equal(t, int64(3), got[1])
+	// Multiple missing migrations and new with missing allowed
+	got, err = UpVersions([]int64{1, 2, 3, 4, 5, 6}, []int64{2, 4, 5}, math.MaxInt64, true)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(got))
+	require.Equal(t, int64(1), got[0])
+	require.Equal(t, int64(3), got[1])
+	require.Equal(t, int64(6), got[2])
+
+	// Missing migrations, no new, with missing not allowed
+	_, err = UpVersions([]int64{1, 2, 3, 4}, []int64{1, 4}, math.MaxInt64, false)
+	require.Error(t, err)
+	require.Equal(t,
+		"found 2 missing (out-of-order) migrations lower than current database max version (4): versions 2,3",
+		err.Error(),
+	)
+	// One missing migration and one new with missing not allowed
+	_, err = UpVersions([]int64{1, 2, 3, 4}, []int64{1, 3}, math.MaxInt64, false)
+	require.Error(t, err)
+	require.Equal(t,
+		"found 1 missing (out-of-order) migration lower than current database max version (3): version 2",
+		err.Error(),
+	)
+
+	// Missing multiple migrations with one new missing not allowed
+	_, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1, 4}, math.MaxInt64, false)
+	require.Error(t, err)
+	require.Equal(t,
+		"found 2 missing (out-of-order) migrations lower than current database max version (4): versions 2,3",
+		err.Error(),
+	)
+
+	// Squashed migrations
+	got, err = UpVersions([]int64{5}, []int64{1, 2, 3, 4, 5}, 3, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(got))
+	got, err = UpVersions([]int64{5}, []int64{1, 2, 3, 4, 5}, 3, true)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(got))
+
+	// With target version
+	got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1, 2, 3}, 3, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(got))
+	got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1, 2, 3}, 3, true)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(got))
+
+	// With target version
+	got, err = UpVersions([]int64{1, 2, 3, 4, 5}, []int64{1}, 4, false)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(got))
+	require.Equal(t, int64(2), got[0])
+	require.Equal(t, int64(3), got[1])
+	require.Equal(t, int64(4), got[2])
+
+	// no input ordering guarantees, but we can check that the output is sorted
+	got, err = UpVersions([]int64{5, 4, 3, 2, 1}, []int64{2, 1, 3}, 3, false)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(got))
+	// same, but with a max target
+	got, err = UpVersions([]int64{5, 4, 3, 2, 1}, []int64{2, 1, 3}, math.MaxInt64, false)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(got))
+	require.Equal(t, int64(4), got[0])
+	require.Equal(t, int64(5), got[1])
+	// same, but with missing allowed
+	got, err = UpVersions([]int64{5, 4, 3, 2, 1}, []int64{1, 3}, math.MaxInt64, true)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(got))
+	require.Equal(t, int64(2), got[0])
+	require.Equal(t, int64(4), got[1])
+	require.Equal(t, int64(5), got[2])
+	// same, but with missing not allowed
+	_, err = UpVersions([]int64{5, 4, 3, 2, 1}, []int64{1, 3}, math.MaxInt64, false)
+	require.Error(t, err)
+	require.Equal(t,
+		"found 1 missing (out-of-order) migration lower than current database max version (3): version 2",
+		err.Error(),
+	)
+
+	t.Run("sort_ascending", func(t *testing.T) {
+		got := []int64{5, 3, 4, 2, 1}
+		sortAscending(got)
+		require.Equal(t, []int64{1, 2, 3, 4, 5}, got)
+	})
+}

--- a/provider.go
+++ b/provider.go
@@ -532,15 +532,9 @@ func (p *Provider) hasPending(ctx context.Context) (_ bool, retErr error) {
 	//      ignored and the user would not know that they have unapplied migrations.
 	//
 	//      Maybe we could consider adding a flag to the provider such as IgnoreMissing, which would
-	//      allow us to ignore missing migrations and only check for the highest applied version. In this case
-	//      the user would be responsible for ensuring that all migrations are applied in the correct order.
-	//
-	// optimize(mf): Ideally we could focus on optimizing the query itself, such as paginating the
-	// results, or ...
-	//
-	// Lastly, we end up duplicating this logic in the up method, which is not ideal. But we also
-	// make a gaurantee that the up method is safe to call concurrently, so we need to be careful
-	// about introducing shared state.
+	//      allow silently ignoring missing migrations. This would be useful for users that have built
+	//      checks that prevent missing migrations from being introduced.
+
 	dbMigrations, err := p.store.ListMigrations(ctx, conn)
 	if err != nil {
 		return false, err

--- a/provider.go
+++ b/provider.go
@@ -153,7 +153,8 @@ func (p *Provider) Status(ctx context.Context) ([]*MigrationStatus, error) {
 	return p.status(ctx)
 }
 
-// HasPending returns true if there are pending migrations to apply, otherwise, it returns false.
+// HasPending returns true if there are pending migrations to apply, otherwise, it returns false. If
+// out-of-order migrations are disabled, yet some are detected, this method returns an error.
 //
 // Note, this method will not use a SessionLocker if one is configured. This allows callers to check
 // for pending migrations without blocking or being blocked by other operations.

--- a/provider_run.go
+++ b/provider_run.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"io/fs"
 	"runtime/debug"
-	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -21,66 +19,6 @@ import (
 var (
 	errMissingZeroVersion = errors.New("missing zero version migration")
 )
-
-func (p *Provider) resolveUpMigrations(
-	dbVersions []*database.ListMigrationsResult,
-	version int64,
-) ([]*Migration, error) {
-	var apply []*Migration
-	var dbMaxVersion int64
-	// dbAppliedVersions is a map of all applied migrations in the database.
-	dbAppliedVersions := make(map[int64]bool, len(dbVersions))
-	for _, m := range dbVersions {
-		dbAppliedVersions[m.Version] = true
-		if m.Version > dbMaxVersion {
-			dbMaxVersion = m.Version
-		}
-	}
-	missingMigrations := checkMissingMigrations(dbVersions, p.migrations)
-	// feat(mf): It is very possible someone may want to apply ONLY new migrations and skip missing
-	// migrations entirely. At the moment this is not supported, but leaving this comment because
-	// that's where that logic would be handled.
-	//
-	// For example, if db has 1,4 applied and 2,3,5 are new, we would apply only 5 and skip 2,3. Not
-	// sure if this is a common use case, but it's possible.
-	if len(missingMigrations) > 0 && !p.cfg.allowMissing {
-		var collected []string
-		for _, v := range missingMigrations {
-			collected = append(collected, strconv.FormatInt(v, 10))
-		}
-		msg := "migration"
-		if len(collected) > 1 {
-			msg += "s"
-		}
-		var versionsMsg string
-		if len(collected) > 1 {
-			versionsMsg = "versions " + strings.Join(collected, ",")
-		} else {
-			versionsMsg = "version " + collected[0]
-		}
-		return nil, fmt.Errorf("found %d missing (out-of-order) %s lower than current database max version (%d): %s",
-			len(missingMigrations), msg, dbMaxVersion, versionsMsg,
-		)
-	}
-	for _, missingVersion := range missingMigrations {
-		m, err := p.getMigration(missingVersion)
-		if err != nil {
-			return nil, err
-		}
-		apply = append(apply, m)
-	}
-	// filter all migrations with a version greater than the supplied version (min) and less than or
-	// equal to the requested version (max). Skip any migrations that have already been applied.
-	for _, m := range p.migrations {
-		if dbAppliedVersions[m.Version] {
-			continue
-		}
-		if m.Version > dbMaxVersion && m.Version <= version {
-			apply = append(apply, m)
-		}
-	}
-	return apply, nil
-}
 
 func (p *Provider) prepareMigration(fsys fs.FS, m *Migration, direction bool) error {
 	switch m.Type {
@@ -393,32 +331,6 @@ func (p *Provider) tryEnsureVersionTable(ctx context.Context, conn *sql.Conn) er
 		}
 		return nil
 	})
-}
-
-// checkMissingMigrations returns a list of migrations that are missing from the database. A missing
-// migration is one that has a version less than the max version in the database.
-func checkMissingMigrations(
-	dbMigrations []*database.ListMigrationsResult,
-	fsMigrations []*Migration,
-) []int64 {
-	existing := make(map[int64]bool)
-	var dbMaxVersion int64
-	for _, m := range dbMigrations {
-		existing[m.Version] = true
-		if m.Version > dbMaxVersion {
-			dbMaxVersion = m.Version
-		}
-	}
-	var missing []int64
-	for _, m := range fsMigrations {
-		if !existing[m.Version] && m.Version < dbMaxVersion {
-			missing = append(missing, m.Version)
-		}
-	}
-	sort.Slice(missing, func(i, j int) bool {
-		return missing[i] < missing[j]
-	})
-	return missing
 }
 
 // getMigration returns the migration for the given version. If no migration is found, then

--- a/provider_run.go
+++ b/provider_run.go
@@ -58,7 +58,7 @@ func (p *Provider) resolveUpMigrations(
 		} else {
 			versionsMsg = "version " + collected[0]
 		}
-		return nil, fmt.Errorf("found %d missing (out-of-order) %s lower than current max (%d): %s",
+		return nil, fmt.Errorf("found %d missing (out-of-order) %s lower than current database max version (%d): %s",
 			len(missingMigrations), msg, dbMaxVersion, versionsMsg,
 		)
 	}

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -822,27 +822,15 @@ func TestPending(t *testing.T) {
 			check.NoError(t, err)
 			_, err = p.ApplyVersion(ctx, versionToApply, true)
 			check.NoError(t, err)
-			{
-				// TODO(mf): revisit the pending check behavior in addition to the HasPending
-				// method.
-				current, target, err := p.CheckPending(ctx)
-				check.NoError(t, err)
-				check.Number(t, current, versionToApply)
-				check.Number(t, target, len(fsys))
-
-				// TODO(mf): This is a bug in the current implementation. We should not allow this.
-				// https://github.com/pressly/goose/issues/761
-				//
-				// The goal was to optimize the pending check by only checking the latest migration,
-				// but this is not correct since the default behavior is to fail if there are
-				// missing migrations. And we can only know if there are missing migrations by
-				// checking all of them. I wish there was a better way. Maybe an "ignore missing"
-				// option for those who enforce this behavior in CI pipelines and have a way to gate
-				// this ahead of time.
-				_, err = p.HasPending(ctx)
-				check.HasError(t, err)
-				check.Contains(t, err.Error(), "missing (out-of-order) migration")
-			}
+			// TODO(mf): revisit the pending check behavior in addition to the HasPending
+			// method.
+			current, target, err := p.CheckPending(ctx)
+			check.NoError(t, err)
+			check.Number(t, current, versionToApply)
+			check.Number(t, target, len(fsys))
+			_, err = p.HasPending(ctx)
+			check.HasError(t, err)
+			check.Contains(t, err.Error(), "missing (out-of-order) migration")
 			_, err = p.Up(ctx)
 			check.HasError(t, err)
 			check.Contains(t, err.Error(), "missing (out-of-order) migration")

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -788,13 +788,15 @@ func TestPending(t *testing.T) {
 		check.NoError(t, err)
 		_, err = p.ApplyVersion(ctx, 3, true)
 		check.NoError(t, err)
-		hasPending, err := p.HasPending(ctx)
-		check.NoError(t, err)
-		check.Bool(t, hasPending, true)
+		// Even though the latest migration HAS been applied, there are still pending out-of-order
+		// migrations.
 		current, target, err := p.CheckPending(ctx)
 		check.NoError(t, err)
 		check.Number(t, current, 3)
 		check.Number(t, target, len(fsys))
+		hasPending, err := p.HasPending(ctx)
+		check.NoError(t, err)
+		check.Bool(t, hasPending, true)
 		// Apply the missing migrations.
 		_, err = p.Up(ctx)
 		check.NoError(t, err)
@@ -809,31 +811,49 @@ func TestPending(t *testing.T) {
 	t.Run("disallow_out_of_order", func(t *testing.T) {
 		ctx := context.Background()
 		fsys := newFsys()
-		p, err := goose.NewProvider(goose.DialectSQLite3, newDB(t), fsys,
-			goose.WithAllowOutofOrder(false),
-		)
-		check.NoError(t, err)
-		// Some migrations have been applied.
-		_, err = p.ApplyVersion(ctx, 1, true)
-		check.NoError(t, err)
-		_, err = p.ApplyVersion(ctx, 2, true)
-		check.NoError(t, err)
-		hasPending, err := p.HasPending(ctx)
-		check.NoError(t, err)
-		check.Bool(t, hasPending, true)
-		current, target, err := p.CheckPending(ctx)
-		check.NoError(t, err)
-		check.Number(t, current, 2)
-		check.Number(t, target, len(fsys))
-		_, err = p.Up(ctx)
-		check.NoError(t, err)
-		// All migrations have been applied.
-		hasPending, err = p.HasPending(ctx)
-		check.NoError(t, err)
-		check.Bool(t, hasPending, false)
-		current, target, err = p.CheckPending(ctx)
-		check.NoError(t, err)
-		check.Number(t, current, target)
+
+		run := func(t *testing.T, versionToApply int64) {
+			p, err := goose.NewProvider(goose.DialectSQLite3, newDB(t), fsys,
+				goose.WithAllowOutofOrder(false),
+			)
+			check.NoError(t, err)
+			// Some migrations have been applied.
+			_, err = p.ApplyVersion(ctx, 1, true)
+			check.NoError(t, err)
+			_, err = p.ApplyVersion(ctx, versionToApply, true)
+			check.NoError(t, err)
+			{
+				// TODO(mf): revisit the pending check behavior in addition to the HasPending
+				// method.
+				current, target, err := p.CheckPending(ctx)
+				check.NoError(t, err)
+				check.Number(t, current, versionToApply)
+				check.Number(t, target, len(fsys))
+
+				// TODO(mf): This is a bug in the current implementation. We should not allow this.
+				// https://github.com/pressly/goose/issues/761
+				//
+				// The goal was to optimize the pending check by only checking the latest migration,
+				// but this is not correct since the default behavior is to fail if there are
+				// missing migrations. And we can only know if there are missing migrations by
+				// checking all of them. I wish there was a better way. Maybe an "ignore missing"
+				// option for those who enforce this behavior in CI pipelines and have a way to gate
+				// this ahead of time.
+				_, err = p.HasPending(ctx)
+				check.HasError(t, err)
+				check.Contains(t, err.Error(), "missing (out-of-order) migration")
+			}
+			_, err = p.Up(ctx)
+			check.HasError(t, err)
+			check.Contains(t, err.Error(), "missing (out-of-order) migration")
+		}
+
+		t.Run("latest_version", func(t *testing.T) {
+			run(t, int64(len(fsys)))
+		})
+		t.Run("latest_version_minus_one", func(t *testing.T) {
+			run(t, int64(len(fsys)-1))
+		})
 	})
 }
 


### PR DESCRIPTION
Fix #761

This PR reverts the optimization in #758 and uses the same up logic to check whether all migrations have been applied. I.e., if allow missing (out-of-order) is disabled, which is the **default**, we report an error instead of false and `nil` error.

This avoids silently ignoring missing migrations, which is typically true for timestamp-based migrations.

I do wish we could optimize this because, for those who convert timestamp -> sequential [hybrid migrations](https://pressly.github.io/goose/blog/2021/out-of-order-migrations/) and gate for the correct ordering in CI, it's not possible to get into this state. It'd be nice for those folks to benefit from more efficient checks along this code path.