### PR TITLE
Clarify .go migrations bot being included along with .sql migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,8 @@ structure.
 1. Create your own goose binary, see [example](./examples/go-migrations)
 2. Import `github.com/pressly/goose`
 3. Register your migration functions
-4. Run goose command, ie. `goose.Up(db *sql.DB, dir string)`
+4. Include your `migrations` package into Go build: in `main.go`, `import _ "github.com/me/myapp/migrations"`
+5. Run goose command, ie. `goose.Up(db *sql.DB, dir string)`
 
 A [sample Go migration 00002_users_add_email.go file](./examples/go-migrations/00002_rename_root.go)
 looks like:


### PR DESCRIPTION
.go migrations are not included into embedded dir along with .sql migrations,
for .go migrations Goose instead relies on SQL driver-style registration via `import _` and `init()`.

This is easy to miss.