### PR TITLE
Add Aurora DSQL as a new database dialect

### DIFF
--- a/database/dialects.go
+++ b/database/dialects.go
@@ -16,6 +16,7 @@ type Dialect string
 const (
 	DialectCustom     Dialect = ""
 	DialectClickHouse Dialect = "clickhouse"
+	DialectAuroraDSQL Dialect = "dsql"
 	DialectMSSQL      Dialect = "mssql"
 	DialectMySQL      Dialect = "mysql"
 	DialectPostgres   Dialect = "postgres"
@@ -35,6 +36,7 @@ func NewStore(d Dialect, tableName string) (Store, error) {
 	}
 	lookup := map[Dialect]dialect.Querier{
 		DialectClickHouse: dialects.NewClickhouse(),
+		DialectAuroraDSQL: dialects.NewAuroraDSQL(),
 		DialectMSSQL:      dialects.NewSqlserver(),
 		DialectMySQL:      dialects.NewMysql(),
 		DialectPostgres:   dialects.NewPostgres(),

--- a/dialect.go
+++ b/dialect.go
@@ -23,6 +23,9 @@ const (
 	DialectTurso      Dialect = database.DialectTurso
 	DialectVertica    Dialect = database.DialectVertica
 	DialectYdB        Dialect = database.DialectYdB
+
+	// Dialects only available to the [Provider].
+	DialectAuroraDSQL Dialect = database.DialectAuroraDSQL
 )
 
 func init() {

--- a/internal/dialects/dsql.go
+++ b/internal/dialects/dsql.go
@@ -1,0 +1,66 @@
+package dialects
+
+import (
+	"fmt"
+
+	"github.com/pressly/goose/v3/database/dialect"
+)
+
+// NewAuroraDSQL returns a new [dialect.Querier] for Aurora DSQL dialect.
+func NewAuroraDSQL() dialect.QuerierExtender {
+	return &dsql{}
+}
+
+type dsql struct{}
+
+var _ dialect.QuerierExtender = (*dsql)(nil)
+
+func (d *dsql) CreateTable(tableName string) string {
+	q := `CREATE TABLE %s (
+		id integer PRIMARY KEY,
+		version_id bigint NOT NULL,
+		is_applied boolean NOT NULL,
+		tstamp timestamp NOT NULL DEFAULT now()
+	)`
+	return fmt.Sprintf(q, tableName)
+}
+
+func (d *dsql) InsertVersion(tableName string) string {
+	q := `INSERT INTO %s (id, version_id, is_applied) 
+	      VALUES (
+	          COALESCE((SELECT MAX(id) FROM %s), 0) + 1,
+	          $1, 
+	          $2
+	      )`
+	return fmt.Sprintf(q, tableName, tableName)
+}
+
+func (d *dsql) DeleteVersion(tableName string) string {
+	q := `DELETE FROM %s WHERE version_id=$1`
+	return fmt.Sprintf(q, tableName)
+}
+
+func (d *dsql) GetMigrationByVersion(tableName string) string {
+	q := `SELECT tstamp, is_applied FROM %s WHERE version_id=$1 ORDER BY tstamp DESC LIMIT 1`
+	return fmt.Sprintf(q, tableName)
+}
+
+func (d *dsql) ListMigrations(tableName string) string {
+	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
+	return fmt.Sprintf(q, tableName)
+}
+
+func (d *dsql) GetLatestVersion(tableName string) string {
+	q := `SELECT max(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}
+
+func (d *dsql) TableExists(tableName string) string {
+	schemaName, tableName := parseTableIdentifier(tableName)
+	if schemaName != "" {
+		q := `SELECT EXISTS ( SELECT 1 FROM pg_tables WHERE schemaname = '%s' AND tablename = '%s' )`
+		return fmt.Sprintf(q, schemaName, tableName)
+	}
+	q := `SELECT EXISTS ( SELECT 1 FROM pg_tables WHERE (current_schema() IS NULL OR schemaname = current_schema()) AND tablename = '%s' )`
+	return fmt.Sprintf(q, tableName)
+}


### PR DESCRIPTION
This PR adds Aurora DSQL as a new database dialect. We can't use the existing Postgres schema because DSQL doesn't support auto-incrementing IDs.

Also, the updated `InsertVersion` SQL is prone to race conditions. Callers will need to guard this, or ensure migrations are applied as a singleton prior to application startup. The postgres lock will not work because DSQL doesn't support advisory locks. Long term, goose needs to support another form of locking via a dedicated lock table.

> ERROR: function pg_try_advisory_lock not supported (SQLSTATE 0A000)

Related to #962