### PR TITLE
#329 Add environment variable support for migrations directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+GOOSE_DRIVER=postgres
+GOOSE_DBSTRING=postgres://admin:admin@localhost:5432/assets_db
+GOOSE_MIGRATION_DIR=./migrations

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-GOOSE_DRIVER=postgres
-GOOSE_DBSTRING=postgres://admin:admin@localhost:5432/assets_db
-GOOSE_MIGRATION_DIR=./migrations

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ brew install goose
 
 See [installation documentation](https://pressly.github.io/goose/installation/) for more details.
 
+# Setting Up Environment Keys
+To start, configure the environment keys using one of the following methods:
+
+**1. Via environment variables:** 
+```shell
+export GOOSE_DRIVER=DRIVER
+export GOOSE_DBSTRING=DBSTRING
+export GOOSE_MIGRATION_DIR=MIGRATION_DIR
+```
+
+**2. Via `.env` files with corresponding variables. `.env` file example**:
+```env
+GOOSE_DRIVER=postgres
+GOOSE_DBSTRING=postgres://admin:admin@localhost:5432/admin_db
+GOOSE_MIGRATION_DIR=./migrations
+```
+For more details about environment variables, see the [official documentation on environment variables]( https://pressly.github.io/goose/documentation/environment-variables/).
+
 # Usage
 
 <details>

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.30.0
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/jackc/pgx/v5 v5.7.1
+	github.com/joho/godotenv v1.5.1
 	github.com/mfridman/interpolate v0.0.2
 	github.com/mfridman/xflag v0.0.0-20240825232106-efb77353e578
 	github.com/microsoft/go-mssqldb v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFr
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -1,8 +1,12 @@
 package cfg
 
-import "os"
+import (
+	"github.com/joho/godotenv"
+	"os"
+)
 
 var (
+	_                 = godotenv.Load()
 	GOOSEDRIVER       = envOr("GOOSE_DRIVER", "")
 	GOOSEDBSTRING     = envOr("GOOSE_DBSTRING", "")
 	GOOSEMIGRATIONDIR = envOr("GOOSE_MIGRATION_DIR", DefaultMigrationDir)


### PR DESCRIPTION
added `GoDotEnv` to extract env vars from `.env` files #329 