### PR TITLE
fix: use DATETIME instead of TIMESTAMP for MySQL/TiDB tstamp column (Y2K38)

### DIFF
--- a/internal/dialects/mysql.go
+++ b/internal/dialects/mysql.go
@@ -20,7 +20,7 @@ func (m *mysql) CreateTable(tableName string) string {
 		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 		version_id bigint NOT NULL,
 		is_applied boolean NOT NULL,
-		tstamp timestamp NULL default now(),
+		tstamp datetime NULL default CURRENT_TIMESTAMP,
 		PRIMARY KEY(id)
 	)`
 	return fmt.Sprintf(q, tableName)

--- a/internal/dialects/tidb.go
+++ b/internal/dialects/tidb.go
@@ -20,7 +20,7 @@ func (t *Tidb) CreateTable(tableName string) string {
 		id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE,
 		version_id bigint NOT NULL,
 		is_applied boolean NOT NULL,
-		tstamp timestamp NULL default now(),
+		tstamp datetime NULL default CURRENT_TIMESTAMP,
 		PRIMARY KEY(id)
 	)`
 	return fmt.Sprintf(q, tableName)


### PR DESCRIPTION
Fixes #432

## Problem

The `goose_db_version` table uses MySQL `TIMESTAMP` type for the `tstamp` column. `TIMESTAMP` stores values as a 32-bit signed Unix timestamp, with a maximum of **2038-01-19 03:14:07 UTC** (the [Year 2038 problem](https://en.wikipedia.org/wiki/Year_2038_problem)).

## Fix

Change to `DATETIME` for both MySQL and TiDB dialects:
- `DATETIME` supports dates up to 9999-12-31 23:59:59
- Use `CURRENT_TIMESTAMP` (SQL standard) instead of `now()` for the default

Only affects newly created tables. Existing tables continue to work.