### PR TITLE
Speed up status command and sort output

### DIFF
--- a/database/dialect/querier.go
+++ b/database/dialect/querier.go
@@ -17,7 +17,7 @@ type Querier interface {
 	GetMigrationByVersion(tableName string) string
 	// ListMigrations returns the SQL query string to list all migrations in descending order by id.
 	//
-	// The query should return the version_id and is_applied columns.
+	// The query should return the timestamp, version_id, and is_applied columns.
 	ListMigrations(tableName string) string
 	// GetLatestVersion returns the SQL query string to get the last version_id from the db version
 	// table. Returns a nullable int64 value.

--- a/database/dialects.go
+++ b/database/dialects.go
@@ -157,7 +157,7 @@ func (s *store) ListMigrations(
 	var migrations []*ListMigrationsResult
 	for rows.Next() {
 		var result ListMigrationsResult
-		if err := rows.Scan(&result.Version, &result.IsApplied); err != nil {
+		if err := rows.Scan(&result.Timestamp, &result.Version, &result.IsApplied); err != nil {
 			return nil, fmt.Errorf("failed to scan list migrations result: %w", err)
 		}
 		migrations = append(migrations, &result)

--- a/database/store.go
+++ b/database/store.go
@@ -61,6 +61,7 @@ type GetMigrationResult struct {
 }
 
 type ListMigrationsResult struct {
+	Timestamp time.Time
 	Version   int64
 	IsApplied bool
 }

--- a/internal/dialects/clickhouse.go
+++ b/internal/dialects/clickhouse.go
@@ -43,7 +43,7 @@ func (c *clickhouse) GetMigrationByVersion(tableName string) string {
 }
 
 func (c *clickhouse) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied FROM %s ORDER BY version_id DESC`
+	q := `SELECT tstamp, version_id, is_applied FROM %s ORDER BY version_id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/dsql.go
+++ b/internal/dialects/dsql.go
@@ -46,7 +46,7 @@ func (d *dsql) GetMigrationByVersion(tableName string) string {
 }
 
 func (d *dsql) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
+	q := `SELECT tstamp, version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/mysql.go
+++ b/internal/dialects/mysql.go
@@ -42,7 +42,7 @@ func (m *mysql) GetMigrationByVersion(tableName string) string {
 }
 
 func (m *mysql) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
+	q := `SELECT tstamp, version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/postgres.go
+++ b/internal/dialects/postgres.go
@@ -42,7 +42,7 @@ func (p *postgres) GetMigrationByVersion(tableName string) string {
 }
 
 func (p *postgres) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
+	q := `SELECT tstamp, version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/redshift.go
+++ b/internal/dialects/redshift.go
@@ -42,7 +42,7 @@ func (r *redshift) GetMigrationByVersion(tableName string) string {
 }
 
 func (r *redshift) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
+	q := `SELECT tstamp, version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/spanner.go
+++ b/internal/dialects/spanner.go
@@ -40,7 +40,7 @@ func (s *spanner) GetMigrationByVersion(tableName string) string {
 }
 
 func (s *spanner) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied from %s ORDER BY version_id DESC`
+	q := `SELECT tstamp, version_id, is_applied from %s ORDER BY version_id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/sqlite3.go
+++ b/internal/dialects/sqlite3.go
@@ -41,7 +41,7 @@ func (s *sqlite3) GetMigrationByVersion(tableName string) string {
 }
 
 func (s *sqlite3) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
+	q := `SELECT tstamp, version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/sqlserver.go
+++ b/internal/dialects/sqlserver.go
@@ -41,7 +41,7 @@ func (s *sqlserver) GetMigrationByVersion(tableName string) string {
 }
 
 func (s *sqlserver) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied FROM %s ORDER BY id DESC`
+	q := `SELECT tstamp, version_id, is_applied FROM %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/starrocks.go
+++ b/internal/dialects/starrocks.go
@@ -44,7 +44,7 @@ func (m *starrocks) GetMigrationByVersion(tableName string) string {
 }
 
 func (m *starrocks) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
+	q := `SELECT tstamp, version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/tidb.go
+++ b/internal/dialects/tidb.go
@@ -42,7 +42,7 @@ func (t *Tidb) GetMigrationByVersion(tableName string) string {
 }
 
 func (t *Tidb) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
+	q := `SELECT tstamp, version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/vertica.go
+++ b/internal/dialects/vertica.go
@@ -44,7 +44,7 @@ func (v *vertica) GetMigrationByVersion(tableName string) string {
 }
 
 func (v *vertica) ListMigrations(tableName string) string {
-	q := `SELECT version_id, is_applied from %s ORDER BY id DESC`
+	q := `SELECT tstamp, version_id, is_applied from %s ORDER BY id DESC`
 	return fmt.Sprintf(q, tableName)
 }
 

--- a/internal/dialects/ydb.go
+++ b/internal/dialects/ydb.go
@@ -58,11 +58,10 @@ func (c *ydb) GetMigrationByVersion(tableName string) string {
 }
 
 func (c *ydb) ListMigrations(tableName string) string {
-	formatedYDBTableName := formatYDBTableName(tableName)
 	q := `
-	SELECT version_id, is_applied, tstamp AS __discard_column_tstamp 
-	FROM %s ORDER BY __discard_column_tstamp DESC`
-	return fmt.Sprintf(q, formatedYDBTableName)
+	SELECT tstamp, version_id, is_applied
+	FROM %s ORDER BY tstamp DESC`
+	return fmt.Sprintf(q, tableName)
 }
 
 func (c *ydb) GetLatestVersion(tableName string) string {

--- a/internal/legacystore/legacystore.go
+++ b/internal/legacystore/legacystore.go
@@ -87,6 +87,7 @@ type GetMigrationResult struct {
 }
 
 type ListMigrationsResult struct {
+	Timestamp time.Time
 	VersionID int64
 	IsApplied bool
 }
@@ -156,12 +157,14 @@ func (s *store) ListMigrations(ctx context.Context, db *sql.DB, tableName string
 
 	var migrations []*ListMigrationsResult
 	for rows.Next() {
+		var timestamp time.Time
 		var version int64
 		var isApplied bool
-		if err := rows.Scan(&version, &isApplied); err != nil {
+		if err := rows.Scan(&timestamp, &version, &isApplied); err != nil {
 			return nil, err
 		}
 		migrations = append(migrations, &ListMigrationsResult{
+			Timestamp: timestamp,
 			VersionID: version,
 			IsApplied: isApplied,
 		})

--- a/status.go
+++ b/status.go
@@ -5,8 +5,40 @@ import (
 	"database/sql"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"time"
+
+	"github.com/pressly/goose/v3/internal/legacystore"
 )
+
+type statusLine struct {
+	Version   int64
+	AppliedAt time.Time
+	Pending   bool
+	Source    string
+}
+
+type statusLines []*statusLine
+
+// helpers so we can use pkg sort
+func (s statusLines) Len() int      { return len(s) }
+func (s statusLines) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s statusLines) Less(i, j int) bool {
+	lineI := s[i]
+	lineJ := s[j]
+	// Pending migrations always come later:
+	if lineI.Pending != lineJ.Pending {
+		// lineJ is pending ---> lineI goes first and return value true means lineI < lineJ
+		return lineJ.Pending
+	}
+	if !lineI.AppliedAt.Equal(lineJ.AppliedAt) {
+		return lineI.AppliedAt.Before(lineJ.AppliedAt)
+	}
+	if lineI.Version != lineJ.Version {
+		return lineI.Version < lineJ.Version
+	}
+	return lineI.Source < lineJ.Source
+}
 
 // Status prints the status of all migrations.
 func Status(db *sql.DB, dir string, opts ...OptionsFunc) error {
@@ -20,14 +52,14 @@ func StatusContext(ctx context.Context, db *sql.DB, dir string, opts ...OptionsF
 	for _, f := range opts {
 		f(option)
 	}
-	migrations, err := CollectMigrations(dir, minVersion, maxVersion)
+	fsMigrations, err := CollectMigrations(dir, minVersion, maxVersion)
 	if err != nil {
 		return fmt.Errorf("failed to collect migrations: %w", err)
 	}
 	if option.noVersioning {
 		log.Printf("    Applied At                  Migration")
 		log.Printf("    =======================================")
-		for _, current := range migrations {
+		for _, current := range fsMigrations {
 			log.Printf("    %-24s -- %v", "no versioning", filepath.Base(current.Source))
 		}
 		return nil
@@ -44,29 +76,37 @@ func StatusContext(ctx context.Context, db *sql.DB, dir string, opts ...OptionsF
 		return fmt.Errorf("failed to list migrations: %w", err)
 	}
 
-	// Build a map of version_id to migration result for quick lookup
-	dbMigrationMap := make(map[int64]*struct {
-		Timestamp time.Time
-		IsApplied bool
-	})
+	// Build a map on version_id to match migrations in DB to migrations from FS.
+	dbMigrationMap := make(map[int64]*legacystore.ListMigrationsResult)
 	for _, m := range dbMigrations {
-		dbMigrationMap[m.VersionID] = &struct {
-			Timestamp time.Time
-			IsApplied bool
-		}{
-			Timestamp: m.Timestamp,
-			IsApplied: m.IsApplied,
-		}
+		dbMigrationMap[m.VersionID] = m
 	}
+
+	// Gather 1 status line for each migration in the FS, enriched with application timestamp from DB if applied:
+	var statusOutput statusLines
+	for _, fsM := range fsMigrations {
+		line := statusLine{
+			Version:   fsM.Version,
+			AppliedAt: time.Time{},
+			Pending:   true,
+			Source:    filepath.Base(fsM.Source),
+		}
+		if dbM, exists := dbMigrationMap[fsM.Version]; exists && dbM.IsApplied {
+			line.Pending = false
+			line.AppliedAt = dbM.Timestamp
+		}
+		statusOutput = append(statusOutput, &line)
+	}
+	sort.Sort(statusOutput)
 
 	log.Printf("    Applied At                  Migration")
 	log.Printf("    =======================================")
-	for _, migration := range migrations {
+	for _, migration := range statusOutput {
 		appliedAt := "Pending"
-		if m, exists := dbMigrationMap[migration.Version]; exists && m.IsApplied {
-			appliedAt = m.Timestamp.Format(time.ANSIC)
+		if !migration.Pending {
+			appliedAt = migration.AppliedAt.Format(time.ANSIC)
 		}
-		log.Printf("    %-24s -- %v", appliedAt, filepath.Base(migration.Source))
+		log.Printf("    %-24s -- %v", appliedAt, migration.Source)
 	}
 
 	return nil

--- a/status.go
+++ b/status.go
@@ -112,15 +112,3 @@ func lessByVersionOrSource(si, sj *statusLine) bool {
 	}
 	return si.Source < sj.Source
 }
-
-func lessByAppliedAt(si, sj *statusLine) bool {
-	// Pending migrations always come later:
-	if si.Pending != sj.Pending {
-		// lineJ is pending ---> lineI goes first and return value true means lineI < lineJ
-		return sj.Pending
-	}
-	if !si.AppliedAt.Equal(sj.AppliedAt) {
-		return si.AppliedAt.Before(sj.AppliedAt)
-	}
-	return lessByVersionOrSource(si, sj)
-}


### PR DESCRIPTION
Fixes #282 
* [Commit 1](https://github.com/pressly/goose/commit/205fa9fc81be28a5414006b0ebca31d29a455fcd) retrieves migration application timestamps in `ListMigrations()`, which requires updating every db-specific querier;

* [Commit 2](https://github.com/pressly/goose/commit/288f715cffc493ad2022c4e11f88cb4c7f2a7d2c) uses the updated `ListMigrations()` to retrieve status of all migrations in a single db query;

* [Commit 3](https://github.com/pressly/goose/commit/7b2b3913f9e3a5b6db6a532baffd8842abed61fb) sorts the output of `goose status` so

    * applied migrations are sorted by the timestamp of their application
    * pending migrations are sorted to the end
        * per [an earlier comment](https://github.com/pressly/goose/pull/280#issuecomment-945006038) about out-of-order migration application.