### PR TITLE
feat: WithLogger Provider Option

### DIFF
--- a/provider_options.go
+++ b/provider_options.go
@@ -165,6 +165,16 @@ func WithDisableVersioning(b bool) ProviderOption {
 	})
 }
 
+// WithLogger set the logger, same behavior as with goose.SetLogger(logger)
+// Using Provider would block the ability to override the logger, which could become painful to have a proper
+// structured logging. By Default, this won't override the default logger.
+func WithLogger(l Logger) ProviderOption {
+	return configFunc(func(c *config) error {
+		c.logger = l
+		return nil
+	})
+}
+
 type config struct {
 	store database.Store
 


### PR DESCRIPTION
* ability to respect the current behaviour of `SetLogger` for Goose Providers

Currently goose provides a `SetLogger` method to overload the goose logger.
Goose providers doesn't provide such mechanism, leading to a painful use to do full structured logging when embedding goose into a custom package.

how to use (with zerolog)
```go
type MyLogger struct {
	l *zerolog.Logger
}

func NewMyLogger(l *zerolog.Logger) *MyLogger {
	return &MyLogger{l: l}
}

func (m MyLogger) Fatalf(format string, v ...interface{}) {
	m.l.Fatal().Msgf(format, v...)
}

func (m MyLogger) Printf(format string, v ...interface{}) {
	m.l.Info().Msgf(format, v...)
}

func RunStuff() {
        log.Info().Msgf("Starting goose stage: creating custom logger")
        l := NewMyLogger(&log.Logger)
        fsObj := os.DirFS("./localtest2/migrations")
	p, err := goose.NewProvider("clickhouse", dbConn, fsObj, goose.WithVerbose(true), goose.WithLogger(l))
	if err != nil {
		log.Fatal().Err(err).Msg("Failed to create provider")
	}
	res, err := p.Up(context.TODO())
	if err != nil {
		log.Fatal().Err(err).Msg("Failed to up")
	}
}
```

which outputs:

```
{"level":"info","time":"2024-10-08T09:15:54+02:00","message":"Starting goose stage: creating custom logger"}
{"level":"info","time":"2024-10-08T09:15:54+02:00","message":"goose: OK    up 00005_testme.sql (73.44ms)"}
{"level":"info","time":"2024-10-08T09:15:54+02:00","message":"goose: successfully migrated database, current version: 5"}
{"level":"info","time":"2024-10-08T09:15:54+02:00","message":"Migration applied: OK    up 00005_testme.sql (73.44ms)"}
```