### PR TITLE
Add SQL Server locking support (table-based and session-based)

### DIFF
--- a/internal/testing/integration/locking/sqlserver_locking_test.go
+++ b/internal/testing/integration/locking/sqlserver_locking_test.go
@@ -1,0 +1,419 @@
+package locking_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"math/rand/v2"
+	"os"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pressly/goose/v3"
+	"github.com/pressly/goose/v3/internal/testing/testdb"
+	"github.com/pressly/goose/v3/lock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestSqlserverSessionLocker(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	db, cleanup, err := testdb.NewSqlserver()
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	// Do not run subtests in parallel, because they are using the same database.
+
+	t.Run("lock_and_unlock", func(t *testing.T) {
+		const (
+			lockID int64 = 123456789
+		)
+		locker, err := lock.NewSqlserverSessionLocker(
+			lock.WithLockID(lockID),
+			lock.WithLockTimeout(1, 4),   // 4 second timeout
+			lock.WithUnlockTimeout(1, 4), // 4 second timeout
+		)
+		require.NoError(t, err)
+		ctx := context.Background()
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, conn.Close())
+		})
+		err = locker.SessionLock(ctx, conn)
+		require.NoError(t, err)
+		// Check that the lock was acquired using SQL Server's sys.dm_tran_locks
+		exists, err := existsSqlserverAppLock(ctx, db, lockID)
+		require.NoError(t, err)
+		require.True(t, exists)
+		// Check that the lock is released.
+		err = locker.SessionUnlock(ctx, conn)
+		require.NoError(t, err)
+		exists, err = existsSqlserverAppLock(ctx, db, lockID)
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+	t.Run("lock_close_conn_unlock", func(t *testing.T) {
+		locker, err := lock.NewSqlserverSessionLocker(
+			lock.WithLockTimeout(1, 4),   // 4 second timeout
+			lock.WithUnlockTimeout(1, 4), // 4 second timeout
+		)
+		require.NoError(t, err)
+		ctx := context.Background()
+		conn, err := db.Conn(ctx)
+		require.NoError(t, err)
+
+		err = locker.SessionLock(ctx, conn)
+		require.NoError(t, err)
+		exists, err := existsSqlserverAppLock(ctx, db, lock.DefaultLockID)
+		require.NoError(t, err)
+		require.True(t, exists)
+		// Simulate a connection close.
+		err = conn.Close()
+		require.NoError(t, err)
+		// Check an error is returned when unlocking, because the connection is already closed.
+		err = locker.SessionUnlock(ctx, conn)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, sql.ErrConnDone))
+	})
+	t.Run("multiple_connections", func(t *testing.T) {
+		const (
+			workers = 5
+		)
+		ch := make(chan error)
+		var wg sync.WaitGroup
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+				ctx := context.Background()
+				conn, err := db.Conn(ctx)
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					require.NoError(t, conn.Close())
+				})
+				// Exactly one connection should acquire the lock. While the other connections
+				// should fail to acquire the lock and timeout.
+				locker, err := lock.NewSqlserverSessionLocker(
+					lock.WithLockTimeout(1, 4),   // 4 second timeout
+					lock.WithUnlockTimeout(1, 4), // 4 second timeout
+				)
+				require.NoError(t, err)
+				// NOTE, we are not unlocking the lock, because we want to test that the lock is
+				// released when the connection is closed.
+				ch <- locker.SessionLock(ctx, conn)
+			}()
+		}
+		go func() {
+			wg.Wait()
+			close(ch)
+		}()
+		var errors []error
+		for err := range ch {
+			if err != nil {
+				errors = append(errors, err)
+			}
+		}
+		require.Equal(t, len(errors), workers-1) // One worker succeeds, the rest fail.
+		for _, err := range errors {
+			require.Error(t, err)
+			require.Equal(t, err.Error(), "failed to acquire lock")
+		}
+		exists, err := existsSqlserverAppLock(context.Background(), db, lock.DefaultLockID)
+		require.NoError(t, err)
+		require.True(t, exists)
+	})
+	t.Run("unlock_with_different_connection_error", func(t *testing.T) {
+		randomLockID := rand.Int64()
+		ctx := context.Background()
+		locker, err := lock.NewSqlserverSessionLocker(
+			lock.WithLockID(randomLockID),
+			lock.WithLockTimeout(1, 4),   // 4 second timeout
+			lock.WithUnlockTimeout(1, 4), // 4 second timeout
+		)
+		require.NoError(t, err)
+
+		conn1, err := db.Conn(ctx)
+		require.NoError(t, err)
+		err = locker.SessionLock(ctx, conn1)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			// Defer the unlock with the same connection.
+			err = locker.SessionUnlock(ctx, conn1)
+			require.NoError(t, err)
+			require.NoError(t, conn1.Close())
+		})
+		exists, err := existsSqlserverAppLock(ctx, db, randomLockID)
+		require.NoError(t, err)
+		require.True(t, exists)
+		// Unlock with a different connection.
+		conn2, err := db.Conn(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, conn2.Close())
+		})
+		// Check an error is returned when unlocking with a different connection.
+		err = locker.SessionUnlock(ctx, conn2)
+		require.Error(t, err)
+	})
+}
+
+func TestSqlserverProviderLocking(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	// The migrations are written in such a way they cannot be applied in parallel, they will fail
+	// 99.9999% of the time. This test ensures that the advisory session lock mode works as
+	// expected.
+
+	db, cleanup, err := testdb.NewSqlserver()
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	newProvider := func() *goose.Provider {
+
+		sessionLocker, err := lock.NewSqlserverSessionLocker(
+			lock.WithLockTimeout(5, 60), // Timeout 5min. Try every 5s up to 60 times.
+		)
+		require.NoError(t, err)
+		p, err := goose.NewProvider(
+			goose.DialectMSSQL,
+			db,
+			os.DirFS("../testdata/migrations/sqlserver"),
+			goose.WithSessionLocker(sessionLocker), // Use advisory session lock mode.
+		)
+		require.NoError(t, err)
+
+		return p
+	}
+
+	provider1 := newProvider()
+	provider2 := newProvider()
+
+	sources := provider1.ListSources()
+	maxVersion := sources[len(sources)-1].Version
+
+	// Since the lock mode is advisory session, only one of these providers is expected to apply ALL
+	// the migrations. The other provider should apply NO migrations. The test MUST fail if both
+	// providers apply migrations.
+
+	t.Run("up", func(t *testing.T) {
+		var g errgroup.Group
+		var res1, res2 int
+		g.Go(func() error {
+			ctx := context.Background()
+			results, err := provider1.Up(ctx)
+			require.NoError(t, err)
+			res1 = len(results)
+			currentVersion, err := provider1.GetDBVersion(ctx)
+			require.NoError(t, err)
+			require.Equal(t, currentVersion, maxVersion)
+			return nil
+		})
+		g.Go(func() error {
+			ctx := context.Background()
+			results, err := provider2.Up(ctx)
+			require.NoError(t, err)
+			res2 = len(results)
+			currentVersion, err := provider2.GetDBVersion(ctx)
+			require.NoError(t, err)
+			require.Equal(t, currentVersion, maxVersion)
+			return nil
+		})
+		require.NoError(t, g.Wait())
+		// One of the providers should have applied all migrations and the other should have applied
+		// no migrations, but with no error.
+		if res1 == 0 && res2 == 0 {
+			t.Fatal("both providers applied no migrations")
+		}
+		if res1 > 0 && res2 > 0 {
+			t.Fatal("both providers applied migrations")
+		}
+	})
+
+	// Reset the database and run the same test with the advisory lock mode, but apply migrations
+	// one-by-one.
+	{
+		_, err := provider1.DownTo(context.Background(), 0)
+		require.NoError(t, err)
+		currentVersion, err := provider1.GetDBVersion(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, currentVersion, int64(0))
+	}
+	t.Run("up_by_one", func(t *testing.T) {
+		var g errgroup.Group
+		var (
+			mu      sync.Mutex
+			applied []int64
+		)
+		g.Go(func() error {
+			for {
+				result, err := provider1.UpByOne(context.Background())
+				if err != nil {
+					if errors.Is(err, goose.ErrNoNextVersion) {
+						return nil
+					}
+					return err
+				}
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				mu.Lock()
+				applied = append(applied, result.Source.Version)
+				mu.Unlock()
+			}
+		})
+		g.Go(func() error {
+			for {
+				result, err := provider2.UpByOne(context.Background())
+				if err != nil {
+					if errors.Is(err, goose.ErrNoNextVersion) {
+						return nil
+					}
+					return err
+				}
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				mu.Lock()
+				applied = append(applied, result.Source.Version)
+				mu.Unlock()
+			}
+		})
+		require.NoError(t, g.Wait())
+		require.Equal(t, len(applied), len(sources))
+		sort.Slice(applied, func(i, j int) bool {
+			return applied[i] < applied[j]
+		})
+		// Each migration should have been applied up exactly once.
+		for i := 0; i < len(sources); i++ {
+			require.Equal(t, applied[i], sources[i].Version)
+		}
+	})
+
+	// Restore the database state by applying all migrations and run the same test with the advisory
+	// lock mode, but apply down migrations in parallel.
+	{
+		_, err := provider1.Up(context.Background())
+		require.NoError(t, err)
+		currentVersion, err := provider1.GetDBVersion(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, currentVersion, maxVersion)
+	}
+
+	t.Run("down_to", func(t *testing.T) {
+		var g errgroup.Group
+		var res1, res2 int
+		g.Go(func() error {
+			ctx := context.Background()
+			results, err := provider1.DownTo(ctx, 0)
+			require.NoError(t, err)
+			res1 = len(results)
+			currentVersion, err := provider1.GetDBVersion(ctx)
+			require.NoError(t, err)
+			require.Equal(t, int64(0), currentVersion)
+			return nil
+		})
+		g.Go(func() error {
+			ctx := context.Background()
+			results, err := provider2.DownTo(ctx, 0)
+			require.NoError(t, err)
+			res2 = len(results)
+			currentVersion, err := provider2.GetDBVersion(ctx)
+			require.NoError(t, err)
+			require.Equal(t, int64(0), currentVersion)
+			return nil
+		})
+		require.NoError(t, g.Wait())
+
+		if res1 == 0 && res2 == 0 {
+			t.Fatal("both providers applied no migrations")
+		}
+		if res1 > 0 && res2 > 0 {
+			t.Fatal("both providers applied migrations")
+		}
+	})
+
+	// Restore the database state by applying all migrations and run the same test with the advisory
+	// lock mode, but apply down migrations one-by-one.
+	{
+		_, err := provider1.Up(context.Background())
+		require.NoError(t, err)
+		currentVersion, err := provider1.GetDBVersion(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, currentVersion, maxVersion)
+	}
+
+	t.Run("down_by_one", func(t *testing.T) {
+		var g errgroup.Group
+		var (
+			mu      sync.Mutex
+			applied []int64
+		)
+		g.Go(func() error {
+			for {
+				result, err := provider1.Down(context.Background())
+				if err != nil {
+					if errors.Is(err, goose.ErrNoNextVersion) {
+						return nil
+					}
+					return err
+				}
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				mu.Lock()
+				applied = append(applied, result.Source.Version)
+				mu.Unlock()
+			}
+		})
+		g.Go(func() error {
+			for {
+				result, err := provider2.Down(context.Background())
+				if err != nil {
+					if errors.Is(err, goose.ErrNoNextVersion) {
+						return nil
+					}
+					return err
+				}
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				mu.Lock()
+				applied = append(applied, result.Source.Version)
+				mu.Unlock()
+			}
+		})
+		require.NoError(t, g.Wait())
+		require.Equal(t, len(applied), len(sources))
+		sort.Slice(applied, func(i, j int) bool {
+			return applied[i] < applied[j]
+		})
+		// Each migration should have been applied down exactly once. Since this is sequential the
+		// applied down migrations should be in reverse order.
+		for i := len(sources) - 1; i >= 0; i-- {
+			require.Equal(t, applied[i], sources[i].Version)
+		}
+	})
+}
+
+func existsSqlserverAppLock(ctx context.Context, db *sql.DB, lockID int64) (bool, error) {
+	// Check for application locks using sys.dm_tran_locks
+	// The lock resource is named 'goose_lock_<lockID>'
+	lockName := "goose_lock_%" // We use LIKE to match our lock pattern
+	q := `SELECT CASE WHEN EXISTS(
+		SELECT 1 FROM sys.dm_tran_locks
+		WHERE resource_type = 'APPLICATION'
+		AND resource_description LIKE @p1
+	) THEN 1 ELSE 0 END`
+	var exists int
+	if err := db.QueryRowContext(ctx, q, lockName).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists == 1, nil
+}

--- a/internal/testing/integration/locking/sqlserver_table_locking_test.go
+++ b/internal/testing/integration/locking/sqlserver_table_locking_test.go
@@ -1,0 +1,339 @@
+package locking_test
+
+import (
+	"context"
+	"log/slog"
+	"math/rand/v2"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pressly/goose/v3"
+	"github.com/pressly/goose/v3/internal/testing/testdb"
+	"github.com/pressly/goose/v3/lock"
+	"github.com/pressly/goose/v3/lock/locktesting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSqlserverConcurrentTableLocking(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	db, cleanup, err := testdb.NewSqlserver()
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	// All lockers must compete for the SAME lock ID
+	lockID := rand.Int64()
+
+	newLocker := func(t *testing.T) lock.Locker {
+		locker, err := lock.NewSqlserverTableLocker(
+			lock.WithTableLockID(lockID), // Same lock ID for all lockers!!
+			lock.WithTableHeartbeatInterval(200*time.Millisecond),
+
+			// This value is important - it controls how long a locker will keep retrying to acquire
+			// the lock and must be shorter than the overall lock timeout below.
+
+			lock.WithTableLockTimeout(50*time.Millisecond, 2), // 200ms total wait time
+		)
+		require.NoError(t, err)
+		return locker
+	}
+
+	locktesting.TestConcurrentLocking(t, db, newLocker, 1*time.Second)
+}
+
+func TestSqlserverSequentialTableLocking(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	db, cleanup, err := testdb.NewSqlserver()
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	lockID := rand.Int64()
+
+	// Create two lockers - first has long lease, second has short retry timeout
+	locker1, err := lock.NewSqlserverTableLocker(
+		lock.WithTableLockID(lockID),
+		lock.WithTableLeaseDuration(2*time.Second), // Long lease to ensure it doesn't expire
+		lock.WithTableHeartbeatInterval(200*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	locker2, err := lock.NewSqlserverTableLocker(
+		lock.WithTableLockID(lockID),
+		lock.WithTableLeaseDuration(2*time.Second),
+		lock.WithTableHeartbeatInterval(200*time.Millisecond),
+		lock.WithTableLockTimeout(50*time.Millisecond, 4), // Only 200ms total timeout
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// First locker acquires the lock
+	err = locker1.Lock(ctx, db)
+	require.NoError(t, err)
+	t.Log("Locker 1 acquired lock")
+
+	// Second locker should fail to acquire the lock (will timeout after 200ms of retries)
+	ctx2, cancel := context.WithTimeout(ctx, 400*time.Millisecond)
+	defer cancel()
+	err = locker2.Lock(ctx2, db)
+	require.Error(t, err)
+	t.Log("Locker 2 correctly failed to acquire lock")
+
+	// First locker releases the lock
+	err = locker1.Unlock(ctx, db)
+	require.NoError(t, err)
+	t.Log("Locker 1 released lock")
+
+	// Now second locker should be able to acquire the lock
+	err = locker2.Lock(ctx, db)
+	require.NoError(t, err)
+	t.Log("Locker 2 acquired lock after locker 1 released")
+
+	// Clean up
+	err = locker2.Unlock(ctx, db)
+	require.NoError(t, err)
+	t.Log("Locker 2 released lock")
+}
+
+func TestSqlserverLockerImplementations(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	t.Run("sqlserver_table_locker_unique", func(t *testing.T) {
+		t.Parallel()
+
+		db, cleanup, err := testdb.NewSqlserver()
+		require.NoError(t, err)
+		t.Cleanup(cleanup)
+
+		// Use the same lock ID for all providers so they compete for the same table row
+		sharedLockID := rand.Int64()
+
+		locktesting.TestProviderLocking(t, func(t *testing.T) *goose.Provider {
+			t.Helper()
+
+			// Create a UNIQUE table-based locker instance per provider, but same lock ID
+			locker, err := lock.NewSqlserverTableLocker(
+				lock.WithTableLockID(sharedLockID),
+				lock.WithTableLockTimeout(200*time.Millisecond, 25), // 25 retries, 5s total
+			)
+			require.NoError(t, err)
+
+			p, err := goose.NewProvider(
+				goose.DialectMSSQL,
+				db,
+				os.DirFS("../testdata/migrations/sqlserver"),
+				goose.WithLocker(locker),
+			)
+			require.NoError(t, err)
+			return p
+		})
+	})
+	t.Run("sqlserver_table_locker_shared", func(t *testing.T) {
+		t.Parallel()
+
+		db, cleanup, err := testdb.NewSqlserver()
+		require.NoError(t, err)
+		t.Cleanup(cleanup)
+
+		// Create a SHARED table-based locker per provider
+		locker, err := lock.NewSqlserverTableLocker(
+			lock.WithTableLockID(rand.Int64()),
+			lock.WithTableLockTimeout(200*time.Millisecond, 25), // 25 retries, 5s total
+		)
+		require.NoError(t, err)
+
+		locktesting.TestProviderLocking(t, func(t *testing.T) *goose.Provider {
+			t.Helper()
+
+			p, err := goose.NewProvider(
+				goose.DialectMSSQL,
+				db,
+				os.DirFS("../testdata/migrations/sqlserver"),
+				goose.WithLocker(locker),
+			)
+			require.NoError(t, err)
+			return p
+		})
+	})
+	t.Run("sqlserver_session_locker_unique", func(t *testing.T) {
+		t.Parallel()
+
+		db, cleanup, err := testdb.NewSqlserver()
+		require.NoError(t, err)
+		t.Cleanup(cleanup)
+
+		// Use the same lock ID for all providers so they compete for the same advisory lock
+		sharedLockID := rand.Int64()
+
+		locktesting.TestProviderLocking(t, func(t *testing.T) *goose.Provider {
+			t.Helper()
+
+			// Each provider gets a UNIQUE session locker instance, but same lock ID
+			// This simulates multiple pods with separate locker instances competing for same advisory lock
+			sessionLocker, err := lock.NewSqlserverSessionLocker(
+				lock.WithLockID(sharedLockID), // Same lock ID for all providers
+				lock.WithLockTimeout(1, 10),   // 10 retries, 10s total
+			)
+			require.NoError(t, err)
+
+			p, err := goose.NewProvider(
+				goose.DialectMSSQL,
+				db,
+				os.DirFS("../testdata/migrations/sqlserver"),
+				goose.WithSessionLocker(sessionLocker),
+			)
+			require.NoError(t, err)
+			return p
+		})
+	})
+	t.Run("sqlserver_session_locker_shared", func(t *testing.T) {
+		t.Parallel()
+
+		db, cleanup, err := testdb.NewSqlserver()
+		require.NoError(t, err)
+		t.Cleanup(cleanup)
+
+		// Create a shared session locker (advisory lock) for all providers
+		sessionLocker, err := lock.NewSqlserverSessionLocker(
+			lock.WithLockID(rand.Int64()),
+			lock.WithLockTimeout(1, 10), // 10 retries, 10s total
+		)
+		require.NoError(t, err)
+
+		locktesting.TestProviderLocking(t, func(t *testing.T) *goose.Provider {
+			t.Helper()
+
+			p, err := goose.NewProvider(
+				goose.DialectMSSQL,
+				db,
+				os.DirFS("../testdata/migrations/sqlserver"),
+				goose.WithSessionLocker(sessionLocker),
+			)
+			require.NoError(t, err)
+			return p
+		})
+	})
+}
+
+func TestSqlserverTableLockerIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	db, cleanup, err := testdb.NewSqlserver()
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	t.Run("basic_lock_unlock", func(t *testing.T) {
+		t.Parallel()
+
+		// Create a table locker with very short timeouts for testing
+		locker, err := lock.NewSqlserverTableLocker(
+			lock.WithTableName("test_locks"),
+			lock.WithTableLockID(rand.Int64()),
+			lock.WithTableLeaseDuration(5*time.Second),
+			lock.WithTableHeartbeatInterval(1*time.Second),
+			lock.WithTableLockTimeout(100*time.Millisecond, 2), // Very short timeout
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err = locker.Lock(ctx, db)
+		require.NoError(t, err)
+
+		err = locker.Unlock(ctx, db)
+		require.NoError(t, err)
+	})
+
+	t.Run("cleanup_stale_locks", func(t *testing.T) {
+		t.Parallel()
+
+		lockID := rand.Int64()
+
+		// Create a locker with very short lease to test cleanup functionality
+		locker, err := lock.NewSqlserverTableLocker(
+			lock.WithTableLockID(lockID),
+			lock.WithTableLeaseDuration(100*time.Millisecond), // Very short lease
+			lock.WithTableHeartbeatInterval(50*time.Millisecond),
+		)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+
+		// Acquire the lock
+		err = locker.Lock(ctx, db)
+		require.NoError(t, err)
+
+		// Let the lease expire by waiting longer than lease duration
+		time.Sleep(200 * time.Millisecond)
+
+		// Create a second locker that should be able to acquire the lock
+		// because the first one's lease has expired
+		locker2, err := lock.NewSqlserverTableLocker(
+			lock.WithTableLockID(lockID), // Same lock ID
+			lock.WithTableLeaseDuration(5*time.Second),
+			lock.WithTableHeartbeatInterval(1*time.Second),
+		)
+		require.NoError(t, err)
+
+		// This should succeed because cleanup of stale locks allows it
+		ctx2, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		err = locker2.Lock(ctx2, db)
+		require.NoError(t, err)
+
+		// Clean up
+		err = locker2.Unlock(ctx, db)
+		require.NoError(t, err)
+	})
+
+	t.Run("with_logger", func(t *testing.T) {
+		t.Parallel()
+
+		var logOutput strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logOutput, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		// Create a table locker with logging enabled
+		locker, err := lock.NewSqlserverTableLocker(
+			lock.WithTableName("test_locks_with_logger"),
+			lock.WithTableLockID(rand.Int64()),
+			lock.WithTableLeaseDuration(2*time.Second),
+			lock.WithTableHeartbeatInterval(500*time.Millisecond),
+			lock.WithTableLogger(logger),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// Test that lock operations generate log messages
+		err = locker.Lock(ctx, db)
+		require.NoError(t, err)
+
+		// Wait a moment for heartbeat
+		time.Sleep(1 * time.Second)
+
+		err = locker.Unlock(ctx, db)
+		require.NoError(t, err)
+
+		// Check that we got some log output
+		logs := logOutput.String()
+		require.Contains(t, logs, "successfully acquired lock")
+		require.Contains(t, logs, "successfully released lock")
+		require.Contains(t, logs, "heartbeat updated lease")
+	})
+}

--- a/internal/testing/integration/testdata/migrations/sqlserver/00001_table.sql
+++ b/internal/testing/integration/testdata/migrations/sqlserver/00001_table.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE owners (
+    owner_id BIGINT IDENTITY(1,1) PRIMARY KEY,
+    owner_name NVARCHAR(255) NOT NULL,
+    owner_type NVARCHAR(50) NOT NULL CHECK (owner_type IN ('user', 'organization'))
+);
+
+CREATE TABLE repos (
+    repo_id BIGINT IDENTITY(1,1) NOT NULL,
+    repo_full_name NVARCHAR(255) NOT NULL,
+    repo_owner_id BIGINT NOT NULL,
+
+    PRIMARY KEY (repo_id),
+    CONSTRAINT FK_repos_owners FOREIGN KEY (repo_owner_id) REFERENCES owners(owner_id) ON DELETE CASCADE
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS repos;
+DROP TABLE IF EXISTS owners;
+-- +goose StatementEnd

--- a/internal/testing/integration/testdata/migrations/sqlserver/00002_insert.sql
+++ b/internal/testing/integration/testdata/migrations/sqlserver/00002_insert.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+INSERT INTO owners (owner_name, owner_type) VALUES ('linus', 'user');
+INSERT INTO owners (owner_name, owner_type) VALUES ('torvalds', 'organization');
+INSERT INTO repos (repo_full_name, repo_owner_id) VALUES ('linux', 1);
+INSERT INTO repos (repo_full_name, repo_owner_id) VALUES ('linux-2.6', 1);
+
+-- +goose Down
+DELETE FROM repos;
+DELETE FROM owners;

--- a/internal/testing/integration/testdata/migrations/sqlserver/00003_alter.sql
+++ b/internal/testing/integration/testdata/migrations/sqlserver/00003_alter.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE owners ADD owner_email NVARCHAR(255) NULL;
+
+-- +goose Down
+ALTER TABLE owners DROP COLUMN owner_email;

--- a/internal/testing/integration/testdata/migrations/sqlserver/00004_empty.sql
+++ b/internal/testing/integration/testdata/migrations/sqlserver/00004_empty.sql
@@ -1,0 +1,3 @@
+-- +goose Up
+
+-- +goose Down

--- a/internal/testing/testdb/sqlserver.go
+++ b/internal/testing/testdb/sqlserver.go
@@ -1,0 +1,91 @@
+package testdb
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"strconv"
+
+	_ "github.com/microsoft/go-mssqldb"
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+)
+
+const (
+	// https://hub.docker.com/_/microsoft-mssql-server
+	SQLSERVER_IMAGE   = "mcr.microsoft.com/mssql/server"
+	SQLSERVER_VERSION = "2022-latest"
+
+	SQLSERVER_DB       = "master"
+	SQLSERVER_USER     = "sa"
+	SQLSERVER_PASSWORD = "Password123!"
+)
+
+func newSqlserver(opts ...OptionsFunc) (*sql.DB, func(), error) {
+	option := &options{}
+	for _, f := range opts {
+		f(option)
+	}
+	// Uses a sensible default on windows (tcp/http) and linux/osx (socket).
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to docker: %v", err)
+	}
+	options := &dockertest.RunOptions{
+		Repository: SQLSERVER_IMAGE,
+		Tag:        SQLSERVER_VERSION,
+		Env: []string{
+			"ACCEPT_EULA=Y",
+			"MSSQL_SA_PASSWORD=" + SQLSERVER_PASSWORD,
+		},
+		Labels:       map[string]string{"goose_test": "1"},
+		PortBindings: make(map[docker.Port][]docker.PortBinding),
+	}
+	if option.bindPort > 0 {
+		options.PortBindings[docker.Port("1433/tcp")] = []docker.PortBinding{
+			{HostPort: strconv.Itoa(option.bindPort)},
+		}
+	}
+	container, err := pool.RunWithOptions(
+		options,
+		func(config *docker.HostConfig) {
+			// Set AutoRemove to true so that stopped container goes away by itself.
+			config.AutoRemove = true
+			config.RestartPolicy = docker.RestartPolicy{Name: "no"}
+		},
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create docker container: %v", err)
+	}
+	cleanup := func() {
+		if option.debug {
+			// User must manually delete the Docker container.
+			return
+		}
+		if err := pool.Purge(container); err != nil {
+			log.Printf("failed to purge resource: %v", err)
+		}
+	}
+	connStr := fmt.Sprintf("sqlserver://%s:%s@localhost:%s?database=%s",
+		SQLSERVER_USER,
+		SQLSERVER_PASSWORD,
+		container.GetPort("1433/tcp"), // Fetch port dynamically assigned to container
+		SQLSERVER_DB,
+	)
+	var db *sql.DB
+	// Exponential backoff-retry, because the application in the container
+	// might not be ready to accept connections yet. SQL Server takes longer to start.
+	if err := pool.Retry(
+		func() error {
+			var err error
+			db, err = sql.Open("sqlserver", connStr)
+			if err != nil {
+				return err
+			}
+			return db.Ping()
+		},
+	); err != nil {
+		return nil, cleanup, fmt.Errorf("could not connect to docker database: %v", err)
+	}
+	return db, cleanup, nil
+}

--- a/internal/testing/testdb/testdb.go
+++ b/internal/testing/testdb/testdb.go
@@ -31,3 +31,8 @@ func NewYdb(options ...OptionsFunc) (db *sql.DB, cleanup func(), err error) {
 func NewStarrocks(options ...OptionsFunc) (db *sql.DB, cleanup func(), err error) {
 	return newStarrocks(options...)
 }
+
+// NewSqlserver starts a SQL Server docker container. Returns db connection and a docker cleanup function.
+func NewSqlserver(options ...OptionsFunc) (db *sql.DB, cleanup func(), err error) {
+	return newSqlserver(options...)
+}

--- a/lock/internal/store/sqlserver.go
+++ b/lock/internal/store/sqlserver.go
@@ -1,0 +1,287 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/multierr"
+)
+
+// NewSqlserver creates a new SQL Server-based [LockStore].
+func NewSqlserver(tableName string) (LockStore, error) {
+	if tableName == "" {
+		return nil, errors.New("table name must not be empty")
+	}
+	return &sqlserverStore{
+		tableName: tableName,
+	}, nil
+}
+
+var _ LockStore = (*sqlserverStore)(nil)
+
+type sqlserverStore struct {
+	tableName string
+}
+
+func (s *sqlserverStore) TableExists(
+	ctx context.Context,
+	db *sql.DB,
+) (bool, error) {
+	var query string
+	schemaName, tableName := parseSqlserverTableIdentifier(s.tableName)
+	if schemaName != "" {
+		q := `SELECT CASE WHEN EXISTS (
+			SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+			WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'
+		) THEN 1 ELSE 0 END`
+		query = fmt.Sprintf(q, schemaName, tableName)
+	} else {
+		q := `SELECT CASE WHEN EXISTS (
+			SELECT 1 FROM INFORMATION_SCHEMA.TABLES
+			WHERE TABLE_SCHEMA = SCHEMA_NAME() AND TABLE_NAME = '%s'
+		) THEN 1 ELSE 0 END`
+		query = fmt.Sprintf(q, tableName)
+	}
+
+	var exists int
+	if err := db.QueryRowContext(ctx, query).Scan(&exists); err != nil {
+		return false, fmt.Errorf("table exists: %w", err)
+	}
+	return exists == 1, nil
+}
+
+func (s *sqlserverStore) CreateLockTable(
+	ctx context.Context,
+	db *sql.DB,
+) error {
+	exists, err := s.TableExists(ctx, db)
+	if err != nil {
+		return fmt.Errorf("check lock table existence: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
+	query := fmt.Sprintf(`CREATE TABLE %s (
+		lock_id BIGINT NOT NULL PRIMARY KEY,
+		locked BIT NOT NULL DEFAULT 0,
+		locked_at DATETIMEOFFSET NULL,
+		locked_by NVARCHAR(255) NULL,
+		lease_expires_at DATETIMEOFFSET NULL,
+		updated_at DATETIMEOFFSET NULL
+	)`, s.tableName)
+	if _, err := db.ExecContext(ctx, query); err != nil {
+		// Double-check if another process created it concurrently
+		if exists, checkErr := s.TableExists(ctx, db); checkErr == nil && exists {
+			// Another process created it, that's fine!
+			return nil
+		}
+		return fmt.Errorf("create lock table %q: %w", s.tableName, err)
+	}
+	return nil
+}
+
+func (s *sqlserverStore) AcquireLock(
+	ctx context.Context,
+	db *sql.DB,
+	lockID int64,
+	lockedBy string,
+	leaseDuration time.Duration,
+) (*AcquireLockResult, error) {
+	// SQL Server uses MERGE for upsert functionality
+	// We only update if the lock is not held (locked = 0) or the lease has expired
+	query := fmt.Sprintf(`
+		MERGE %s WITH (HOLDLOCK) AS target
+		USING (SELECT @p1 AS lock_id) AS source
+		ON target.lock_id = source.lock_id
+		WHEN MATCHED AND (target.locked = 0 OR target.lease_expires_at < SYSUTCDATETIME()) THEN
+			UPDATE SET
+				locked = 1,
+				locked_at = SYSUTCDATETIME(),
+				locked_by = @p2,
+				lease_expires_at = DATEADD(SECOND, @p3, SYSUTCDATETIME()),
+				updated_at = SYSUTCDATETIME()
+		WHEN NOT MATCHED THEN
+			INSERT (lock_id, locked, locked_at, locked_by, lease_expires_at, updated_at)
+			VALUES (@p1, 1, SYSUTCDATETIME(), @p2, DATEADD(SECOND, @p3, SYSUTCDATETIME()), SYSUTCDATETIME())
+		OUTPUT inserted.locked_by, inserted.lease_expires_at;`,
+		s.tableName)
+
+	// Convert duration to seconds
+	leaseDurationSeconds := int(leaseDuration.Seconds())
+
+	var returnedLockedBy string
+	var leaseExpiresAt time.Time
+	err := db.QueryRowContext(ctx, query,
+		lockID,
+		lockedBy,
+		leaseDurationSeconds,
+	).Scan(
+		&returnedLockedBy,
+		&leaseExpiresAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("acquire lock %d: already held by another instance", lockID)
+		}
+		return nil, fmt.Errorf("acquire lock %d: %w", lockID, err)
+	}
+
+	// Verify we got the lock by checking the returned locked_by matches our instance ID
+	if returnedLockedBy != lockedBy {
+		return nil, fmt.Errorf("acquire lock %d: acquired by %s instead of %s", lockID, returnedLockedBy, lockedBy)
+	}
+
+	return &AcquireLockResult{
+		LockedBy:       returnedLockedBy,
+		LeaseExpiresAt: leaseExpiresAt,
+	}, nil
+}
+
+func (s *sqlserverStore) ReleaseLock(
+	ctx context.Context,
+	db *sql.DB,
+	lockID int64,
+	lockedBy string,
+) (*ReleaseLockResult, error) {
+	// Release lock only if it's held by the current instance
+	query := fmt.Sprintf(`UPDATE %s SET
+		locked = 0,
+		locked_at = NULL,
+		locked_by = NULL,
+		lease_expires_at = NULL,
+		updated_at = SYSUTCDATETIME()
+	OUTPUT inserted.lock_id
+	WHERE lock_id = @p1 AND locked_by = @p2`, s.tableName)
+
+	var returnedLockID int64
+	err := db.QueryRowContext(ctx, query,
+		lockID,
+		lockedBy,
+	).Scan(
+		&returnedLockID,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("release lock %d: not held by this instance", lockID)
+		}
+		return nil, fmt.Errorf("release lock %d: %w", lockID, err)
+	}
+
+	// Verify the correct lock was released
+	if returnedLockID != lockID {
+		return nil, fmt.Errorf("release lock %d: returned lock ID %d does not match", lockID, returnedLockID)
+	}
+
+	return &ReleaseLockResult{
+		LockID: returnedLockID,
+	}, nil
+}
+
+func (s *sqlserverStore) UpdateLease(
+	ctx context.Context,
+	db *sql.DB,
+	lockID int64,
+	lockedBy string,
+	leaseDuration time.Duration,
+) (*UpdateLeaseResult, error) {
+	// Update lease expiration time for heartbeat, only if we own the lock
+	query := fmt.Sprintf(`UPDATE %s SET
+		lease_expires_at = DATEADD(SECOND, @p1, SYSUTCDATETIME()),
+		updated_at = SYSUTCDATETIME()
+	OUTPUT inserted.lease_expires_at
+	WHERE lock_id = @p2 AND locked_by = @p3 AND locked = 1`, s.tableName)
+
+	// Convert duration to seconds
+	leaseDurationSeconds := int(leaseDuration.Seconds())
+
+	var leaseExpiresAt time.Time
+	err := db.QueryRowContext(ctx, query,
+		leaseDurationSeconds,
+		lockID,
+		lockedBy,
+	).Scan(
+		&leaseExpiresAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("failed to update lease for lock %d: not held by this instance", lockID)
+		}
+		return nil, fmt.Errorf("failed to update lease for lock %d: %w", lockID, err)
+	}
+
+	return &UpdateLeaseResult{
+		LeaseExpiresAt: leaseExpiresAt,
+	}, nil
+}
+
+func (s *sqlserverStore) CheckLockStatus(
+	ctx context.Context,
+	db *sql.DB,
+	lockID int64,
+) (*LockStatus, error) {
+	query := fmt.Sprintf(`SELECT locked, locked_by, lease_expires_at, updated_at FROM %s WHERE lock_id = @p1`, s.tableName)
+	var status LockStatus
+
+	err := db.QueryRowContext(ctx, query,
+		lockID,
+	).Scan(
+		&status.Locked,
+		&status.LockedBy,
+		&status.LeaseExpiresAt,
+		&status.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("lock %d not found", lockID)
+		}
+		return nil, fmt.Errorf("check lock status for %d: %w", lockID, err)
+	}
+
+	return &status, nil
+}
+
+func (s *sqlserverStore) CleanupStaleLocks(ctx context.Context, db *sql.DB) (_ []int64, retErr error) {
+	query := fmt.Sprintf(`UPDATE %s SET
+		locked = 0,
+		locked_at = NULL,
+		locked_by = NULL,
+		lease_expires_at = NULL,
+		updated_at = SYSUTCDATETIME()
+	OUTPUT inserted.lock_id
+	WHERE locked = 1 AND lease_expires_at < SYSUTCDATETIME()`, s.tableName)
+
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("cleanup stale locks: %w", err)
+	}
+	defer func() {
+		retErr = multierr.Append(retErr, rows.Close())
+	}()
+
+	var cleanedLocks []int64
+	for rows.Next() {
+		var lockID int64
+		if err := rows.Scan(&lockID); err != nil {
+			return nil, fmt.Errorf("scan cleaned lock ID: %w", err)
+		}
+		cleanedLocks = append(cleanedLocks, lockID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate over cleaned locks: %w", err)
+	}
+
+	return cleanedLocks, nil
+}
+
+func parseSqlserverTableIdentifier(name string) (schema, table string) {
+	schema, table, found := strings.Cut(name, ".")
+	if !found {
+		return "", name
+	}
+	return schema, table
+}

--- a/lock/sqlserver.go
+++ b/lock/sqlserver.go
@@ -1,0 +1,184 @@
+package lock
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/pressly/goose/v3/lock/internal/store"
+	"github.com/pressly/goose/v3/lock/internal/table"
+	"github.com/sethvargo/go-retry"
+)
+
+// NewSqlserverTableLocker returns a Locker that uses SQL Server table-based locking. It manages a
+// single lock row and keeps the lock alive automatically.
+//
+// Default behavior:
+//
+//   - Lease (30s): How long the lock is valid if heartbeat stops
+//   - Heartbeat (5s): How often the lock gets refreshed to keep it alive
+//   - If the process dies, others can take the lock after lease expires
+//
+// Defaults:
+//
+//	Table: "goose_lock"
+//	Lock ID: 4097083626 (crc64 of "goose")
+//	Lock retry: 5s intervals, 5min timeout
+//	Unlock retry: 2s intervals, 1min timeout
+//
+// Lock and Unlock both retry on failure. Lock stays alive automatically until released. All
+// defaults can be overridden with options.
+func NewSqlserverTableLocker(options ...TableLockerOption) (Locker, error) {
+	config := table.Config{
+		TableName:         DefaultLockTableName,
+		LockID:            DefaultLockID,
+		LeaseDuration:     30 * time.Second,
+		HeartbeatInterval: 5 * time.Second,
+		LockTimeout: table.ProbeConfig{
+			IntervalDuration: 5 * time.Second,
+			FailureThreshold: 60, // 5 minutes total
+		},
+		UnlockTimeout: table.ProbeConfig{
+			IntervalDuration: 2 * time.Second,
+			FailureThreshold: 30, // 1 minute total
+		},
+	}
+	for _, opt := range options {
+		if err := opt.apply(&config); err != nil {
+			return nil, err
+		}
+	}
+	lockStore, err := store.NewSqlserver(config.TableName)
+	if err != nil {
+		return nil, fmt.Errorf("create lock store: %w", err)
+	}
+	return table.New(lockStore, config), nil
+}
+
+// NewSqlserverSessionLocker returns a SessionLocker that utilizes SQL Server's sp_getapplock
+// and sp_releaseapplock stored procedures for application-level locking.
+//
+// This function creates a SessionLocker that can be used to acquire and release a lock for
+// synchronization purposes. The lock acquisition is retried until it is successfully acquired or
+// until the failure threshold is reached. The default lock duration is set to 5 minutes, and the
+// default unlock duration is set to 1 minute.
+//
+// If you have long running migrations, you may want to increase the lock duration.
+//
+// See [SessionLockerOption] for options that can be used to configure the SessionLocker.
+func NewSqlserverSessionLocker(opts ...SessionLockerOption) (SessionLocker, error) {
+	cfg := sessionLockerConfig{
+		lockID: DefaultLockID,
+		lockProbe: probe{
+			intervalDuration: 5 * time.Second,
+			failureThreshold: 60,
+		},
+		unlockProbe: probe{
+			intervalDuration: 2 * time.Second,
+			failureThreshold: 30,
+		},
+	}
+	for _, opt := range opts {
+		if err := opt.apply(&cfg); err != nil {
+			return nil, err
+		}
+	}
+	return &sqlserverSessionLocker{
+		lockID: cfg.lockID,
+		retryLock: retry.WithMaxRetries(
+			cfg.lockProbe.failureThreshold,
+			retry.NewConstant(cfg.lockProbe.intervalDuration),
+		),
+		retryUnlock: retry.WithMaxRetries(
+			cfg.unlockProbe.failureThreshold,
+			retry.NewConstant(cfg.unlockProbe.intervalDuration),
+		),
+	}, nil
+}
+
+type sqlserverSessionLocker struct {
+	lockID      int64
+	retryLock   retry.Backoff
+	retryUnlock retry.Backoff
+}
+
+var _ SessionLocker = (*sqlserverSessionLocker)(nil)
+
+func (l *sqlserverSessionLocker) SessionLock(ctx context.Context, conn *sql.Conn) error {
+	return retry.Do(ctx, l.retryLock, func(ctx context.Context) error {
+		// sp_getapplock acquires an application-level lock
+		// @Resource: lock name (using lock ID as string)
+		// @LockMode: 'Exclusive' for exclusive lock
+		// @LockOwner: 'Session' for session-level lock
+		// @LockTimeout: 0 for immediate return (no wait)
+		// Return value: 0 or 1 = success, < 0 = failure
+		lockName := fmt.Sprintf("goose_lock_%d", l.lockID)
+		query := `
+			DECLARE @result INT;
+			EXEC @result = sp_getapplock
+				@Resource = @p1,
+				@LockMode = 'Exclusive',
+				@LockOwner = 'Session',
+				@LockTimeout = 0;
+			SELECT @result;
+		`
+		var result int
+		if err := conn.QueryRowContext(ctx, query, lockName).Scan(&result); err != nil {
+			return fmt.Errorf("failed to execute sp_getapplock: %w", err)
+		}
+		// sp_getapplock return values:
+		// 0 = lock was granted synchronously
+		// 1 = lock was granted after waiting for other incompatible locks to be released
+		// -1 = lock request timed out
+		// -2 = lock request was canceled
+		// -3 = lock request was chosen as a deadlock victim
+		// -999 = parameter validation or other call error
+		if result >= 0 {
+			// Lock was acquired successfully
+			return nil
+		}
+		// Lock could not be acquired. Continue retrying until the lock is acquired or the
+		// maximum number of retries is reached.
+		return retry.RetryableError(errors.New("failed to acquire lock"))
+	})
+}
+
+func (l *sqlserverSessionLocker) SessionUnlock(ctx context.Context, conn *sql.Conn) error {
+	return retry.Do(ctx, l.retryUnlock, func(ctx context.Context) error {
+		lockName := fmt.Sprintf("goose_lock_%d", l.lockID)
+		query := `
+			DECLARE @result INT;
+			EXEC @result = sp_releaseapplock
+				@Resource = @p1,
+				@LockOwner = 'Session';
+			SELECT @result;
+		`
+		var result int
+		if err := conn.QueryRowContext(ctx, query, lockName).Scan(&result); err != nil {
+			return fmt.Errorf("failed to execute sp_releaseapplock: %w", err)
+		}
+		// sp_releaseapplock return values:
+		// 0 = lock was released successfully
+		// -999 = parameter validation error or other call error
+		if result == 0 {
+			// Lock was released successfully
+			return nil
+		}
+		/*
+			Unlike PostgreSQL's advisory locks, SQL Server's sp_releaseapplock will fail if the
+			lock was not held by the current session. This is expected behavior and should be
+			retried as the lock might have been released by another operation.
+
+			To manually check application locks in SQL Server:
+
+			SELECT * FROM sys.dm_tran_locks WHERE resource_type = 'APPLICATION';
+
+			To forcefully release all locks held by a session, terminate the session:
+
+			KILL <session_id>;
+		*/
+		return retry.RetryableError(errors.New("failed to unlock session"))
+	})
+}


### PR DESCRIPTION
This adds a complete locking mechanism for SQL Server, similar to the existing PostgreSQL implementation from PR #993.

Features:
- Table-based locking using MERGE for atomic upserts
- Session-based locking using sp_getapplock/sp_releaseapplock
- Automatic lease renewal via heartbeat mechanism
- Stale lock cleanup for expired leases

Implementation:
- lock/internal/store/sqlserver.go: LockStore implementation
- lock/sqlserver.go: Public API (NewSqlserverTableLocker, NewSqlserverSessionLocker)
- internal/testing/testdb/sqlserver.go: Docker test helper
- SQL Server specific test migrations
- Comprehensive integration tests for both locking modes

The table-based locker uses SQL Server's MERGE statement with HOLDLOCK for atomic lock acquisition and SYSUTCDATETIME() for server-side time. The session-based locker uses SQL Server's built-in application lock stored procedures which provide session-level advisory locking.