### PR TITLE
feat: Add Unwrap to PartialError

### DIFF
--- a/provider_errors.go
+++ b/provider_errors.go
@@ -42,3 +42,7 @@ func (e *PartialError) Error() string {
 		e.Failed.Source.Type, e.Failed.Source.Version, e.Err,
 	)
 }
+
+func (e *PartialError) Unwrap() error {
+	return e.Err
+}

--- a/provider_test.go
+++ b/provider_test.go
@@ -35,7 +35,6 @@ func TestProvider(t *testing.T) {
 	check.Equal(t, len(sources), 2)
 	check.Equal(t, sources[0], newSource(goose.TypeSQL, "001_foo.sql", 1))
 	check.Equal(t, sources[1], newSource(goose.TypeSQL, "002_bar.sql", 2))
-
 }
 
 var (
@@ -76,3 +75,10 @@ ALTER TABLE my_foo DROP COLUMN timestamp;
 ALTER TABLE my_foo RENAME TO foo;
 `
 )
+
+func TestPartialErrorUnwrap(t *testing.T) {
+	err := &goose.PartialError{Err: goose.ErrNoCurrentVersion}
+
+	got := errors.Is(err, goose.ErrNoCurrentVersion)
+	check.Bool(t, got, true)
+}


### PR DESCRIPTION
This allows `PartialError` to expose the error it wraps so that it is compatible with Go's error inspection machinery defined in package errors.