### PR TITLE
Log SQL query results if supported by DB (rows affected, last insert ID)

### DIFF
--- a/migration_sql.go
+++ b/migration_sql.go
@@ -42,7 +42,7 @@ func runSQLMigration(
 				_ = tx.Rollback()
 				return fmt.Errorf("failed to execute SQL query %q: %w", clearStatement(query), err)
 			}
-			if resInfo := formatResult(res); resInfo != "" {
+			if resInfo := formatResultInfo(res); resInfo != "" {
 				verboseInfo(resInfo)
 			}
 		}
@@ -78,7 +78,7 @@ func runSQLMigration(
 		if err != nil {
 			return fmt.Errorf("failed to execute SQL query %q: %w", clearStatement(query), err)
 		}
-		if resInfo := formatResult(res); resInfo != "" {
+		if resInfo := formatResultInfo(res); resInfo != "" {
 			verboseInfo(resInfo)
 		}
 	}
@@ -122,7 +122,7 @@ func clearStatement(s string) string {
 	return matchEmptyEOL.ReplaceAllString(s, ``)
 }
 
-func formatResult(res sql.Result) string {
+func formatResultInfo(res sql.Result) string {
 	resInfo := ""
 	if rowsAffected, err := res.RowsAffected(); err == nil {
 		resInfo += fmt.Sprintf("rows affected: %d", rowsAffected)

--- a/provider_run.go
+++ b/provider_run.go
@@ -443,7 +443,7 @@ func (p *Provider) runSQL(ctx context.Context, db database.DBTxConn, m *Migratio
 	}
 	for _, stmt := range statements {
 		if p.cfg.verbose {
-			p.cfg.logger.Printf("Excuting statement: %s", stmt)
+			p.cfg.logger.Printf("Executing statement: %s", stmt)
 		}
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return err


### PR DESCRIPTION
Hi! Recently we have started using goose to run all SQL migrations in a company I work for, so first of all thank you for this great project. 

Our developers came to us with a **feature request - is it possible to log results of `UPDATE`/`DELETE` SQL queries?** We run migrations as a part of our CI process, so there are 50 devs looking at CI logs wanting to understand how data has changed immediately. There are cases when devs do not have any access to production databases, so they can't get this info anywhere except logs.

I have prepared a basic implementation which for now covers only CLI migration runs – I would be happy to implement it for the `Provider` type if you consider this feature useful. This was my first experience with go so please pay attention for any rookie mistakes I could make. I didn't test it against any DB except SQLite - thought I could trust [`sql.Result`](https://pkg.go.dev/database/sql#Result) interface.

(BTW #1, am I right that there are SQL-execution code duplication in [migration_sql.go](https://github.com/pressly/goose/blob/main/migration_sql.go#L18) and [provider_run.go](https://github.com/pressly/goose/blob/main/provider_run.go#L433)? A that `migration.go` could in theory be rewritten to use `Provider` object? Probably it's already planned, just trying to understand the project.)

(BTW #2 I have noticed a typo [here](https://github.com/pressly/goose/blob/c6cc2e2bc678baea64691eeb82e3eaa9b83cab07/provider_run.go#L446), may be reverted if you want to integrate it separately.)

Thanks in advance.