### PR TITLE
feat: allow empty migrations in providers

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -135,9 +135,6 @@ func newProvider(
 	if err != nil {
 		return nil, err
 	}
-	if len(migrations) == 0 {
-		return nil, ErrNoMigrations
-	}
 	return &Provider{
 		db:         db,
 		fsys:       fsys,
@@ -505,7 +502,11 @@ func (p *Provider) getVersions(ctx context.Context) (current, target int64, retE
 		retErr = multierr.Append(retErr, cleanup())
 	}()
 
-	target = p.migrations[len(p.migrations)-1].Version
+	if len(p.migrations) > 0 {
+		target = p.migrations[len(p.migrations)-1].Version
+	} else {
+		target = 0 //If there are no migrations, the target is 0
+	}
 
 	// If versioning is disabled, we always have pending migrations and the target version is the
 	// last migration.


### PR DESCRIPTION
Hello,

This PR allow the usage of a provider without any version.

When there are no versions, I'm not sure there are a reason to disable provider usage. I would like to be able to use my provider as usual, it's just it's going to tell me there are no migration to apply and no specifying handling of the "I got a provider / I didn't" is needed when using the library.

This mean there won't be an error if someone is initialize the provider without migrations witch may not be desirable. The new behavior may be implemented as an option, or the Provider returned with the error, leaving the choice to the programmer :)