### PR TITLE
fix: include DB-only applied versions in Status as untracked

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -10,9 +10,11 @@ import (
 	"log/slog"
 	"maps"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pressly/goose/v3/database"
 	"github.com/pressly/goose/v3/internal/controller"
@@ -616,7 +618,9 @@ func (p *Provider) status(ctx context.Context) (_ []*MigrationStatus, retErr err
 	}()
 
 	status := make([]*MigrationStatus, 0, len(p.migrations))
+	sourceVersions := make(map[int64]struct{}, len(p.migrations))
 	for _, m := range p.migrations {
+		sourceVersions[m.Version] = struct{}{}
 		migrationStatus := &MigrationStatus{
 			Source: &Source{
 				Type:    m.Type,
@@ -638,6 +642,43 @@ func (p *Provider) status(ctx context.Context) (_ []*MigrationStatus, retErr err
 			}
 		}
 		status = append(status, migrationStatus)
+	}
+
+	// Also surface DB-applied versions that have no local source so status reflects
+	// production reality even with a partial checkout (#1073).
+	if !p.cfg.disableVersioning {
+		dbMigrations, err := p.store.ListMigrations(ctx, conn)
+		if err != nil {
+			return nil, err
+		}
+		for _, dbm := range dbMigrations {
+			if !dbm.IsApplied {
+				continue
+			}
+			if dbm.Version == 0 {
+				// Skip the zero/bootstrap version row.
+				continue
+			}
+			if _, ok := sourceVersions[dbm.Version]; ok {
+				continue
+			}
+			// ListMigrations may not include timestamps; fetch details when available.
+			var appliedAt time.Time
+			if res, err := p.store.GetMigration(ctx, conn, dbm.Version); err == nil && res != nil {
+				appliedAt = res.Timestamp
+			}
+			status = append(status, &MigrationStatus{
+				Source: &Source{
+					Version: dbm.Version,
+				},
+				State:     StateUntracked,
+				AppliedAt: appliedAt,
+			})
+		}
+		// Keep ascending version order after appending DB-only rows.
+		sort.SliceStable(status, func(i, j int) bool {
+			return status[i].Source.Version < status[j].Source.Version
+		})
 	}
 
 	return status, nil

--- a/provider_status_untracked_test.go
+++ b/provider_status_untracked_test.go
@@ -1,0 +1,52 @@
+package goose_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/pressly/goose/v3"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+func TestProviderStatusIncludesDBOnlyApplied(t *testing.T) {
+	ctx := context.Background()
+	dbName := filepath.Join(t.TempDir(), "status_untracked.db")
+	db, err := sql.Open("sqlite", dbName)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Provider with only version 1 source.
+	fsys := fstest.MapFS{
+		"00001_a.sql": {Data: []byte(`-- +goose Up
+CREATE TABLE a (id INTEGER);
+-- +goose Down
+DROP TABLE a;
+`)},
+	}
+	p, err := goose.NewProvider(goose.DialectSQLite3, db, fsys)
+	require.NoError(t, err)
+	_, err = p.Up(ctx)
+	require.NoError(t, err)
+
+	// Insert an applied version that has no local source (simulates production-only migration).
+	_, err = db.Exec(`INSERT INTO goose_db_version (version_id, is_applied) VALUES (99, 1)`)
+	require.NoError(t, err)
+
+	status, err := p.Status(ctx)
+	require.NoError(t, err)
+
+	var found *goose.MigrationStatus
+	for _, s := range status {
+		if s.Source != nil && s.Source.Version == 99 {
+			found = s
+			break
+		}
+	}
+	require.NotNil(t, found, "expected untracked version 99 in status")
+	require.Equal(t, goose.StateUntracked, found.State)
+	require.True(t, found.Source.Path == "")
+}

--- a/provider_types.go
+++ b/provider_types.go
@@ -77,10 +77,10 @@ const (
 	// StateApplied is a migration that has been applied to the database and exists on the
 	// filesystem.
 	StateApplied State = "applied"
-
-	// TODO(mf): we could also add a third state for untracked migrations. This would be useful for
-	// migrations that were manually applied to the database, but not versioned. Or the Source was
-	// deleted, but the migration still exists in the database. StateUntracked State = "untracked"
+	// StateUntracked is a migration that is recorded as applied in the database, but has no
+	// corresponding source on the filesystem (or registered Go migrations). This commonly happens
+	// when an operator runs status against a production DB with a partial local checkout.
+	StateUntracked State = "untracked"
 )
 
 // MigrationStatus represents the status of a single migration.


### PR DESCRIPTION
## Summary
`Provider.Status` previously only walked local/filesystem migrations and checked the DB for each of those versions. Applied rows that exist only in the DB (no local source) were silently omitted, which is dangerous when operators run status against production with a partial checkout (#1073).

## Fix
- Add `StateUntracked` for DB-applied migrations missing a local source
- Merge `ListMigrations` DB rows into `Status`, appending untracked applied versions and sorting by version

## Test plan
- [x] `go test -run TestProviderStatusIncludesDBOnlyApplied .`
- [x] New regression test inserts an applied version with no source and asserts `StateUntracked`

Fixes #1073
