### PR TITLE
Add `stamp`, `stamp-to` commands

### DIFF
--- a/goose.go
+++ b/goose.go
@@ -126,6 +126,22 @@ func run(ctx context.Context, command string, db *sql.DB, dir string, args []str
 		if err := ResetContext(ctx, db, dir, options...); err != nil {
 			return err
 		}
+	case "stamp":
+		if err := StampContext(ctx, db, dir, options...); err != nil {
+			return err
+		}
+	case "stamp-to":
+		if len(args) == 0 {
+			return fmt.Errorf("stamp-to must be of form: goose [OPTIONS] DRIVER DBSTRING stamp-to VERSION")
+		}
+
+		version, err := strconv.ParseInt(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("version must be a number (got '%s')", args[0])
+		}
+		if err := StampToContext(ctx, db, dir, version, options...); err != nil {
+			return err
+		}
 	case "status":
 		if err := StatusContext(ctx, db, dir, options...); err != nil {
 			return err

--- a/stamp.go
+++ b/stamp.go
@@ -1,0 +1,93 @@
+package goose
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// StampTo stamps the database to a specific version.
+func StampTo(db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
+	ctx := context.Background()
+	return StampToContext(ctx, db, dir, version, opts...)
+}
+
+func StampToContext(ctx context.Context, db *sql.DB, dir string, version int64, opts ...OptionsFunc) error {
+	option := &options{}
+	for _, f := range opts {
+		f(option)
+	}
+	foundMigrations, err := CollectMigrations(dir, minVersion, maxVersion)
+	if err != nil {
+		log.Printf("meh")
+		return err
+	}
+	// Ensure that the target migration version actually exists.
+	if _, err := foundMigrations.Current(version); err != nil && version != 0 {
+		return fmt.Errorf("migration %d not found", version)
+	}
+
+	if _, err := EnsureDBVersionContext(ctx, db); err != nil {
+		return err
+	}
+	dbMigrations, err := listAllDBVersions(ctx, db)
+	if err != nil {
+		return err
+	}
+	dbMaxVersion := dbMigrations[len(dbMigrations)-1].Version
+	lookupAppliedInDB := make(map[int64]bool)
+	for _, m := range dbMigrations {
+		lookupAppliedInDB[m.Version] = true
+	}
+
+	if version < dbMaxVersion {
+		// stamp "down"
+		for {
+			currentVersion, err := GetDBVersionContext(ctx, db)
+			if err != nil {
+				return err
+			}
+
+			if currentVersion == version {
+				log.Printf("goose: database stamped to version: %d", currentVersion)
+				return nil
+			}
+			_, err = foundMigrations.Current(currentVersion)
+			if err != nil && !option.allowMissing {
+				log.Printf("goose: migration file not found for current version (%d), error: %s", currentVersion, err)
+				return err
+			}
+
+			if err := store.DeleteVersionNoTx(ctx, db, TableName(), currentVersion); err != nil {
+				return fmt.Errorf("failed to delete goose version: %w", err)
+			}
+		}
+	} else if version > dbMaxVersion {
+		// stamp "up"
+		for _, m := range foundMigrations {
+			if lookupAppliedInDB[m.Version] {
+				continue
+			}
+			if m.Version > dbMaxVersion && m.Version <= version {
+				if err := store.InsertVersionNoTx(ctx, db, TableName(), m.Version); err != nil {
+					return fmt.Errorf("failed to insert goose version: %w", err)
+				}
+			}
+		}
+		log.Printf("goose: database stamped to version: %d", version)
+	} else {
+		log.Printf("goose: database already at version: %d", version)
+	}
+	return nil
+}
+
+// Stamp stamps the database to the latest available migration.
+func Stamp(db *sql.DB, dir string, opts ...OptionsFunc) error {
+	ctx := context.Background()
+	return StampContext(ctx, db, dir, opts...)
+}
+
+// StampContext stamps the database to the latest available migration.
+func StampContext(ctx context.Context, db *sql.DB, dir string, opts ...OptionsFunc) error {
+	return StampToContext(ctx, db, dir, maxVersion, opts...)
+}


### PR DESCRIPTION
These commands modify the version table without actually running any migrations. The command names are taken from [alembic][1], but other frameworks also support this under different names (repair, force, ...), see #938.

The `stamp` command simply sets the database version to that of the latest available migration, where as the `stamp-to` command allows to specify a version (including 0). Stamping can both increase and decrease the database version.

[1]: https://alembic.sqlalchemy.org/en/latest/api/commands.html#alembic.command.stamp

Fixes: #938