### PR TITLE
fix issue: https://github.com/pressly/goose/issues/937

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -232,13 +232,40 @@ func mergeArgs(config *envConfig, args []string) []string {
 	if len(args) < 1 {
 		return args
 	}
-	if s := config.driver; s != "" {
-		args = append([]string{s}, args...)
+
+	// Explicit positional arguments should win over environment values.
+	if len(args) >= 3 {
+		return args
 	}
-	if s := config.dbstring; s != "" {
-		args = append([]string{args[0], s}, args[1:]...)
+
+	// Command-first form: goose COMMAND [ARGS...]
+	if isDBCommand(args[0]) {
+		if s := config.driver; s != "" {
+			args = append([]string{s}, args...)
+		}
+		if s := config.dbstring; s != "" {
+			args = append([]string{args[0], s}, args[1:]...)
+		}
+		return args
 	}
+
+	// Driver-first short form: goose DRIVER COMMAND
+	if len(args) == 2 && isDBCommand(args[1]) {
+		if s := config.dbstring; s != "" {
+			args = append([]string{args[0], s}, args[1:]...)
+		}
+	}
+
 	return args
+}
+
+func isDBCommand(s string) bool {
+	switch s {
+	case "up", "up-by-one", "up-to", "down", "down-to", "redo", "reset", "status", "version":
+		return true
+	default:
+		return false
+	}
 }
 
 func usage() {

--- a/cmd/goose/main_test.go
+++ b/cmd/goose/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -62,6 +63,59 @@ func TestFirstNonEmpty(t *testing.T) {
 			result := firstNonEmpty(tt.input...)
 			if result != tt.expected {
 				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMergeArgs(t *testing.T) {
+	config := &envConfig{
+		driver:   "postgres",
+		dbstring: "postgresql://postgres:postgres@localhost:5433/alpha",
+	}
+
+	tests := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{
+			name:     "empty args",
+			args:     []string{},
+			expected: []string{},
+		},
+		{
+			name:     "command only uses env driver and dbstring",
+			args:     []string{"status"},
+			expected: []string{"postgres", "postgresql://postgres:postgres@localhost:5433/alpha", "status"},
+		},
+		{
+			name:     "command with argument uses env driver and dbstring",
+			args:     []string{"up-to", "42"},
+			expected: []string{"postgres", "postgresql://postgres:postgres@localhost:5433/alpha", "up-to", "42"},
+		},
+		{
+			name:     "cli driver and dbstring override env values",
+			args:     []string{"postgres", "postgresql://override", "status"},
+			expected: []string{"postgres", "postgresql://override", "status"},
+		},
+		{
+			name:     "cli driver with command uses env dbstring only",
+			args:     []string{"postgres", "status"},
+			expected: []string{"postgres", "postgresql://postgres:postgres@localhost:5433/alpha", "status"},
+		},
+		{
+			name:     "driver only remains unchanged",
+			args:     []string{"postgres"},
+			expected: []string{"postgres"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeArgs(config, tt.args)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("expected %v, got %v", tt.expected, result)
 			}
 		})
 	}


### PR DESCRIPTION
This fix allows the cli args to override env vars as per the issue case. Issue: 937.
This patch changed behaviour of main.go:func mergeArgs, added 1 more function isDBCommand and 1 test in main_test.go: TestMergeArgs.

I understand issue is not pressing, but this is my first try to contribute to goose, which I use practically every day, so feedback would also be very much appriciated. 
