### PR TITLE
fix: StarRocks version table initializing — fallback to NoTx

### DIFF
--- a/internal/legacystore/legacystore.go
+++ b/internal/legacystore/legacystore.go
@@ -24,6 +24,9 @@ type Store interface {
 	// CreateVersionTable creates the version table within a transaction.
 	// This table is used to store goose migrations.
 	CreateVersionTable(ctx context.Context, tx *sql.Tx, tableName string) error
+	// CreateVersionTableNoTx creates the version table without a transaction.
+	// Use this for databases that don't support DDL in transactions (e.g. StarRocks).
+	CreateVersionTableNoTx(ctx context.Context, db *sql.DB, tableName string) error
 
 	// InsertVersion inserts a version id into the version table within a transaction.
 	InsertVersion(ctx context.Context, tx *sql.Tx, tableName string, version int64) error
@@ -100,6 +103,12 @@ var _ Store = (*store)(nil)
 func (s *store) CreateVersionTable(ctx context.Context, tx *sql.Tx, tableName string) error {
 	q := s.querier.CreateTable(tableName)
 	_, err := tx.ExecContext(ctx, q)
+	return err
+}
+
+func (s *store) CreateVersionTableNoTx(ctx context.Context, db *sql.DB, tableName string) error {
+	q := s.querier.CreateTable(tableName)
+	_, err := db.ExecContext(ctx, q)
 	return err
 }
 

--- a/migrate.go
+++ b/migrate.go
@@ -252,14 +252,20 @@ func EnsureDBVersionContext(ctx context.Context, db *sql.DB) (int64, error) {
 
 // createVersionTable creates the db version table and inserts the
 // initial 0 value into it.
+// StarRocks and other databases that reject DDL in transactions use
+// the NoTx variants.
 func createVersionTable(ctx context.Context, db *sql.DB) error {
 	txn, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	if err := store.CreateVersionTable(ctx, txn, TableName()); err != nil {
+		// StarRocks & friends: DDL in transaction is rejected. Fall back to NoTx.
 		_ = txn.Rollback()
-		return err
+		if err := store.CreateVersionTableNoTx(ctx, db, TableName()); err != nil {
+			return err
+		}
+		return store.InsertVersionNoTx(ctx, db, TableName(), 0)
 	}
 	if err := store.InsertVersion(ctx, txn, TableName(), 0); err != nil {
 		_ = txn.Rollback()


### PR DESCRIPTION
StarRocks rejects DDL in transactions (Error 5305). When createVersionTable() detects that the transactional path fails, it falls back to non-transactional execution of the version table DDL and initial insert. Other databases are unaffected — the fallback is only triggered on error.

- legacystore: add CreateVersionTableNoTx
- migrate.go: try tx path first, rollback+retry NoTx on failure

Closes #1035