### PR TITLE
feat: add WithDisableTransactions() provider option

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -147,6 +147,26 @@ func newProvider(
 	if len(migrations) == 0 {
 		return nil, ErrNoMigrations
 	}
+	// for RunTx along with disableTransactions = true
+	if cfg.disableTransactions {
+		for _, m := range migrations {
+			if m.Type != TypeGo {
+				continue
+			}
+			if m.goUp.RunTx != nil {
+				return nil, fmt.Errorf(
+					"go migration %d uses RunTx which is incompatible with disable transactions",
+					m.Version,
+				)
+			}
+			if m.goDown.RunTx != nil {
+				return nil, fmt.Errorf(
+					"go migration %d uses RunTx (down) which is incompatible with disable transactions",
+					m.Version,
+				)
+			}
+		}
+	}
 	return &Provider{
 		db:         db,
 		fsys:       fsys,

--- a/provider_options.go
+++ b/provider_options.go
@@ -247,13 +247,11 @@ func WithIsolateDDL(b bool) ProviderOption {
 // WithDisableTransactions disables all transaction usage. This is useful for databases that do not
 // support transactions at all, such as chDB (embedded ClickHouse).
 //
-// This differs from [WithIsolateDDL], which separates DDL and DML operations but may still use
-// transactions for individual operations. WithDisableTransactions ensures that BEGIN/COMMIT are
-// never issued.
-//
-// Note: this option is incompatible with Go migrations that use [GoFunc.RunTx], which requires a
-// *sql.Tx. If any registered Go migration uses RunTx, the provider will return an error at
-// construction time.
+// Today, this guards the same transaction sites as [WithIsolateDDL]. The key differences are:
+//   - Semantic: WithIsolateDDL signals "separate DDL from DML," while this option signals
+//     "the database does not support transactions at all."
+//   - Validation: this option rejects Go migrations that use [GoFunc.RunTx] at construction
+//     time, since a *sql.Tx cannot be created when transactions are disabled.
 func WithDisableTransactions(b bool) ProviderOption {
 	return configFunc(func(c *config) error {
 		c.disableTransactions = b

--- a/provider_options.go
+++ b/provider_options.go
@@ -244,6 +244,23 @@ func WithIsolateDDL(b bool) ProviderOption {
 	})
 }
 
+// WithDisableTransactions disables all transaction usage. This is useful for databases that do not
+// support transactions at all, such as chDB (embedded ClickHouse).
+//
+// This differs from [WithIsolateDDL], which separates DDL and DML operations but may still use
+// transactions for individual operations. WithDisableTransactions ensures that BEGIN/COMMIT are
+// never issued.
+//
+// Note: this option is incompatible with Go migrations that use [GoFunc.RunTx], which requires a
+// *sql.Tx. If any registered Go migration uses RunTx, the provider will return an error at
+// construction time.
+func WithDisableTransactions(b bool) ProviderOption {
+	return configFunc(func(c *config) error {
+		c.disableTransactions = b
+		return nil
+	})
+}
+
 type config struct {
 	tableName string
 	store     database.Store
@@ -266,6 +283,7 @@ type config struct {
 	allowMissing          bool
 	disableGlobalRegistry bool
 	isolateDDL            bool
+	disableTransactions   bool
 
 	// Only a single logger can be set, they are mutually exclusive. If neither is set, a default
 	// [Logger] will be set to maintain backward compatibility in /v3.

--- a/provider_options_test.go
+++ b/provider_options_test.go
@@ -1,6 +1,7 @@
 package goose_test
 
 import (
+	"context"
 	"database/sql"
 	"path/filepath"
 	"testing"
@@ -55,6 +56,31 @@ func TestNewProvider(t *testing.T) {
 			goose.WithTableName("custom_table"),
 		)
 		require.Error(t, err)
+	})
+	t.Run("disable_transactions_with_run_tx", func(t *testing.T) {
+		// RunTx Go migrations are incompatible with WithDisableTransactions because
+		// RunTx requires a *sql.Tx which cannot be created when transactions are disabled.
+		m := goose.NewGoMigration(1,
+			&goose.GoFunc{RunTx: func(ctx context.Context, tx *sql.Tx) error { return nil }},
+			&goose.GoFunc{RunTx: func(ctx context.Context, tx *sql.Tx) error { return nil }},
+		)
+		_, err = goose.NewProvider(goose.DialectSQLite3, db, nil,
+			goose.WithDisableTransactions(true),
+			goose.WithGoMigrations(m),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "incompatible with disable transactions")
+		// Down-only RunTx should also fail
+		m2 := goose.NewGoMigration(2,
+			&goose.GoFunc{RunDB: func(ctx context.Context, db *sql.DB) error { return nil }},
+			&goose.GoFunc{RunTx: func(ctx context.Context, tx *sql.Tx) error { return nil }},
+		)
+		_, err = goose.NewProvider(goose.DialectSQLite3, db, nil,
+			goose.WithDisableTransactions(true),
+			goose.WithGoMigrations(m2),
+		)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "incompatible with disable transactions")
 	})
 	t.Run("valid", func(t *testing.T) {
 		// Valid dialect, db, and fsys allowed

--- a/provider_run.go
+++ b/provider_run.go
@@ -210,7 +210,7 @@ func (p *Provider) runIndividually(
 	if err != nil {
 		return err
 	}
-	if useTx && !p.cfg.isolateDDL {
+	if useTx && !p.cfg.isolateDDL && !p.cfg.disableTransactions {
 		return beginTx(ctx, conn, func(tx *sql.Tx) error {
 			if err := p.runMigration(ctx, tx, m, direction); err != nil {
 				return err
@@ -382,7 +382,7 @@ func (p *Provider) tryEnsureVersionTable(ctx context.Context, conn *sql.Conn) er
 			return fmt.Errorf("check if version table exists: %w", err)
 		}
 
-		if p.cfg.isolateDDL {
+		if p.cfg.isolateDDL || p.cfg.disableTransactions {
 			// If isolation is enabled, we create the version table separately to ensure subsequent
 			// DML operations are not mixed with DDL.
 			if err := p.store.CreateVersionTable(ctx, conn); err != nil {

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -371,6 +371,82 @@ INSERT INTO owners (owner_name) VALUES ('seed-user-3');
 		require.NoError(t, err)
 		require.EqualValues(t, 7, currentVersion)
 	})
+	t.Run("disable_transactions", func(t *testing.T) {
+		ctx := context.Background()
+		p, _ := newProviderWithDB(t, goose.WithDisableTransactions(true))
+		// Apply all SQL migrations without transactions
+		res, err := p.Up(ctx)
+		require.NoError(t, err)
+		require.Len(t, res, 7)
+		currentVersion, err := p.GetDBVersion(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 7, currentVersion)
+		// Rollback all migrations without transactions
+		res, err = p.DownTo(ctx, 0)
+		require.NoError(t, err)
+		require.Len(t, res, 7)
+	})
+	t.Run("disable_transactions_with_go_rundb", func(t *testing.T) {
+		ctx := context.Background()
+		db := newDB(t)
+		fsys := fstest.MapFS{
+			"00001_create_table.sql": newMapFile(`
+-- +goose Up
+CREATE TABLE test_users (id INTEGER PRIMARY KEY);
+-- +goose Down
+DROP TABLE test_users;
+`),
+		}
+		goMigration := goose.NewGoMigration(2,
+			&goose.GoFunc{RunDB: newDBFn("INSERT INTO test_users (id) VALUES (1), (2), (3)")},
+			&goose.GoFunc{RunDB: newDBFn("DELETE FROM test_users")},
+		)
+		p, err := goose.NewProvider(goose.DialectSQLite3, db, fsys,
+			goose.WithVerbose(testing.Verbose()),
+			goose.WithDisableTransactions(true),
+			goose.WithGoMigrations(goMigration),
+		)
+		require.NoError(t, err)
+		// Apply both migrations
+		res, err := p.Up(ctx)
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		currentVersion, err := p.GetDBVersion(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 2, currentVersion)
+		// Verify the Go migration ran
+		var count int
+		err = db.QueryRow("SELECT count(*) FROM test_users").Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 3, count)
+	})
+	t.Run("disable_transactions_nil_go_func", func(t *testing.T) {
+		ctx := context.Background()
+		db := newDB(t)
+		fsys := fstest.MapFS{
+			"00001_create_table.sql": newMapFile(`
+-- +goose Up
+CREATE TABLE test_nil (id INTEGER PRIMARY KEY);
+-- +goose Down
+DROP TABLE test_nil;
+`),
+		}
+		// Nil functions default to TransactionEnabled mode but have no RunTx set,
+		// so they should pass validation and execute as no-ops.
+		goMigration := goose.NewGoMigration(2, nil, nil)
+		p, err := goose.NewProvider(goose.DialectSQLite3, db, fsys,
+			goose.WithVerbose(testing.Verbose()),
+			goose.WithDisableTransactions(true),
+			goose.WithGoMigrations(goMigration),
+		)
+		require.NoError(t, err)
+		res, err := p.Up(ctx)
+		require.NoError(t, err)
+		require.Len(t, res, 2)
+		currentVersion, err := p.GetDBVersion(ctx)
+		require.NoError(t, err)
+		require.EqualValues(t, 2, currentVersion)
+	})
 }
 
 func TestConcurrentProvider(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a `WithDisableTransactions(bool)` provider option that globally disables all transaction usage for databases that do not support transactions at all (e.g., chDB/embedded ClickHouse).

Today, this guards the same transaction sites as `WithIsolateDDL`. The key differences are:

- **Semantic**: `WithIsolateDDL` signals "separate DDL from DML," while `WithDisableTransactions` signals "the database does not support transactions at all."
- **Validation**: `WithDisableTransactions` rejects Go migrations using `RunTx` at construction time, since a `*sql.Tx` cannot be created when transactions are disabled.
- **Future separation**: if `WithIsolateDDL` evolves to wrap individual DDL and DML operations in their own separate transactions, the two options would diverge in behavior. `WithDisableTransactions` would still guarantee no `BEGIN`/`COMMIT` is ever issued.

## Changes

- Add `disableTransactions` field to provider config
- Add `WithDisableTransactions()` option function
- Add `RunTx` conflict validation at provider construction time
- Skip transactions in `runIndividually` when `disableTransactions` is set
- Skip transactions in `tryEnsureVersionTable` when `disableTransactions` is set
- Add unit tests for validation and behavioral correctness

Fixes #1047 