### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,8 @@ builds:
       - "-s -w -X main.version=v{{ .Version }}"
 
 archives:
-  - format: binary
+  - formats:
+      - binary
     name_template: >-
       {{ .ProjectName }}_{{- tolower .Os }}_{{- if eq .Arch "amd64" }}x86_64{{- else }}{{ .Arch }}{{ end }}
 checksum:


### PR DESCRIPTION
# Description
This small PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/pressly/goose/actions/runs/17528135386/job/49781367739#step:8:16): 
```
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```