### PR TITLE
Rename CheckPending to GetVersions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Add `CheckPending` method to `goose.Provider` to check if there are pending migrations, returns
-  the current (max db) version and the latest (max file) version. (#756)
+- Add `GetVersions` method to `goose.Provider`, returns the current (max db) version and the latest
+  (max filesystem) version. (#756)
 - Clarify `GetLatestVersion` method MUST return `ErrVersionNotFound` if no latest migration is
   found. Previously it was returning a -1 and nil error, which was inconsistent with the rest of the
   API surface.

--- a/internal/testing/integration/postgres_locking_test.go
+++ b/internal/testing/integration/postgres_locking_test.go
@@ -437,7 +437,7 @@ func TestPostgresPending(t *testing.T) {
 				hasPending, err := p.HasPending(context.Background())
 				check.NoError(t, err)
 				boolCh <- hasPending
-				current, target, err := p.CheckPending(context.Background())
+				current, target, err := p.GetVersions(context.Background())
 				check.NoError(t, err)
 				check.Number(t, current, int64(wantCurrent))
 				check.Number(t, target, int64(wantTarget))
@@ -492,7 +492,7 @@ SELECT pg_sleep_for('4 seconds');
 			return err
 		}
 		check.Bool(t, hasPending, true)
-		current, target, err := newProvider.CheckPending(context.Background())
+		current, target, err := newProvider.GetVersions(context.Background())
 		if err != nil {
 			return err
 		}
@@ -506,7 +506,7 @@ SELECT pg_sleep_for('4 seconds');
 			return err
 		}
 		check.Bool(t, hasPending, false)
-		current, target, err := oldProvider.CheckPending(context.Background())
+		current, target, err := oldProvider.GetVersions(context.Background())
 		if err != nil {
 			return err
 		}
@@ -531,7 +531,7 @@ SELECT pg_sleep_for('4 seconds');
 	hasPending, err := oldProvider.HasPending(context.Background())
 	check.NoError(t, err)
 	check.Bool(t, hasPending, false)
-	current, target, err := oldProvider.CheckPending(context.Background())
+	current, target, err := oldProvider.GetVersions(context.Background())
 	check.NoError(t, err)
 	check.Number(t, current, lastVersion)
 	check.Number(t, target, lastVersion)
@@ -541,7 +541,7 @@ SELECT pg_sleep_for('4 seconds');
 	hasPending, err = newProvider.HasPending(context.Background())
 	check.NoError(t, err)
 	check.Bool(t, hasPending, false)
-	current, target, err = newProvider.CheckPending(context.Background())
+	current, target, err = newProvider.GetVersions(context.Background())
 	check.NoError(t, err)
 	check.Number(t, current, lastVersion+1)
 	check.Number(t, target, lastVersion+1)

--- a/provider.go
+++ b/provider.go
@@ -163,7 +163,7 @@ func (p *Provider) HasPending(ctx context.Context) (bool, error) {
 	return p.hasPending(ctx)
 }
 
-// GetVersions returns the current database version and the target version to migrate to.
+// GetVersions returns the max database version and the target version to migrate to.
 //
 // Note, this method will not use a SessionLocker if one is configured. This allows callers to check
 // for versions without blocking or being blocked by other operations.

--- a/provider.go
+++ b/provider.go
@@ -163,17 +163,12 @@ func (p *Provider) HasPending(ctx context.Context) (bool, error) {
 	return p.hasPending(ctx)
 }
 
-// CheckPending returns the current database version and the target version to migrate to. If there
-// are no pending migrations, the target version will be the same as the current version.
+// GetVersions returns the current database version and the target version to migrate to.
 //
 // Note, this method will not use a SessionLocker if one is configured. This allows callers to check
-// for pending migrations without blocking or being blocked by other operations.
-//
-// If out-of-order migrations are enabled this method is not suitable for checking pending
-// migrations because it ONLY returns the highest version in the database. Instead, use the
-// [HasPending] method.
-func (p *Provider) CheckPending(ctx context.Context) (current, target int64, err error) {
-	return p.checkPending(ctx)
+// for versions without blocking or being blocked by other operations.
+func (p *Provider) GetVersions(ctx context.Context) (current, target int64, err error) {
+	return p.getVersions(ctx)
 }
 
 // GetDBVersion returns the highest version recorded in the database, regardless of the order in
@@ -491,7 +486,7 @@ func (p *Provider) apply(
 	return p.runMigrations(ctx, conn, []*Migration{m}, d, true)
 }
 
-func (p *Provider) checkPending(ctx context.Context) (current, target int64, retErr error) {
+func (p *Provider) getVersions(ctx context.Context) (current, target int64, retErr error) {
 	conn, cleanup, err := p.initialize(ctx, false)
 	if err != nil {
 		return -1, -1, fmt.Errorf("failed to initialize: %w", err)

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -790,7 +790,7 @@ func TestPending(t *testing.T) {
 		check.NoError(t, err)
 		// Even though the latest migration HAS been applied, there are still pending out-of-order
 		// migrations.
-		current, target, err := p.CheckPending(ctx)
+		current, target, err := p.GetVersions(ctx)
 		check.NoError(t, err)
 		check.Number(t, current, 3)
 		check.Number(t, target, len(fsys))
@@ -804,7 +804,7 @@ func TestPending(t *testing.T) {
 		hasPending, err = p.HasPending(ctx)
 		check.NoError(t, err)
 		check.Bool(t, hasPending, false)
-		current, target, err = p.CheckPending(ctx)
+		current, target, err = p.GetVersions(ctx)
 		check.NoError(t, err)
 		check.Number(t, current, target)
 	})
@@ -824,7 +824,7 @@ func TestPending(t *testing.T) {
 			check.NoError(t, err)
 			// TODO(mf): revisit the pending check behavior in addition to the HasPending
 			// method.
-			current, target, err := p.CheckPending(ctx)
+			current, target, err := p.GetVersions(ctx)
 			check.NoError(t, err)
 			check.Number(t, current, versionToApply)
 			check.Number(t, target, len(fsys))


### PR DESCRIPTION
Picking up from https://github.com/pressly/goose/pull/762#discussion_r1585810694

I don't want to give the impression this method is suitable for checking "pending" migrations because it's a bit nuanced. I.e., what if a missing (out-of-order) migration has snuck in, it'd be **silently ignored if we just compare the max db version and target filesystem version**.

This is what `HasPending` is intended to do, handle all the edge cases around missing migrations (which can be enabled or disabled). For a better understanding of all the possible cases see:

https://github.com/pressly/goose/blob/8c8def43/provider.go#L530-L544 and https://github.com/pressly/goose/blob/8c8def43/internal/gooseutil/resolve_test.go#L73-L83

Once you enumerate the edge cases it becomes clear that internally we cannot compare latest versions, e.g., what happens when running `goose up-to 4` and the current db version is 6, where the "missing" migration is 5? I'll write up a reference for "What is a missing migration?"

### TL;DR

So, rename `CheckPending` to `GetVersions` which does what it says on the tin: get the (max) version from the database and filesystem, which are termed current and target, respectively.