### PR TITLE
Remove depreceated call to Run and replace with RunContext

### DIFF
--- a/examples/go-migrations/main.go
+++ b/examples/go-migrations/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"os"
@@ -43,7 +44,8 @@ func main() {
 		arguments = append(arguments, args[3:]...)
 	}
 
-	if err := goose.Run(command, db, *dir, arguments...); err != nil {
+	ctx := context.Background()
+	if err := goose.RunContext(ctx, command, db, *dir, arguments...); err != nil {
 		log.Fatalf("goose %v: %v", command, err)
 	}
 }


### PR DESCRIPTION
Replaces the deprecated call to `goose.Run` with the supported goose.`RunContext` in the example file for go-migrations