### PR TITLE
Add flag to increment by arbitrary integer

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -34,6 +34,7 @@ var (
 	versionFlag  = flags.Bool("version", false, "print version")
 	certfile     = flags.String("certfile", "", "file path to root CA's certificates in pem format (only support on mysql)")
 	sequential   = flags.Bool("s", false, "use sequential numbering for new migrations")
+	inc          = flags.Int("inc", 1, "The value to increment sequential migrations by")
 	allowMissing = flags.Bool("allow-missing", false, "applies missing (out-of-order) migrations")
 	sslcert      = flags.String("ssl-cert", "", "file path to SSL certificates in pem format (only support on mysql)")
 	sslkey       = flags.String("ssl-key", "", "file path to SSL key in pem format (only support on mysql)")
@@ -82,6 +83,10 @@ func main() {
 	}
 	if *sequential {
 		goose.SetSequential(true)
+	}
+
+	if inc != nil && *inc > 0 {
+		goose.SetSeqIncrement(int64(*inc))
 	}
 
 	// The order of precedence should be: flag > env variable > default value.

--- a/create.go
+++ b/create.go
@@ -16,8 +16,14 @@ type tmplVars struct {
 }
 
 var (
-	sequential = false
+	sequential       = false
+	seqInc     int64 = 1
 )
+
+// SetSeqIncrement set the value serial migrations are incremented by
+func SetSeqIncrement(i int64) {
+	seqInc = i
+}
 
 // SetSequential set whether to use sequential versioning instead of timestamp based versioning
 func SetSequential(s bool) {
@@ -41,9 +47,9 @@ func CreateWithTemplate(db *sql.DB, dir string, tmpl *template.Template, name, m
 		}
 
 		if last, err := vMigrations.Last(); err == nil {
-			version = fmt.Sprintf(seqVersionTemplate, last.Version+1)
+			version = fmt.Sprintf(seqVersionTemplate, last.Version+seqInc)
 		} else {
-			version = fmt.Sprintf(seqVersionTemplate, int64(1))
+			version = fmt.Sprintf(seqVersionTemplate, seqInc)
 		}
 	}
 

--- a/create_test.go
+++ b/create_test.go
@@ -15,38 +15,77 @@ func TestSequential(t *testing.T) {
 		t.Skip("skip long running test")
 	}
 
-	dir := t.TempDir()
-	defer os.Remove("./bin/create-goose") // clean up
+	t.Run("Create migrations with sequential keys", func(t *testing.T) {
+		dir := t.TempDir()
+		defer os.Remove("./bin/create-goose") // clean up
 
-	commands := []string{
-		"go build -o ./bin/create-goose ./cmd/goose",
-		fmt.Sprintf("./bin/create-goose -s -dir=%s create create_table", dir),
-		fmt.Sprintf("./bin/create-goose -s -dir=%s create add_users", dir),
-		fmt.Sprintf("./bin/create-goose -s -dir=%s create add_indices", dir),
-		fmt.Sprintf("./bin/create-goose -s -dir=%s create update_users", dir),
-	}
+		commands := []string{
+			"go build -o ./bin/create-goose ./cmd/goose",
+			fmt.Sprintf("./bin/create-goose -s -dir=%s create create_table", dir),
+			fmt.Sprintf("./bin/create-goose -s -dir=%s create add_users", dir),
+			fmt.Sprintf("./bin/create-goose -s -dir=%s create add_indices", dir),
+			fmt.Sprintf("./bin/create-goose -s -dir=%s create update_users", dir),
+		}
 
-	for _, cmd := range commands {
-		args := strings.Split(cmd, " ")
-		time.Sleep(1 * time.Second)
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Env = os.Environ()
-		out, err := cmd.CombinedOutput()
+		for _, cmd := range commands {
+			args := strings.Split(cmd, " ")
+			time.Sleep(1 * time.Second)
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Env = os.Environ()
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s:\n%v\n\n%s", err, cmd, out)
+			}
+		}
+
+		files, err := os.ReadDir(dir)
 		if err != nil {
-			t.Fatalf("%s:\n%v\n\n%s", err, cmd, out)
+			t.Fatal(err)
 		}
-	}
 
-	files, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// check that the files are in order
-	for i, f := range files {
-		expected := fmt.Sprintf("%05v", i+1)
-		if !strings.HasPrefix(f.Name(), expected) {
-			t.Errorf("failed to find %s prefix in %s", expected, f.Name())
+		// check that the files are in order
+		for i, f := range files {
+			expected := fmt.Sprintf("%05v", i+1)
+			if !strings.HasPrefix(f.Name(), expected) {
+				t.Errorf("failed to find %s prefix in %s", expected, f.Name())
+			}
 		}
-	}
+	})
+
+	t.Run("Increment by 10", func(t *testing.T) {
+		inc := 10
+		dir := t.TempDir()
+		defer os.Remove("./bin/create-goose") // clean up
+		commands := []string{
+			"go build -o ./bin/create-goose ./cmd/goose",
+			fmt.Sprintf("./bin/create-goose -s -inc %d -dir=%s create create_table", inc, dir),
+			fmt.Sprintf("./bin/create-goose -s -inc %d -dir=%s create add_users", inc, dir),
+			fmt.Sprintf("./bin/create-goose -s -inc %d -dir=%s create add_indices", inc, dir),
+			fmt.Sprintf("./bin/create-goose -s -inc %d -dir=%s create update_users", inc, dir),
+		}
+
+		for _, cmd := range commands {
+			args := strings.Split(cmd, " ")
+			time.Sleep(1 * time.Second)
+			cmd := exec.Command(args[0], args[1:]...)
+			cmd.Env = os.Environ()
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("%s:\n%v\n\n%s", err, cmd, out)
+			}
+		}
+
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// check that the files are in order
+		for i, f := range files {
+			expected := fmt.Sprintf("%05v", i+inc)
+			if !strings.HasPrefix(f.Name(), expected) {
+				t.Errorf("failed to find %s prefix in %s", expected, f.Name())
+			}
+		}
+	})
 }


### PR DESCRIPTION
Allow users to increment sequential migrations by an arbitrary integer. This allows them to add migrations like network rules to add new migrations between existing ones