### PR TITLE
fix: use `version_id` instead of `date` as ordering key

### DIFF
--- a/internal/dialects/clickhouse.go
+++ b/internal/dialects/clickhouse.go
@@ -23,7 +23,7 @@ func (c *clickhouse) CreateTable(tableName string) string {
 		tstamp DateTime default now()
 	  )
 	  ENGINE = MergeTree()
-		ORDER BY (date)`
+		ORDER BY (version_id)`
 	return fmt.Sprintf(q, tableName)
 }
 


### PR DESCRIPTION
As far as all the queries use filtering by `version_id`, it's better to order the table by this column.