### PR TITLE
Set table name based on flag or environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ arguments, you can set the following environment variables:
 export GOOSE_DRIVER=DRIVER
 export GOOSE_DBSTRING=DBSTRING
 export GOOSE_MIGRATION_DIR=MIGRATION_DIR
+export GOOSE_TABLE=TABLENAME
 ```
 
 **2. Via `.env` files with corresponding variables. `.env` file example**:
@@ -255,6 +256,7 @@ export GOOSE_MIGRATION_DIR=MIGRATION_DIR
 GOOSE_DRIVER=postgres
 GOOSE_DBSTRING=postgres://admin:admin@localhost:5432/admin_db
 GOOSE_MIGRATION_DIR=./migrations
+GOOSE_TABLE=custom.goose_migrations
 ```
 
 Loading from `.env` files is enabled by default. To disable this feature, set the `-env=none` flag.

--- a/cmd/goose/main_test.go
+++ b/cmd/goose/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{
+			name:     "no values",
+			input:    []string{},
+			expected: "",
+		},
+		{
+			name:     "all empty values",
+			input:    []string{"", "", ""},
+			expected: "",
+		},
+		{
+			name:     "single non-empty value at start",
+			input:    []string{"value", "", ""},
+			expected: "value",
+		},
+		{
+			name:     "single non-empty value in middle",
+			input:    []string{"", "value", ""},
+			expected: "value",
+		},
+		{
+			name:     "single non-empty value at end",
+			input:    []string{"", "", "value"},
+			expected: "value",
+		},
+		{
+			name:     "multiple non-empty values",
+			input:    []string{"first", "second", "third"},
+			expected: "first",
+		},
+		{
+			name:     "mixed empty and non-empty values",
+			input:    []string{"", "value1", "", "value2"},
+			expected: "value1",
+		},
+		{
+			name:     "only one value, empty",
+			input:    []string{""},
+			expected: "",
+		},
+		{
+			name:     "only one value, non-empty",
+			input:    []string{"value"},
+			expected: "value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := firstNonEmpty(tt.input...)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Created a new environment variable, `GOOSE_TABLE`, that enables users to configure a custom table name. Updated the `SetTableName` logic to prioritize flags over the new environment variable, following the previous behaviour for other env vars. Implemented a helper function, `firstNonEmpty`, to facilitate flexible value selection. Wrote unit tests to validate the function. Updated the `README.md` with the newly create `GOOSE_TABLE` environment variable.

Example:
```
export GOOSE_TABLE=custom.table_name
goose up
```

Please let me know if any other change is required.