### PR TITLE
Added formatting for YDB table names include folder

### DIFF
--- a/internal/dialects/ydb.go
+++ b/internal/dialects/ydb.go
@@ -16,7 +16,7 @@ type ydb struct{}
 var _ dialect.Querier = (*ydb)(nil)
 
 func formatYDBTableName(tableName string) string {
-	return "`" + tableName + "`"
+	return fmt.Sprintf("`%s`", tableName)
 }
 
 func (c *ydb) CreateTable(tableName string) string {


### PR DESCRIPTION
For YDB, the operation of the -table argument has been fixed when specifying tables with a nesting level (folders), for example: `-table service-123/goose_db_version`

<img width="505" height="204" alt="2025-11-23 в 16 23 51" src="https://github.com/user-attachments/assets/412cfd82-8445-468b-b2a2-8790649fd008" />
