### PR TITLE
Add slog support to goose provider

### DIFF
--- a/provider_options.go
+++ b/provider_options.go
@@ -3,6 +3,7 @@ package goose
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/pressly/goose/v3/database"
 	"github.com/pressly/goose/v3/lock"
@@ -165,10 +166,20 @@ func WithDisableVersioning(b bool) ProviderOption {
 	})
 }
 
+// WithLogger sets the logger to use for logging. By default, goose will use a modified version of
+// the [slog.NewTextHandler] with a custom format.
+func WithLogger(logger *slog.Logger) ProviderOption {
+	return configFunc(func(c *config) error {
+		c.logger = logger
+		return nil
+	})
+}
+
 type config struct {
 	store database.Store
 
 	verbose         bool
+	logger          *slog.Logger
 	excludePaths    map[string]bool
 	excludeVersions map[int64]bool
 
@@ -184,11 +195,6 @@ type config struct {
 	disableVersioning     bool
 	allowMissing          bool
 	disableGlobalRegistry bool
-
-	// Let's not expose the Logger just yet. Ideally we consolidate on the std lib slog package
-	// added in go1.21 and then expose that (if that's even necessary). For now, just use the std
-	// lib log package.
-	logger Logger
 }
 
 type configFunc func(*config) error


### PR DESCRIPTION
This PR enable callers to pass a `*slog.Logger` logger to goose provider. Example:

```go
logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
_, err = goose.NewProvider(goose.DialectSQLite3, db, fsys,
	goose.WithLogger(logger),
)
```

And internally goose will invoke the structured logger:

```go
logger.Info("applied migration",
	slog.String("source", filepath.Base(m.Source)),
	slog.Any("direction", direction),
	slog.Any("duration", result.Duration),
	slog.Bool("empty", result.Empty),
)
```

By default if `WithVerbose(true)` is enabled but no logger is supplied, goose will use an internal text logger:

```
time="2024-10-14 13:07:30" level=INFO msg="applied migration" logger=goose source=00001_users_table.sql direction=up duration=1.174375ms empty=false
```

An alternative implementation is to using the existing `goose.Logger` interface, but I worry this may corner goose into a corner.