### PR TITLE
Add DDL isolation support for Aurora DSQL compatibility

### DIFF
--- a/provider_options.go
+++ b/provider_options.go
@@ -173,6 +173,15 @@ func WithLogger(l Logger) ProviderOption {
 	})
 }
 
+// WithIsolateDDL executes DDL operations separately from DML operations. This is useful for
+// databases like AWS Aurora DSQL that don't support mixing DDL and DML within the same transaction.
+func WithIsolateDDL(b bool) ProviderOption {
+	return configFunc(func(c *config) error {
+		c.isolateDDL = b
+		return nil
+	})
+}
+
 type config struct {
 	store database.Store
 
@@ -192,6 +201,7 @@ type config struct {
 	disableVersioning     bool
 	allowMissing          bool
 	disableGlobalRegistry bool
+	isolateDDL            bool
 
 	logger Logger
 }

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -360,6 +360,17 @@ INSERT INTO owners (owner_name) VALUES ('seed-user-3');
 		assertStatus(t, status[1], goose.StatePending, newSource(goose.TypeSQL, "00002_partial_error.sql", 2), true)
 		assertStatus(t, status[2], goose.StatePending, newSource(goose.TypeSQL, "00003_insert_data.sql", 3), true)
 	})
+	t.Run("isolate_ddl", func(t *testing.T) {
+		ctx := context.Background()
+		p, _ := newProviderWithDB(t, goose.WithIsolateDDL(true))
+		// Apply all migrations
+		res, err := p.Up(ctx)
+		require.NoError(t, err)
+		require.Len(t, res, 7)
+		currentVersion, err := p.GetDBVersion(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 7, currentVersion)
+	})
 }
 
 func TestConcurrentProvider(t *testing.T) {


### PR DESCRIPTION
This PR adds `WithIsolateDDL()` option to execute DDL operations in separate transactions from DML operations. Required for databases like AWS Aurora DSQL that don't support mixing DDL and DML in the same transaction.

Note, this option is likely useful beyond just DSQL.

Related to #962