### PR TITLE
fix: log reason for version table creation

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -213,6 +213,7 @@ func EnsureDBVersion(db *sql.DB) (int64, error) {
 func EnsureDBVersionContext(ctx context.Context, db *sql.DB) (int64, error) {
 	dbMigrations, err := store.ListMigrations(ctx, db, TableName())
 	if err != nil {
+		log.Printf("goose: create version table due to issue: %s\n", err.Error())
 		return 0, createVersionTable(ctx, db)
 	}
 	// The most recent record for each migration specifies


### PR DESCRIPTION
Adds a log entry for when the version table is created, including the reason (original error). This simplifies debugging of environments where users expect version tables to already exist.

In our case, a PostgreSQL database was backed up and restored. Despite the version table existing, due to a misconfiguration it could not access it and tried to create it again. Logging the reason why we create the table improves the debugging experience and transparency of what goose is actually doing.