### PR TITLE
fix: allow inlined migration functions in goose validate

### DIFF
--- a/internal/migrationstats/migration_go.go
+++ b/internal/migrationstats/migration_go.go
@@ -18,9 +18,9 @@ const (
 )
 
 type goMigration struct {
-	name                     string
-	useTx                    *bool
-	upFuncName, downFuncName string
+	name                   string
+	useTx                  *bool
+	upFuncNil, downFuncNil bool
 }
 
 func parseGoFile(r io.Reader) (*goMigration, error) {
@@ -91,22 +91,12 @@ func parseInitFunc(fd *ast.FuncDecl) (*goMigration, error) {
 		if len(call.Args) != 2 {
 			return nil, fmt.Errorf("registered goose functions have 2 arguments: got %d", len(call.Args))
 		}
-		getNameFromExpr := func(expr ast.Expr) (string, error) {
-			arg, ok := expr.(*ast.Ident)
-			if !ok {
-				return "", fmt.Errorf("failed to assert argument identifier: got %T", arg)
-			}
-			return arg.Name, nil
-		}
-		var err error
-		gf.upFuncName, err = getNameFromExpr(call.Args[0])
-		if err != nil {
-			return nil, err
-		}
-		gf.downFuncName, err = getNameFromExpr(call.Args[1])
-		if err != nil {
-			return nil, err
-		}
+		// The only thing we need to know about each argument is whether a
+		// migration function was supplied or not. Anything that is not the nil
+		// identifier counts as a function, which covers named functions,
+		// qualified names such as pkg.Up001 and inlined function literals.
+		gf.upFuncNil = isNilIdent(call.Args[0])
+		gf.downFuncNil = isNilIdent(call.Args[1])
 	}
 	// validation
 	switch gf.name {
@@ -124,13 +114,11 @@ func parseInitFunc(fd *ast.FuncDecl) (*goMigration, error) {
 	if gf.useTx == nil {
 		return nil, errors.New("validation error: failed to identify transaction: got nil bool")
 	}
-	// The up and down functions can either be named Go functions or "nil", an
-	// empty string means there is a flaw in our parsing logic of the Go source code.
-	if gf.upFuncName == "" {
-		return nil, fmt.Errorf("validation error: up function is empty string")
-	}
-	if gf.downFuncName == "" {
-		return nil, fmt.Errorf("validation error: down function is empty string")
-	}
 	return gf, nil
+}
+
+// isNilIdent reports whether the expression is the nil identifier.
+func isNilIdent(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == "nil"
 }

--- a/internal/migrationstats/migrationstats.go
+++ b/internal/migrationstats/migrationstats.go
@@ -52,7 +52,7 @@ func GatherStats(fw FileWalker, debug bool) ([]*Stats, error) {
 			if err != nil {
 				return fmt.Errorf("failed to parse file %q: %w", filename, err)
 			}
-			up, down = nilAsNumber(m.upFuncName), nilAsNumber(m.downFuncName)
+			up, down = nilAsNumber(m.upFuncNil), nilAsNumber(m.downFuncNil)
 			tx = *m.useTx
 		}
 		stats = append(stats, &Stats{
@@ -70,9 +70,9 @@ func GatherStats(fw FileWalker, debug bool) ([]*Stats, error) {
 	return stats, nil
 }
 
-func nilAsNumber(s string) int {
-	if s != "nil" {
-		return 1
+func nilAsNumber(isNil bool) int {
+	if isNil {
+		return 0
 	}
-	return 0
+	return 1
 }

--- a/internal/migrationstats/migrationstats_test.go
+++ b/internal/migrationstats/migrationstats_test.go
@@ -12,21 +12,31 @@ import (
 func TestParsingGoMigrations(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name                     string
-		input                    string
-		wantUpName, wantDownName string
-		wantTx                   bool
+		name                   string
+		input                  string
+		wantUpNil, wantDownNil bool
+		wantTx                 bool
 	}{
 		// AddMigration
-		{"upAndDown", upAndDown, "up001", "down001", true},
-		{"downOnly", downOnly, "nil", "down002", true},
-		{"upOnly", upOnly, "up003", "nil", true},
-		{"upAndDownNil", upAndDownNil, "nil", "nil", true},
+		{"upAndDown", upAndDown, false, false, true},
+		{"downOnly", downOnly, true, false, true},
+		{"upOnly", upOnly, false, true, true},
+		{"upAndDownNil", upAndDownNil, true, true, true},
 		// AddMigrationNoTx
-		{"upAndDownNoTx", upAndDownNoTx, "up001", "down001", false},
-		{"downOnlyNoTx", downOnlyNoTx, "nil", "down002", false},
-		{"upOnlyNoTx", upOnlyNoTx, "up003", "nil", false},
-		{"upAndDownNilNoTx", upAndDownNilNoTx, "nil", "nil", false},
+		{"upAndDownNoTx", upAndDownNoTx, false, false, false},
+		{"downOnlyNoTx", downOnlyNoTx, true, false, false},
+		{"upOnlyNoTx", upOnlyNoTx, false, true, false},
+		{"upAndDownNilNoTx", upAndDownNilNoTx, true, true, false},
+		// Inlined function literals, see https://github.com/pressly/goose/issues/519
+		{"upAndDownInline", upAndDownInline, false, false, true},
+		{"upInlineDownNil", upInlineDownNil, false, true, true},
+		{"upNilDownInline", upNilDownInline, true, false, true},
+		{"upAndDownInlineNoTx", upAndDownInlineNoTx, false, false, false},
+		{"upAndDownInlineContext", upAndDownInlineContext, false, false, true},
+		{"upAndDownInlineNoTxContext", upAndDownInlineNoTxContext, false, false, false},
+		{"upInlineDownNamed", upInlineDownNamed, false, false, true},
+		// Functions referenced through another package
+		{"upAndDownQualified", upAndDownQualified, false, false, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -34,8 +44,34 @@ func TestParsingGoMigrations(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, g.useTx)
 			require.Equal(t, tc.wantTx, *g.useTx)
-			require.Equal(t, tc.wantDownName, g.downFuncName)
-			require.Equal(t, tc.wantUpName, g.upFuncName)
+			require.Equal(t, tc.wantDownNil, g.downFuncNil)
+			require.Equal(t, tc.wantUpNil, g.upFuncNil)
+		})
+	}
+}
+
+func TestGoMigrationStatsInline(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name             string
+		input            string
+		wantUp, wantDown int
+		wantTx           bool
+	}{
+		{"upAndDownInline", upAndDownInline, 1, 1, true},
+		{"upInlineDownNil", upInlineDownNil, 1, 0, true},
+		{"upNilDownInline", upNilDownInline, 0, 1, true},
+		{"upAndDownInlineNoTx", upAndDownInlineNoTx, 1, 1, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			filename := filepath.Join(dir, "001_"+tc.name+".go")
+			require.NoError(t, os.WriteFile(filename, []byte(tc.input), 0o644))
+			stats, err := GatherStats(NewFileWalker(filename), false)
+			require.NoError(t, err)
+			require.Len(t, stats, 1)
+			checkGoStats(t, stats[0], filepath.Base(filename), 1, tc.wantUp, tc.wantDown, tc.wantTx)
 		})
 	}
 }
@@ -90,6 +126,10 @@ func TestParsingGoMigrationsError(t *testing.T) {
 	_, err = parseGoFile(strings.NewReader(wrongName))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "AddMigration, AddMigrationNoTx, AddMigrationContext, AddMigrationNoTxContext")
+
+	_, err = parseGoFile(strings.NewReader(wrongArgCount))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "registered goose functions have 2 arguments: got 1")
 }
 
 var (
@@ -222,5 +262,125 @@ import (
 
 func init() {
 	goose.AddMigrationWrongName(nil, nil)
+}`
+
+	wrongArgCount = `package testgo
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigration(nil)
+}`
+)
+
+var (
+	upAndDownInline = `package testgo
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigration(func(tx *sql.Tx) error { return nil }, func(tx *sql.Tx) error { return nil })
+}`
+
+	upInlineDownNil = `package testgo
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigration(func(tx *sql.Tx) error { return nil }, nil)
+}`
+
+	upNilDownInline = `package testgo
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigration(nil, func(tx *sql.Tx) error { return nil })
+}`
+
+	upAndDownInlineNoTx = `package testgo
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationNoTx(func(db *sql.DB) error { return nil }, func(db *sql.DB) error { return nil })
+}`
+
+	upAndDownInlineContext = `package testgo
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(
+		func(ctx context.Context, tx *sql.Tx) error { return nil },
+		func(ctx context.Context, tx *sql.Tx) error { return nil },
+	)
+}`
+
+	upAndDownInlineNoTxContext = `package testgo
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationNoTxContext(
+		func(ctx context.Context, db *sql.DB) error { return nil },
+		func(ctx context.Context, db *sql.DB) error { return nil },
+	)
+}`
+
+	upInlineDownNamed = `package testgo
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigration(func(tx *sql.Tx) error { return nil }, down004)
+}
+
+func down004(tx *sql.Tx) error { return nil }`
+
+	upAndDownQualified = `package testgo
+
+import (
+	"github.com/pressly/goose/v3"
+
+	"example.com/migrations"
+)
+
+func init() {
+	goose.AddMigration(migrations.Up005, migrations.Down005)
 }`
 )


### PR DESCRIPTION
`goose validate` refuses any Go migration that registers an inlined function:

```go
func init() {
	goose.AddMigration(func(tx *sql.Tx) error { return nil }, nil)
}
```

```
failed to parse file "00001_inline.go": failed to assert argument identifier: got *ast.Ident
```

`parseInitFunc` in `internal/migrationstats/migration_go.go` asserted that each argument to `AddMigration` and its three siblings was an `*ast.Ident` so it could read the function's name. A function literal parses as `*ast.FuncLit`, the assertion fails, and the whole command aborts. The same rejection hits a function reached through another package, such as `goose.AddMigration(migrations.Up001, migrations.Down001)`, which parses as `*ast.SelectorExpr`.

The migrations themselves run fine, so the command reports a problem that does not exist.

**Why dropping the identifier requirement is safe.** The extracted names were never used as names. They were read in exactly two places: `migrationstats.go` passed them to `nilAsNumber`, which compared the string against `"nil"` and returned 0 or 1 for `Stats.UpCount`/`DownCount` — the name itself never reaches the output, since the Name column prints the file name — and `parseInitFunc` itself, which rejected an empty string as a sign its own parsing had gone wrong. So the name collapsed to a single bit before use, and `migrationstats` is under `internal/`, so there is no external caller either. Replacing the two string fields with two booleans set by a nil check preserves every observable output, which is what @mfridman suggested in the issue.

The removed branch also formatted `%T` against `arg`, the result of the failed type assertion, rather than against `expr`. `arg` is a nil `*ast.Ident` in that branch, so the message always claimed the argument was an `*ast.Ident` no matter what it really was — that is why #519 shows `got *ast.Ident` for a function literal.

`TestParsingGoMigrations` gains inlined literals for all four register functions, plus mixed cases and a case using qualified names from another package; the existing named-function and `nil` rows are converted to assert the new booleans. `TestGoMigrationStatsInline` runs the inlined sources through `GatherStats` and checks the Up and Down counts that `goose validate` prints. `TestParsingGoMigrationsError` gains a case for a call with the wrong number of arguments.

I also built the CLI on both sides of the change and ran `goose validate -v` against a directory holding the snippet from the issue. Before, it exits 1 with the parse error. After, it prints the row with Up 1 and Down 0.

Ran locally: `go test ./internal/migrationstats/...` with `-race`, the package tests for the rest of the module, `go test ./tests/gomigrations/...`, `go vet ./...`, and `golangci-lint run ./...`, all green. I did not run the Docker-backed integration tests under `internal/testing/integration` or `pkg/dockermanage`, since Docker was not available here.

Fixes #519