### PR TITLE
Remove trailing newline from log calls

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -151,11 +151,11 @@ func main() {
 	driver, dbstring, command := args[0], args[1], args[2]
 	db, err := goose.OpenDBWithDriver(driver, normalizeDBString(driver, dbstring, *certfile, *sslcert, *sslkey))
 	if err != nil {
-		log.Fatalf("-dbstring=%q: %v\n", dbstring, err)
+		log.Fatalf("-dbstring=%q: %v", dbstring, err)
 	}
 	defer func() {
 		if err := db.Close(); err != nil {
-			log.Fatalf("goose: failed to close DB: %v\n", err)
+			log.Fatalf("goose: failed to close DB: %v", err)
 		}
 	}()
 

--- a/create.go
+++ b/create.go
@@ -76,7 +76,7 @@ func CreateWithTemplate(db *sql.DB, dir string, tmpl *template.Template, name, m
 		return fmt.Errorf("failed to execute tmpl: %w", err)
 	}
 
-	log.Printf("Created new file: %s\n", f.Name())
+	log.Printf("Created new file: %s", f.Name())
 	return nil
 }
 

--- a/down.go
+++ b/down.go
@@ -68,17 +68,17 @@ func DownToContext(ctx context.Context, db *sql.DB, dir string, version int64, o
 		}
 
 		if currentVersion == 0 {
-			log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
+			log.Printf("goose: no migrations to run. current version: %d", currentVersion)
 			return nil
 		}
 		current, err := migrations.Current(currentVersion)
 		if err != nil {
-			log.Printf("goose: migration file not found for current version (%d), error: %s\n", currentVersion, err)
+			log.Printf("goose: migration file not found for current version (%d), error: %s", currentVersion, err)
 			return err
 		}
 
 		if current.Version <= version {
-			log.Printf("goose: no migrations to run. current version: %d\n", currentVersion)
+			log.Printf("goose: no migrations to run. current version: %d", currentVersion)
 			return nil
 		}
 
@@ -102,6 +102,6 @@ func downToNoVersioning(ctx context.Context, db *sql.DB, migrations Migrations, 
 			return err
 		}
 	}
-	log.Printf("goose: down to current file version: %d\n", finalVersion)
+	log.Printf("goose: down to current file version: %d", finalVersion)
 	return nil
 }

--- a/examples/go-migrations/main.go
+++ b/examples/go-migrations/main.go
@@ -29,12 +29,12 @@ func main() {
 
 	db, err := goose.OpenDBWithDriver("sqlite", dbstring)
 	if err != nil {
-		log.Fatalf("goose: failed to open DB: %v\n", err)
+		log.Fatalf("goose: failed to open DB: %v", err)
 	}
 
 	defer func() {
 		if err := db.Close(); err != nil {
-			log.Fatalf("goose: failed to close DB: %v\n", err)
+			log.Fatalf("goose: failed to close DB: %v", err)
 		}
 	}()
 

--- a/migration.go
+++ b/migration.go
@@ -232,9 +232,9 @@ func (m *Migration) run(ctx context.Context, db *sql.DB, direction bool) error {
 		finish := truncateDuration(time.Since(start))
 
 		if len(statements) > 0 {
-			log.Printf("OK   %s (%s)\n", filepath.Base(m.Source), finish)
+			log.Printf("OK   %s (%s)", filepath.Base(m.Source), finish)
 		} else {
-			log.Printf("EMPTY %s (%s)\n", filepath.Base(m.Source), finish)
+			log.Printf("EMPTY %s (%s)", filepath.Base(m.Source), finish)
 		}
 
 	case ".go":
@@ -280,9 +280,9 @@ func (m *Migration) run(ctx context.Context, db *sql.DB, direction bool) error {
 		}
 		finish := truncateDuration(time.Since(start))
 		if !empty {
-			log.Printf("OK   %s (%s)\n", filepath.Base(m.Source), finish)
+			log.Printf("OK   %s (%s)", filepath.Base(m.Source), finish)
 		} else {
-			log.Printf("EMPTY %s (%s)\n", filepath.Base(m.Source), finish)
+			log.Printf("EMPTY %s (%s)", filepath.Base(m.Source), finish)
 		}
 	}
 	return nil

--- a/status.go
+++ b/status.go
@@ -26,10 +26,10 @@ func StatusContext(ctx context.Context, db *sql.DB, dir string, opts ...OptionsF
 		return fmt.Errorf("failed to collect migrations: %w", err)
 	}
 	if option.noVersioning {
-		log.Printf("    Applied At                  Migration\n")
-		log.Printf("    =======================================\n")
+		log.Printf("    Applied At                  Migration")
+		log.Printf("    =======================================")
 		for _, current := range migrations {
-			log.Printf("    %-24s -- %v\n", "no versioning", filepath.Base(current.Source))
+			log.Printf("    %-24s -- %v", "no versioning", filepath.Base(current.Source))
 		}
 		return nil
 	}
@@ -39,8 +39,8 @@ func StatusContext(ctx context.Context, db *sql.DB, dir string, opts ...OptionsF
 		return fmt.Errorf("failed to ensure DB version: %w", err)
 	}
 
-	log.Printf("    Applied At                  Migration\n")
-	log.Printf("    =======================================\n")
+	log.Printf("    Applied At                  Migration")
+	log.Printf("    =======================================")
 	for _, migration := range migrations {
 		if err := printMigrationStatus(ctx, db, migration.Version, filepath.Base(migration.Source)); err != nil {
 			return fmt.Errorf("failed to print status: %w", err)
@@ -59,6 +59,6 @@ func printMigrationStatus(ctx context.Context, db *sql.DB, version int64, script
 	if m != nil && m.IsApplied {
 		appliedAt = m.Timestamp.Format(time.ANSIC)
 	}
-	log.Printf("    %-24s -- %v\n", appliedAt, script)
+	log.Printf("    %-24s -- %v", appliedAt, script)
 	return nil
 }

--- a/up.go
+++ b/up.go
@@ -122,9 +122,9 @@ func UpToContext(ctx context.Context, db *sql.DB, dir string, version int64, opt
 			return err
 		}
 
-		log.Printf("goose: no migrations to run. current version: %d\n", current)
+		log.Printf("goose: no migrations to run. current version: %d", current)
 	} else {
-		log.Printf("goose: successfully migrated database to version: %d\n", current)
+		log.Printf("goose: successfully migrated database to version: %d", current)
 	}
 
 	// At this point there are no more migrations to apply. But we need to maintain
@@ -153,7 +153,7 @@ func upToNoVersioning(ctx context.Context, db *sql.DB, migrations Migrations, ve
 		}
 		finalVersion = current.Version
 	}
-	log.Printf("goose: up to current file version: %d\n", finalVersion)
+	log.Printf("goose: up to current file version: %d", finalVersion)
 	return nil
 }
 

--- a/version.go
+++ b/version.go
@@ -27,7 +27,7 @@ func VersionContext(ctx context.Context, db *sql.DB, dir string, opts ...Options
 		if len(migrations) > 0 {
 			current = migrations[len(migrations)-1].Version
 		}
-		log.Printf("goose: file version %v\n", current)
+		log.Printf("goose: file version %v", current)
 		return nil
 	}
 
@@ -35,7 +35,7 @@ func VersionContext(ctx context.Context, db *sql.DB, dir string, opts ...Options
 	if err != nil {
 		return err
 	}
-	log.Printf("goose: version %v\n", current)
+	log.Printf("goose: version %v", current)
 	return nil
 }
 


### PR DESCRIPTION
This way there is no need to clean up a newline when implementing your own goose.Logger. The standard log package being used by default will add a newline if it is not there.

For reference, I noticed this when trying to implement a `goose.Logger` using https://github.com/rs/zerolog, looking like so:
```
type gooseLogger struct {
	logger zerolog.Logger
}

func (gl gooseLogger) Fatalf(format string, v ...interface{}) {
	gl.logger.Fatal().Msgf(format, v...)
}

func (gl gooseLogger) Printf(format string, v ...interface{}) {
	gl.logger.Info().Msgf(format, v...)
}
```

Where the resulting log message ended up like this (note the trailing newline in `message`):
```
{"level":"info", "time":"2024-12-19T08:36:40+01:00","caller":"migrations.go:25","message":"goose: no migrations to run. current version: 1\n"}
```