### PR TITLE
Support for last N migrations for the database #254

### DIFF
--- a/status.go
+++ b/status.go
@@ -25,6 +25,9 @@ func StatusContext(ctx context.Context, db *sql.DB, dir string, opts ...OptionsF
 	if err != nil {
 		return fmt.Errorf("failed to collect migrations: %w", err)
 	}
+	if option.statusLimit > 0 && len(migrations) > option.statusLimit {
+		migrations = migrations[len(migrations)-option.statusLimit:]
+	}
 	if option.noVersioning {
 		log.Printf("    Applied At                  Migration")
 		log.Printf("    =======================================")

--- a/up.go
+++ b/up.go
@@ -12,6 +12,7 @@ type options struct {
 	allowMissing bool
 	applyUpByOne bool
 	noVersioning bool
+	statusLimit  int
 }
 
 type OptionsFunc func(o *options)
@@ -22,6 +23,12 @@ func WithAllowMissing() OptionsFunc {
 
 func WithNoVersioning() OptionsFunc {
 	return func(o *options) { o.noVersioning = true }
+}
+
+// WithStatusLimit limits the number of migrations printed by the status command.
+// A value <= 0 means no limit.
+func WithStatusLimit(n int) OptionsFunc {
+	return func(o *options) { o.statusLimit = n }
 }
 
 func WithNoColor(b bool) OptionsFunc {


### PR DESCRIPTION
Adds -n/--limit to goose status to print only the last N migrations
Keeps default status behavior unchanged
Adds CLI regression tests for default and limited output