### PR TITLE
fix: return clear error when migration file already exists

### DIFF
--- a/create.go
+++ b/create.go
@@ -58,7 +58,9 @@ func CreateWithTemplate(db *sql.DB, dir string, tmpl *template.Template, name, m
 	}
 
 	path := filepath.Join(dir, filename)
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("failed to create migration file: %w", os.ErrExist)
+	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to create migration file: %w", err)
 	}
 

--- a/create.go
+++ b/create.go
@@ -58,13 +58,10 @@ func CreateWithTemplate(db *sql.DB, dir string, tmpl *template.Template, name, m
 	}
 
 	path := filepath.Join(dir, filename)
-	if _, err := os.Stat(path); err == nil {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if errors.Is(err, os.ErrExist) {
 		return fmt.Errorf("failed to create migration file: %w", os.ErrExist)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("failed to create migration file: %w", err)
 	}
-
-	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to create migration file: %w", err)
 	}

--- a/create_test.go
+++ b/create_test.go
@@ -53,7 +53,12 @@ func TestSequential(t *testing.T) {
 }
 
 func TestCreateDuplicateFile(t *testing.T) {
+	prev := timestampFormat
+	timestampFormat = "STATIC"
+	t.Cleanup(func() { timestampFormat = prev })
+
 	dir := t.TempDir()
+
 	if err := Create(nil, dir, "add_users", "sql"); err != nil {
 		t.Fatalf("first create should succeed: %v", err)
 	}

--- a/create_test.go
+++ b/create_test.go
@@ -1,6 +1,7 @@
 package goose
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -48,5 +49,19 @@ func TestSequential(t *testing.T) {
 		if !strings.HasPrefix(f.Name(), expected) {
 			t.Errorf("failed to find %s prefix in %s", expected, f.Name())
 		}
+	}
+}
+
+func TestCreateDuplicateFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := Create(nil, dir, "add_users", "sql"); err != nil {
+		t.Fatalf("first create should succeed: %v", err)
+	}
+	err := Create(nil, dir, "add_users", "sql")
+	if err == nil {
+		t.Fatal("second create should have failed, got nil")
+	}
+	if !errors.Is(err, os.ErrExist) {
+		t.Fatalf("want os.ErrExist, got %v", err)
 	}
 }


### PR DESCRIPTION
Fixes the `%!w(<nil>)` error from `goose create` when a migration with the same
name is created within the same second (same timestamp filename).

The old check `!os.IsNotExist(err)` wrapped a `nil` error with `%w` in the
file exists case. Now it returns a clear `os.ErrExist` ("file already exists")
and still surfaces other stat errors.

Builds on #708 / @obalunenko's review. Uses `os.ErrNotExist` (not `fs.ErrNotExist`)
to avoid a new import.

**Testing:** added `TestCreateDuplicateFile` — verified it fails on the old code
and passes with the fix; full suite green under `-race`.

_Out of scope:_ the same-second collision comes from second-granularity versioning,
and concurrent creates can still race the check — happy to file a separate issue.

Closes #707