### PR TITLE
status: report applied migrations missing from the filesystem

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"maps"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -638,6 +639,38 @@ func (p *Provider) status(ctx context.Context) (_ []*MigrationStatus, retErr err
 			}
 		}
 		status = append(status, migrationStatus)
+	}
+
+	if !p.cfg.disableVersioning {
+		dbMigrations, err := p.store.ListMigrations(ctx, conn)
+		if err != nil {
+			return nil, err
+		}
+		known := make(map[int64]struct{}, len(p.migrations))
+		for _, m := range p.migrations {
+			known[m.Version] = struct{}{}
+		}
+		for _, dbm := range dbMigrations {
+			if dbm.Version == 0 {
+				continue
+			}
+			if _, ok := known[dbm.Version]; ok {
+				continue
+			}
+			applied := &MigrationStatus{
+				Source: &Source{Version: dbm.Version},
+				State:  StateMissing,
+			}
+			if dbResult, err := p.store.GetMigration(ctx, conn, dbm.Version); err == nil && dbResult != nil {
+				applied.AppliedAt = dbResult.Timestamp
+			} else if err != nil && !errors.Is(err, database.ErrVersionNotFound) {
+				return nil, err
+			}
+			status = append(status, applied)
+		}
+		slices.SortFunc(status, func(a, b *MigrationStatus) int {
+			return cmp.Compare(a.Source.Version, b.Source.Version)
+		})
 	}
 
 	return status, nil

--- a/provider_run_test.go
+++ b/provider_run_test.go
@@ -299,6 +299,31 @@ func TestProviderRun(t *testing.T) {
 		assertStatus(t, status[5], goose.StateApplied, newSource(goose.TypeSQL, "00006_empty_up.sql", 6), false)
 		assertStatus(t, status[6], goose.StateApplied, newSource(goose.TypeSQL, "00007_empty_up_down.sql", 7), false)
 	})
+	t.Run("status_missing_source", func(t *testing.T) {
+		ctx := context.Background()
+		p, db := newProviderWithDB(t)
+		_, err := p.Up(ctx)
+		require.NoError(t, err)
+
+		fsys := fstest.MapFS{
+			"00001_users_table.sql": newMapFile(runMigration1),
+		}
+		p2, err := goose.NewProvider(goose.DialectSQLite3, db, fsys)
+		require.NoError(t, err)
+
+		status, err := p2.Status(ctx)
+		require.NoError(t, err)
+		require.Equal(t, goose.StateApplied, status[0].State)
+		require.Equal(t, int64(1), status[0].Source.Version)
+
+		var missing []int64
+		for _, s := range status {
+			if s.State == goose.StateMissing {
+				missing = append(missing, s.Source.Version)
+			}
+		}
+		require.Equal(t, []int64{2, 3, 4, 5, 6, 7}, missing)
+	})
 	t.Run("tx_partial_errors", func(t *testing.T) {
 		countOwners := func(db *sql.DB) (int, error) {
 			q := `SELECT count(*)FROM owners`

--- a/provider_types.go
+++ b/provider_types.go
@@ -77,10 +77,9 @@ const (
 	// StateApplied is a migration that has been applied to the database and exists on the
 	// filesystem.
 	StateApplied State = "applied"
-
-	// TODO(mf): we could also add a third state for untracked migrations. This would be useful for
-	// migrations that were manually applied to the database, but not versioned. Or the Source was
-	// deleted, but the migration still exists in the database. StateUntracked State = "untracked"
+	// StateMissing is a migration that has been applied to the database, but no longer exists
+	// on the filesystem.
+	StateMissing State = "missing"
 )
 
 // MigrationStatus represents the status of a single migration.


### PR DESCRIPTION
`Status` only walked local sources, so a version present in `goose_db_version` but absent from the checkout was omitted. Operators could think production matched their tree.

Surface those DB-only rows as `StateMissing`. Skip goose version 0 (the table init row).

Fixes #1073

## Test
`go test . -run TestProviderRun -count=1`
