### PR TITLE
fix: only use postgres schema name if explicitly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Fix regression in postgres migration table existence check for non-default schema. (#882, #883)
+- Fix regression (`v3.23.1` and `v3.24.0`) in postgres migration table existence check for
+  non-default schema. (#882, #883)
 
 ## [v3.24.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fix regression in postgres migration table existence check for non-default schema. (#882, #883)
+
 ## [v3.24.0]
 
 - Add support for loading environment variables from `.env` files, enabled by default.

--- a/internal/dialect/dialectquery/postgres.go
+++ b/internal/dialect/dialectquery/postgres.go
@@ -5,13 +5,6 @@ import (
 	"strings"
 )
 
-const (
-	// defaultSchemaName is the default schema name for Postgres.
-	//
-	// https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC
-	defaultSchemaName = "public"
-)
-
 type Postgres struct{}
 
 var _ Querier = (*Postgres)(nil)
@@ -52,15 +45,18 @@ func (p *Postgres) GetLatestVersion(tableName string) string {
 }
 
 func (p *Postgres) TableExists(tableName string) string {
+	q := `SELECT EXISTS ( SELECT 1 FROM pg_tables WHERE tablename = '%s' )`
 	schemaName, tableName := parseTableIdentifier(tableName)
-	q := `SELECT EXISTS ( SELECT FROM pg_tables WHERE schemaname = '%s' AND tablename = '%s' )`
+	if schemaName != "" {
+		q = `SELECT EXISTS ( SELECT 1 FROM pg_tables WHERE schemaname = '%s' AND tablename = '%s' )`
+	}
 	return fmt.Sprintf(q, schemaName, tableName)
 }
 
 func parseTableIdentifier(name string) (schema, table string) {
 	schema, table, found := strings.Cut(name, ".")
 	if !found {
-		return defaultSchemaName, name
+		return "", name
 	}
 	return schema, table
 }

--- a/internal/dialect/dialectquery/postgres.go
+++ b/internal/dialect/dialectquery/postgres.go
@@ -45,12 +45,13 @@ func (p *Postgres) GetLatestVersion(tableName string) string {
 }
 
 func (p *Postgres) TableExists(tableName string) string {
-	q := `SELECT EXISTS ( SELECT 1 FROM pg_tables WHERE tablename = '%s' )`
 	schemaName, tableName := parseTableIdentifier(tableName)
 	if schemaName != "" {
-		q = `SELECT EXISTS ( SELECT 1 FROM pg_tables WHERE schemaname = '%s' AND tablename = '%s' )`
+		q := `SELECT EXISTS ( SELECT 1 FROM pg_tables WHERE schemaname = '%s' AND tablename = '%s' )`
+		return fmt.Sprintf(q, schemaName, tableName)
 	}
-	return fmt.Sprintf(q, schemaName, tableName)
+	q := `SELECT EXISTS ( SELECT 1 FROM pg_tables WHERE tablename = '%s' )`
+	return fmt.Sprintf(q, tableName)
 }
 
 func parseTableIdentifier(name string) (schema, table string) {


### PR DESCRIPTION
Fix #882 

This PR updates the postgres table existence check SQL queries. We were previously defaulting in app code to the postgres default of `public` schema ([link](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC)), but instead, we should respect whatever a user may have set and let postgres handle it.

Note, we still use the schema if the user explicitly sets a custom table name like `schema.table`.