### PR TITLE
Install released binaries in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,11 @@ jobs:
             exit 1
           fi
       - name: Install tparse
-        run: go install github.com/mfridman/tparse@main
+        run: |
+          mkdir -p $HOME/.local/bin
+          curl -L -o $HOME/.local/bin/tparse https://github.com/mfridman/tparse/releases/latest/download/tparse_linux_x86_64
+          chmod +x $HOME/.local/bin/tparse
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Run tests
         run: |
           make add-gowork

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -25,7 +25,11 @@ jobs:
         with:
           go-version: "stable"
       - name: Install tparse
-        run: go install github.com/mfridman/tparse@main
+        run: |
+          mkdir -p $HOME/.local/bin
+          curl -L -o $HOME/.local/bin/tparse https://github.com/mfridman/tparse/releases/latest/download/tparse_linux_x86_64
+          chmod +x $HOME/.local/bin/tparse
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Run full integration tests
         run: |
           make test-integration


### PR DESCRIPTION
Let's avoid `go install ...` and just rely on the pre-built binaries.