### PR TITLE
mysql: do not use SERIAL alias in goose_db_version table creation

### DIFF
--- a/internal/dialect/dialectquery/mysql.go
+++ b/internal/dialect/dialectquery/mysql.go
@@ -8,7 +8,7 @@ var _ Querier = (*Mysql)(nil)
 
 func (m *Mysql) CreateTable(tableName string) string {
 	q := `CREATE TABLE %s (
-		id serial NOT NULL,
+		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 		version_id bigint NOT NULL,
 		is_applied boolean NOT NULL,
 		tstamp timestamp NULL default now(),


### PR DESCRIPTION
We are using `goose` to run migrations on Vitess with MySQL setup. Unfortunately, Vitess does not support `SERIAL` keyword. Right now our work-around is to create `goose_db_version` table manually without using `SERIAL` keyword. We can solve this problem by NOT using `SERIAL` keyword and explicitly define the type of the column.

This change is backwards-compatible

As stated in the [MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html): 

```
SERIAL is an alias for BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE.
```

After table is created with `SERIAL` keyword, it automatically resolves to `bigint(20) unsigned NOT NULL AUTO_INCREMENT`:

```
mysql> create table mytable (id serial primary key);

mysql> show create table mytable\G
*************************** 1. row ***************************
       Table: mytable
Create Table: CREATE TABLE `mytable` (
  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`id`),
  UNIQUE KEY `id` (`id`) -- this one is superfluous
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
```

