### PR TITLE
Use datetime for the MySQL goose_db_version tstamp column

### DIFF
--- a/internal/dialects/mysql.go
+++ b/internal/dialects/mysql.go
@@ -20,7 +20,7 @@ func (m *mysql) CreateTable(tableName string) string {
 		id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 		version_id bigint NOT NULL,
 		is_applied boolean NOT NULL,
-		tstamp timestamp NULL default now(),
+		tstamp datetime NULL default now(),
 		PRIMARY KEY(id)
 	)`
 	return fmt.Sprintf(q, tableName)


### PR DESCRIPTION
Closes #432.

MySQL's `TIMESTAMP` is stored as a 32-bit Unix epoch, so it tops out at 2038-01-19. The `goose_db_version` table created by the MySQL dialect used `TIMESTAMP` for `tstamp`, which means any migration recorded after that date can't be stored correctly.

Switched it to `DATETIME`, which has a 1000-9999 range. Since MySQL 5.6.5 a `DATETIME` column still accepts `now()` / `CURRENT_TIMESTAMP` as its default, so the `default now()` is unchanged. The SQL Server dialect already uses `DATETIME` for this same column, so there's precedent.

This only affects newly created bookkeeping tables; existing `goose_db_version` tables keep their current column type.

The TiDB dialect (`internal/dialects/tidb.go`) has the identical `tstamp timestamp` pattern and the same 2038 limit since TiDB follows MySQL semantics. I left it out to keep this scoped to the MySQL issue, but happy to fold that in here or as a follow-up if you'd like.