### PR TITLE
Allow Apply to respect no versioning option

### DIFF
--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -261,6 +261,7 @@ func TestProviderRun(t *testing.T) {
 		t.Run("no_versioning", func(t *testing.T) {
 			p, db := newProviderWithDB(t, goose.WithDisableVersioning(true))
 			_, err := p.ApplyVersion(ctx, 1, true)
+			require.NoError(t, err)
 			tables, err := getTableNames(db)
 			require.NoError(t, err)
 			// When versioning is disabled and a single migration is applied, the only table

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -258,6 +258,16 @@ func TestProviderRun(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, goose.ErrAlreadyApplied)
 		require.Contains(t, err.Error(), "version 1: migration already applied")
+		t.Run("no_versioning", func(t *testing.T) {
+			p, db := newProviderWithDB(t, goose.WithDisableVersioning(true))
+			_, err := p.ApplyVersion(ctx, 1, true)
+			tables, err := getTableNames(db)
+			require.NoError(t, err)
+			// When versioning is disabled and a single migration is applied, the only table
+			// expected is whatever the migration creates. No goose table is created.
+			knownTables := []string{"users"}
+			require.Equal(t, knownTables, tables)
+		})
 	})
 	t.Run("status", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
Fix #934

This PR updates the Provider implementation to respect the `no versioning` option when using `(*goose.Provider).Apply`. Effectively enabling users to run ad-hoc migration files without tracking their state.