### PR TITLE
Remove explicit failure in WithDisableGlobalRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Update `WithDisableGlobalRegistry` behavior, which allows disabling the global registry without
+  error. Specifically, the folling check is removed:
+
+```go
+if len(global) > 0 {
+	return nil, errors.New("global registry disabled, but provider has registered go migrations")
+}
+```
+
 ## [v3.21.1]
 
 - Add `GetVersions` method to `goose.Provider`, returns the current (max db) version and the latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Update `WithDisableGlobalRegistry` behavior, which allows disabling the global registry without
-  error. Specifically, the folling check is removed:
+- Update `WithDisableGlobalRegistry` behavior (#783). If set, this will ignore globally-registered
+  migrations instead of raising an error. Specifically, the following check is removed:
 
 ```go
 if len(global) > 0 {
 	return nil, errors.New("global registry disabled, but provider has registered go migrations")
 }
 ```
+
+This enables creating isolated goose provider(s) in legacy environments where global migrations may
+be registered. Without updating this behavior, it would be impossible to use
+`WithDisableGlobalRegistry` in combination with `WithGoMigrations`.
 
 ## [v3.21.1]
 

--- a/provider.go
+++ b/provider.go
@@ -116,16 +116,14 @@ func newProvider(
 	for version, m := range cfg.registered {
 		versionToGoMigration[version] = m
 	}
-	// Return an error if the global registry is explicitly disabled, but there are registered Go
-	// migrations.
-	if cfg.disableGlobalRegistry {
-		if len(global) > 0 {
-			return nil, errors.New("global registry disabled, but provider has registered go migrations")
-		}
-	} else {
+	// Skip adding global go migrations if explicitly disabled. This allows users to disable the
+	// global registry and have fully isolated go migrations scoped to the current provider.
+	if !cfg.disableGlobalRegistry {
+		// TODO(mf): should we log a warning if the global registry is disabled and there are
+		// registered go migrations?
 		for version, m := range global {
 			if _, ok := versionToGoMigration[version]; ok {
-				return nil, fmt.Errorf("global go migration with version %d previously registered with provider", version)
+				return nil, fmt.Errorf("global go migration conflicts with provider-registered go migration with version %d", version)
 			}
 			versionToGoMigration[version] = m
 		}

--- a/provider.go
+++ b/provider.go
@@ -116,11 +116,11 @@ func newProvider(
 	for version, m := range cfg.registered {
 		versionToGoMigration[version] = m
 	}
-	// Skip adding global go migrations if explicitly disabled. This allows users to disable the
-	// global registry and have fully isolated go migrations scoped to the current provider.
-	if !cfg.disableGlobalRegistry {
-		// TODO(mf): should we log a warning if the global registry is disabled and there are
-		// registered go migrations?
+	// Skip adding global Go migrations if explicitly disabled.
+	if cfg.disableGlobalRegistry {
+		// TODO(mf): let's add a warn-level log here to inform users if len(global) > 0. Would like
+		// to add this once we're on go1.21 and leverage the new slog package.
+	} else {
 		for version, m := range global {
 			if _, ok := versionToGoMigration[version]; ok {
 				return nil, fmt.Errorf("global go migration conflicts with provider-registered go migration with version %d", version)


### PR DESCRIPTION
Fix #782

This PR updates the behavior of the provider `WithDisableGlobalRegistry` option, specifically removing this check:

```go
if len(global) > 0 {
	return nil, errors.New("global registry disabled, but provider has registered go migrations")
}
```

Allowing programs to have multiple providers who may be running in a (legacy) environment with globaly-registered migrations. By removing this check, the caller can now explicitly disable global migrations and isolate go migrations to the current provider with `WithGoMigrations`.

TL;DR - the combination of `WithGoMigrations` and `WithDisableGlobalRegistry` allows you to have a fully isolated provider.

- [ ] Decide whether this should log a warning, or simple ignore and do nothing