### PR TITLE
Fix tests for StarRocks 3.5

### DIFF
--- a/internal/testing/integration/database_test.go
+++ b/internal/testing/integration/database_test.go
@@ -136,12 +136,12 @@ func TestYDB(t *testing.T) {
 func TestStarrocks(t *testing.T) {
 	t.Parallel()
 
-	t.Skip("Starrocks is flaky on CI, see https://github.com/pressly/goose/issues/881")
+	// t.Skip("Starrocks is flaky on CI, see https://github.com/pressly/goose/issues/881")
 
 	db, cleanup, err := testdb.NewStarrocks()
 	require.NoError(t, err)
 	t.Cleanup(cleanup)
 	require.NoError(t, db.Ping())
 
-	testDatabase(t, database.DialectStarrocks, db, "testdata/migrations/starrocks")
+	testDatabase(t, database.DialectStarrocks, db, "testdata/migrations/starrocks", goose.WithIsolateDDL(true))
 }

--- a/internal/testing/testdb/starrocks.go
+++ b/internal/testing/testdb/starrocks.go
@@ -15,7 +15,7 @@ import (
 const (
 	// https://hub.docker.com/r/starrocks/allin1-ubuntu
 	STARROCKS_IMAGE   = "starrocks/allin1-ubuntu"
-	STARROCKS_VERSION = "3.2-latest"
+	STARROCKS_VERSION = "3.5.11"
 
 	STARROCKS_USER    = "root"
 	STARROCKS_INIT_DB = "migrations"


### PR DESCRIPTION
Fix tests for StarRocks 3.5: enable isolate_ddl. Pin a specific Docker image version in tests for better stability.
May be it will resolve https://github.com/pressly/goose/issues/881