### PR TITLE
Fixed the installation of the linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint: tools
 
 .PHONY: tools
 tools:
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 	@go install github.com/mfridman/tparse@main
 
 test-packages:


### PR DESCRIPTION
Fixed the installation of the linter to the one [recommended](https://golangci-lint.run/welcome/install/#install-from-sources) by the developer