### PR TITLE
Update README - examply mssql connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Examples:
     goose mysql "user:password@/dbname?parseTime=true" status
     goose redshift "postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" status
     goose tidb "user:password@/dbname?parseTime=true" status
-    goose mssql "sqlserver://user:password@dbname:1433?database=master" status
+    goose mssql "sqlserver://user:password@hostname:1433?database=master" status
     goose clickhouse "tcp://127.0.0.1:9000" status
     goose vertica "vertica://user:password@localhost:5433/dbname?connection_load_balance=1" status
     goose ydb "grpcs://localhost:2135/local?go_query_mode=scripting&go_fake_tx=scripting&go_query_bind=declare,numeric" status


### PR DESCRIPTION
the use of `dbname` in the example mssql connection string is confusing, it should be the hostname rather than the name of the database 