### PR TITLE
feat: Spark support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Examples:
     goose clickhouse "tcp://127.0.0.1:9000" status
     goose ydb "grpcs://localhost:2135/local?go_query_mode=scripting&go_fake_tx=scripting&go_query_bind=declare,numeric" status
     goose starrocks "user:password@/dbname?parseTime=true&interpolateParams=true" status
+    goose spark "hive://user:password@127.0.0.1:10000/default?auth=LDAP" status
 
     GOOSE_DRIVER=sqlite3 GOOSE_DBSTRING=./foo.db goose status
     GOOSE_DRIVER=sqlite3 GOOSE_DBSTRING=./foo.db goose create init sql
@@ -105,6 +106,7 @@ Examples:
     GOOSE_DRIVER=mysql GOOSE_DBSTRING="user:password@/dbname" goose status
     GOOSE_DRIVER=redshift GOOSE_DBSTRING="postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" goose status
     GOOSE_DRIVER=clickhouse GOOSE_DBSTRING="clickhouse://user:password@qwerty.clickhouse.cloud:9440/dbname?secure=true&skip_verify=false" goose status
+    GOOSE_DRIVER=spark GOOSE_DBSTRING="hive://user:password@127.0.0.1:10000/default?auth=LDAP" goose status
 
 Options:
 
@@ -249,6 +251,7 @@ export GOOSE_DRIVER=DRIVER
 export GOOSE_DBSTRING=DBSTRING
 export GOOSE_MIGRATION_DIR=MIGRATION_DIR
 export GOOSE_TABLE=TABLENAME
+export GOOSE_SPARK_STORAGE_FORMAT=PAIMON
 ```
 
 **2. Via `.env` files with corresponding variables. `.env` file example**:
@@ -258,7 +261,12 @@ GOOSE_DRIVER=postgres
 GOOSE_DBSTRING=postgres://admin:admin@localhost:5432/admin_db
 GOOSE_MIGRATION_DIR=./migrations
 GOOSE_TABLE=custom.goose_migrations
+GOOSE_SPARK_STORAGE_FORMAT=PAIMON
 ```
+
+`GOOSE_SPARK_STORAGE_FORMAT` affects only the `spark` dialect and controls the table format used for
+the goose version table. Supported values are `PAIMON` and `ICEBERG`. If unset or invalid, goose
+falls back to `PAIMON`.
 
 Loading from `.env` files is enabled by default. To disable this feature, set the `-env=none` flag.
 If you want to load from a specific file, set the `-env` flag to the file path.

--- a/cmd/goose/driver_hive.go
+++ b/cmd/goose/driver_hive.go
@@ -1,0 +1,13 @@
+//go:build !no_hive
+
+package main
+
+import (
+	"database/sql"
+
+	"github.com/beltran/gohive/v2"
+)
+
+func init() {
+	sql.Register("spark", &gohive.Driver{})
+}

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -271,6 +271,7 @@ Drivers:
     ydb
     starrocks
     turso
+	spark
 
 Examples:
     goose sqlite3 ./foo.db status
@@ -287,6 +288,7 @@ Examples:
     goose clickhouse "tcp://127.0.0.1:9000" status
     goose ydb "grpcs://localhost:2135/local?go_query_mode=scripting&go_fake_tx=scripting&go_query_bind=declare,numeric" status
     goose turso "libsql://dbname.turso.io?authToken=token" status
+	goose spark "hive://user:password@127.0.0.1:10000/default?auth=LDAP" status
 
     GOOSE_DRIVER=sqlite3 GOOSE_DBSTRING=./foo.db goose status
     GOOSE_DRIVER=sqlite3 GOOSE_DBSTRING=./foo.db goose create init sql
@@ -295,6 +297,7 @@ Examples:
     GOOSE_DRIVER=redshift GOOSE_DBSTRING="postgres://user:password@qwerty.us-east-1.redshift.amazonaws.com:5439/db" goose status
     GOOSE_DRIVER=turso GOOSE_DBSTRING="libsql://dbname.turso.io?authToken=token" goose status
     GOOSE_DRIVER=clickhouse GOOSE_DBSTRING="clickhouse://user:password@qwerty.clickhouse.cloud:9440/dbname?secure=true&skip_verify=false" goose status
+	GOOSE_DRIVER=spark GOOSE_DBSTRING="hive://user:password@127.0.0.1:10000/default?auth=LDAP" goose status
 
 Options:
 `

--- a/database/dialects.go
+++ b/database/dialects.go
@@ -17,6 +17,7 @@ const (
 	DialectCustom     Dialect = ""
 	DialectClickHouse Dialect = "clickhouse"
 	DialectAuroraDSQL Dialect = "dsql"
+	DialectSpark      Dialect = "spark"
 	DialectMSSQL      Dialect = "mssql"
 	DialectMySQL      Dialect = "mysql"
 	DialectPostgres   Dialect = "postgres"
@@ -40,6 +41,7 @@ func NewStore(d Dialect, tableName string) (Store, error) {
 	lookup := map[Dialect]dialect.Querier{
 		DialectClickHouse: dialects.NewClickhouse(),
 		DialectAuroraDSQL: dialects.NewAuroraDSQL(),
+		DialectSpark:      dialects.NewSpark(),
 		DialectMSSQL:      dialects.NewSqlserver(),
 		DialectMySQL:      dialects.NewMysql(),
 		DialectPostgres:   dialects.NewPostgres(),

--- a/db.go
+++ b/db.go
@@ -37,10 +37,12 @@ func OpenDBWithDriver(driver string, dbstring string) (*sql.DB, error) {
 		driver = "pgx"
 	case "starrocks":
 		driver = "mysql"
+	case "spark":
+		driver = "spark"
 	}
 
 	switch driver {
-	case "postgres", "pgx", "sqlite3", "sqlite", "spanner", "mysql", "sqlserver", "clickhouse", "vertica", "azuresql", "ydb", "libsql", "starrocks":
+	case "postgres", "pgx", "sqlite3", "sqlite", "spanner", "mysql", "sqlserver", "clickhouse", "vertica", "azuresql", "ydb", "libsql", "starrocks", "spark":
 		return sql.Open(driver, dbstring)
 	default:
 		return nil, fmt.Errorf("unsupported driver %s", driver)

--- a/dialect.go
+++ b/dialect.go
@@ -23,6 +23,7 @@ const (
 	DialectTiDB       Dialect = database.DialectTiDB
 	DialectTurso      Dialect = database.DialectTurso
 	DialectYdB        Dialect = database.DialectYdB
+	DialectSpark      Dialect = database.DialectSpark
 
 	// Dialects only available to the [Provider].
 	DialectAuroraDSQL Dialect = database.DialectAuroraDSQL
@@ -65,6 +66,8 @@ func SetDialect(s string) error {
 		d = DialectTurso
 	case "starrocks":
 		d = DialectStarrocks
+	case "spark":
+		d = DialectSpark
 	default:
 		return fmt.Errorf("%q: unknown dialect", s)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0
+	github.com/beltran/gohive/v2 v2.0.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/jackc/pgx/v5 v5.8.0
@@ -30,6 +31,9 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	github.com/apache/thrift v0.22.0 // indirect
+	github.com/beltran/gosasl v1.0.0 // indirect
+	github.com/beltran/gssapi v0.0.0-20200324152954-d86554db4bab // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coder/websocket v1.8.14 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -61,6 +65,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/paulmach/orb v0.12.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,14 @@ github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUS
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
+github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
+github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
+github.com/beltran/gohive/v2 v2.0.0 h1:Rb7d33EwaG1mc2Cl014x3Mh5RGTNxmKd652gCXzVw5c=
+github.com/beltran/gohive/v2 v2.0.0/go.mod h1:MrxyI0sdriG52I+Bo2lJpGR75bxjcI/Hx3+MBnYqR10=
+github.com/beltran/gosasl v1.0.0 h1:iiRtLxkvKhrNv3Ohh/n2NiyyfwIo/UbMzy/dZWiUHXE=
+github.com/beltran/gosasl v1.0.0/go.mod h1:Qx8cW6jkI8riyzmklj80kAIkv+iezFUTBiGU0qHhHes=
+github.com/beltran/gssapi v0.0.0-20200324152954-d86554db4bab h1:ayfcn60tXOSYy5zUN1AMSTQo4nJCf7hrdzAVchpPst4=
+github.com/beltran/gssapi v0.0.0-20200324152954-d86554db4bab/go.mod h1:GLe4UoSyvJ3cVG+DVtKen5eAiaD8mAJFuV5PT3Eeg9Q=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -182,6 +190,7 @@ github.com/pierrec/lz4/v4 v4.1.25/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcR
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/dialects/spark.go
+++ b/internal/dialects/spark.go
@@ -1,0 +1,97 @@
+package dialects
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/pressly/goose/v3/database/dialect"
+)
+
+// DefaultSparkStorageFormat is the default storage format used for the goose_db_version table in Spark SQL.
+var DefaultSparkStorageFormat = "PAIMON"
+
+// NewSpark returns a new [dialect.Querier] for the Spark SQL dialect.
+// It initializes the querier using an environment-provided storage format.
+func NewSpark() dialect.Querier {
+	return NewSparkWithFormat(os.Getenv("GOOSE_SPARK_STORAGE_FORMAT"))
+}
+
+// NewSparkWithFormat returns a new [dialect.Querier] for the Spark SQL dialect
+// using a specific storage format (e.g., "ICEBERG" or "PAIMON").
+func NewSparkWithFormat(format string) dialect.Querier {
+	return &spark{storageFormat: normalizeSparkStorageFormat(format)}
+}
+
+func normalizeSparkStorageFormat(format string) string {
+	f := strings.ToUpper(strings.TrimSpace(format))
+	switch f {
+	case "PAIMON", "ICEBERG":
+		return f
+	default:
+		return DefaultSparkStorageFormat
+	}
+}
+
+// spark implements the dialect.Querier interface for Spark SQL.
+type spark struct {
+	storageFormat string
+}
+
+var _ dialect.Querier = (*spark)(nil)
+
+// CreateTable generates the SQL to create the goose_db_version table.
+func (s *spark) CreateTable(tableName string) string {
+	// Spark SQL uses the 'USING' clause for table formats instead of 'STORED BY'.
+	// Since Spark does not support AUTO_INCREMENT or IDENTITY intuitively here,
+	// the 'id' field remains a standard bigint.
+	var tblProps string
+
+	switch s.storageFormat {
+	case "PAIMON":
+		tblProps = "\n    TBLPROPERTIES ('primary-key'='id','bucket'='1','full-compaction.delta-commits'='1','snapshot.num-retained.max'='5','snapshot.num-retained.min'='2')"
+	case "ICEBERG":
+		tblProps = "\n    TBLPROPERTIES ('format-version'='2')"
+	}
+	q := `CREATE TABLE IF NOT EXISTS %s (
+		id string,
+		version_id bigint,
+		is_applied boolean,
+		tstamp timestamp
+	) USING %s%s`
+	return fmt.Sprintf(q, tableName, s.storageFormat, tblProps)
+}
+
+// InsertVersion generates the SQL to insert a new migration record.
+func (s *spark) InsertVersion(tableName string) string {
+	id := uuid.Must(uuid.NewV7()).String()
+
+	q := `INSERT INTO %s (id, version_id, is_applied, tstamp) VALUES ('%s', ?, ?, CURRENT_TIMESTAMP)`
+	return fmt.Sprintf(q, tableName, id)
+}
+
+// DeleteVersion generates the SQL to delete a migration record.
+func (s *spark) DeleteVersion(tableName string) string {
+	q := `DELETE FROM %s WHERE version_id=?`
+	return fmt.Sprintf(q, tableName)
+}
+
+// GetMigrationByVersion generates the SQL to retrieve a specific migration.
+func (s *spark) GetMigrationByVersion(tableName string) string {
+	q := `SELECT tstamp, is_applied FROM %s WHERE version_id=? ORDER BY tstamp DESC LIMIT 1`
+	return fmt.Sprintf(q, tableName)
+}
+
+// ListMigrations generates the SQL to list all migrations.
+func (s *spark) ListMigrations(tableName string) string {
+	q := `SELECT version_id, is_applied FROM %s ORDER BY version_id DESC`
+	return fmt.Sprintf(q, tableName)
+}
+
+// GetLatestVersion generates the SQL to get the maximum version_id.
+func (s *spark) GetLatestVersion(tableName string) string {
+	q := `SELECT max(version_id) FROM %s`
+	return fmt.Sprintf(q, tableName)
+}

--- a/internal/legacystore/legacystore.go
+++ b/internal/legacystore/legacystore.go
@@ -75,6 +75,8 @@ func NewStore(d database.Dialect) (Store, error) {
 		querier = dialects.NewTurso()
 	case database.DialectStarrocks:
 		querier = dialects.NewStarrocks()
+	case database.DialectSpark:
+		querier = dialects.NewSpark()
 	default:
 		return nil, fmt.Errorf("unknown querier dialect: %v", d)
 	}


### PR DESCRIPTION
This PR adds support for the Spark SQL dialect in Goose, including Spark-specific version table SQL generation in Paimon or Iceberg table formats